### PR TITLE
Graceful reconnect/reload recovery for active games + stabilize comprehensive e2e

### DIFF
--- a/poker-client/src/contexts/GameContext.tsx
+++ b/poker-client/src/contexts/GameContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import type {
@@ -44,6 +45,7 @@ interface GameContextType {
   player: Player | null;
   yourCards: Card[] | null;
   isHost: boolean;
+  isRecoveringSession: boolean;
   lastError: string | null;
   createRoom: (playerName: string) => void;
   joinRoom: (roomId: string, playerName: string) => void;
@@ -69,6 +71,53 @@ interface GameProviderProps {
   children: ReactNode;
 }
 
+type StoredSession = {
+  roomId: string;
+  playerId: string;
+  playerName: string;
+};
+
+const SESSION_STORAGE_KEY = "poker.activeSession";
+
+function readStoredSession(): StoredSession | null {
+  if (typeof window === "undefined") return null;
+
+  const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredSession>;
+    if (
+      typeof parsed.roomId !== "string" ||
+      !parsed.roomId ||
+      typeof parsed.playerId !== "string" ||
+      !parsed.playerId ||
+      typeof parsed.playerName !== "string" ||
+      !parsed.playerName
+    ) {
+      return null;
+    }
+    return parsed as StoredSession;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSession(session: StoredSession) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+}
+
+function clearStoredSession() {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(SESSION_STORAGE_KEY);
+}
+
+function isInvalidReconnectReason(reason: string): boolean {
+  const normalized = reason.toLowerCase();
+  return normalized.includes("not found");
+}
+
 declare global {
   interface Window {
     pokerDebug?: DebugApi;
@@ -80,7 +129,25 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
   const [room, setRoom] = useState<Room | null>(null);
   const [player, setPlayer] = useState<Player | null>(null);
   const [yourCards, setYourCards] = useState<Card[] | null>(null);
+  const [isRecoveringSession, setIsRecoveringSession] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
+  const roomRef = useRef<Room | null>(null);
+  const playerRef = useRef<Player | null>(null);
+  const reconnectInFlightRef = useRef(false);
+
+  useEffect(() => {
+    roomRef.current = room;
+    playerRef.current = player;
+  }, [room, player]);
+
+  useEffect(() => {
+    if (!room?.id || !player?.id || !player.name) return;
+    writeStoredSession({
+      roomId: room.id,
+      playerId: player.id,
+      playerName: player.name,
+    });
+  }, [player?.id, player?.name, room?.id]);
 
   useEffect(() => {
     if (!socket) return;
@@ -90,6 +157,7 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
       setRoom(data.room as unknown as Room); // SanitizedRoom from server
       const host = data.room.players[0];
       setPlayer({ ...host, cards: null } as Player);
+      setIsRecoveringSession(false);
       console.log("Room created:", data.roomId);
     });
 
@@ -97,6 +165,32 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
     socket.on("ROOM_JOINED", (data) => {
       setRoom(data.room as unknown as Room); // SanitizedRoom from server
       setPlayer(data.player);
+      setIsRecoveringSession(false);
+      setLastError(null);
+    });
+
+    // Explicit reconnect success
+    socket.on("RECONNECT_SUCCESS", (data) => {
+      setRoom(data.room as unknown as Room);
+      setPlayer(data.player as Player);
+      setYourCards(data.yourCards ?? null);
+      setLastError(null);
+      setIsRecoveringSession(false);
+      reconnectInFlightRef.current = false;
+    });
+
+    // Explicit reconnect failure
+    socket.on("RECONNECT_ERROR", (data) => {
+      const reason = data.reason || "Reconnect failed";
+      reconnectInFlightRef.current = false;
+      setIsRecoveringSession(false);
+      if (isInvalidReconnectReason(reason)) {
+        clearStoredSession();
+        setRoom(null);
+        setPlayer(null);
+        setYourCards(null);
+      }
+      setLastError(reason);
     });
 
     // Player joined
@@ -119,6 +213,59 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
           players: prev.players.filter((p) => p.id !== data.playerId),
         };
       });
+    });
+
+    socket.on("PLAYER_DISCONNECTED", (data) => {
+      setRoom((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          players: prev.players.map((p) =>
+            p.id === data.playerId ? { ...p, status: "disconnected" } : p,
+          ),
+        };
+      });
+      setPlayer((prev) =>
+        prev && prev.id === data.playerId
+          ? { ...prev, status: "disconnected" }
+          : prev,
+      );
+    });
+
+    socket.on("PLAYER_RECONNECTED", (data) => {
+      setRoom((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          players: prev.players.map((p) =>
+            p.id === data.playerId ? { ...p, status: "connected" } : p,
+          ),
+        };
+      });
+      setPlayer((prev) =>
+        prev && prev.id === data.playerId
+          ? { ...prev, status: "connected" }
+          : prev,
+      );
+    });
+
+    socket.on("PLAYER_AUTO_FOLDED", (data) => {
+      setRoom((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          players: prev.players.map((p) =>
+            p.id === data.playerId
+              ? { ...p, status: "folded", lastAction: "fold" }
+              : p,
+          ),
+        };
+      });
+      setPlayer((prev) =>
+        prev && prev.id === data.playerId
+          ? { ...prev, status: "folded", lastAction: "fold" }
+          : prev,
+      );
     });
 
     // Host changed
@@ -310,8 +457,13 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
     return () => {
       socket.off("ROOM_CREATED");
       socket.off("ROOM_JOINED");
+      socket.off("RECONNECT_SUCCESS");
+      socket.off("RECONNECT_ERROR");
       socket.off("PLAYER_JOINED");
       socket.off("PLAYER_LEFT");
+      socket.off("PLAYER_DISCONNECTED");
+      socket.off("PLAYER_RECONNECTED");
+      socket.off("PLAYER_AUTO_FOLDED");
       socket.off("HOST_CHANGED");
       socket.off("GAME_STARTED");
       socket.off("YOUR_CARDS");
@@ -322,6 +474,68 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
       socket.off("NEW_HAND_STARTING");
       socket.off("BETTING_ROUND_COMPLETE");
       socket.off("ERROR");
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const attemptSessionRecovery = () => {
+      if (reconnectInFlightRef.current) return;
+
+      const roomState = roomRef.current;
+      const playerState = playerRef.current;
+      const fromState =
+        roomState?.id && playerState?.name
+          ? { roomId: roomState.id, playerName: playerState.name }
+          : null;
+      const fromStorage = readStoredSession();
+      const payload = fromState ?? fromStorage;
+
+      if (!payload) {
+        setIsRecoveringSession(false);
+        return;
+      }
+
+      reconnectInFlightRef.current = true;
+      setIsRecoveringSession(true);
+      socket.emit("RECONNECT", payload, (response) => {
+        reconnectInFlightRef.current = false;
+        if (response && "success" in response && !response.success) {
+          const reason = response.error || "Reconnect failed";
+          setIsRecoveringSession(false);
+          if (isInvalidReconnectReason(reason)) {
+            clearStoredSession();
+            setRoom(null);
+            setPlayer(null);
+            setYourCards(null);
+          }
+          setLastError(reason);
+        }
+      });
+    };
+
+    const handleConnect = () => {
+      attemptSessionRecovery();
+    };
+
+    const handleDisconnect = () => {
+      const stored = readStoredSession();
+      const hasKnownSession =
+        Boolean(roomRef.current?.id && playerRef.current?.name) || Boolean(stored);
+      setIsRecoveringSession(hasKnownSession);
+    };
+
+    socket.on("connect", handleConnect);
+    socket.on("disconnect", handleDisconnect);
+
+    if (socket.connected) {
+      handleConnect();
+    }
+
+    return () => {
+      socket.off("connect", handleConnect);
+      socket.off("disconnect", handleDisconnect);
     };
   }, [socket]);
 
@@ -383,9 +597,11 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
   const leaveRoom = useCallback(() => {
     if (!socket) return;
     socket.emit("LEAVE_ROOM", () => {
+      clearStoredSession();
       setRoom(null);
       setPlayer(null);
       setYourCards(null);
+      setIsRecoveringSession(false);
       setLastError(null);
     });
   }, [socket]);
@@ -463,6 +679,7 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
         player,
         yourCards,
         isHost,
+        isRecoveringSession,
         lastError,
         createRoom,
         joinRoom,

--- a/poker-client/src/pages/Home.tsx
+++ b/poker-client/src/pages/Home.tsx
@@ -14,7 +14,13 @@ export const Home: React.FC<HomeProps> = ({
 }) => {
   const navigate = useNavigate();
   const { connected } = useSocket();
-  const { createRoom, joinRoom, lastError, clearError } = useGame();
+  const {
+    createRoom,
+    joinRoom,
+    isRecoveringSession,
+    lastError,
+    clearError,
+  } = useGame();
 
   const [playerName, setPlayerName] = useState("");
   const [roomId, setRoomId] = useState("");
@@ -44,6 +50,8 @@ export const Home: React.FC<HomeProps> = ({
   };
 
   const handleCreateRoom = () => {
+    if (isRecoveringSession) return;
+
     const trimmedName = playerName.trim();
     if (!trimmedName) {
       setFeedback("Please enter your name");
@@ -56,6 +64,8 @@ export const Home: React.FC<HomeProps> = ({
   };
 
   const handleJoinRoom = () => {
+    if (isRecoveringSession) return;
+
     const trimmedName = playerName.trim();
     const trimmedRoomId = roomId.trim();
     const normalizedRoomId = trimmedRoomId.toUpperCase();
@@ -103,6 +113,15 @@ export const Home: React.FC<HomeProps> = ({
           </div>
 
           <div className="space-y-5">
+            {isRecoveringSession && (
+              <div
+                className="rounded-xl border border-sky-400/50 bg-sky-500/10 px-3 py-2 text-sm text-sky-200"
+                data-testid="session-recovery-status"
+              >
+                Reconnecting to your previous table...
+              </div>
+            )}
+
             <div>
               <label
                 htmlFor="player-name"
@@ -137,7 +156,7 @@ export const Home: React.FC<HomeProps> = ({
               <>
                 <button
                   onClick={handleCreateRoom}
-                  disabled={!connected}
+                  disabled={!connected || isRecoveringSession}
                   data-testid="create-room-button"
                   className="w-full rounded-xl bg-emerald-500 px-4 py-3 font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
                 >
@@ -146,9 +165,11 @@ export const Home: React.FC<HomeProps> = ({
 
                 <button
                   onClick={() => {
+                    if (isRecoveringSession) return;
                     setIsJoining(true);
                     clearFeedback();
                   }}
+                  disabled={isRecoveringSession}
                   data-testid="join-toggle-button"
                   className="w-full rounded-xl border border-emerald-500/70 bg-transparent px-4 py-3 font-semibold text-emerald-200 transition hover:bg-emerald-500/15"
                 >
@@ -180,7 +201,7 @@ export const Home: React.FC<HomeProps> = ({
 
                 <button
                   onClick={handleJoinRoom}
-                  disabled={!connected}
+                  disabled={!connected || isRecoveringSession}
                   data-testid="join-room-button"
                   className="w-full rounded-xl bg-sky-500 px-4 py-3 font-semibold text-sky-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-50"
                 >

--- a/poker-server/playwright.config.ts
+++ b/poker-server/playwright.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
       timeout: 30000,
       env: {
         TEST_MODE: 'true',
+        PORT: '3001',
       },
     },
   ],

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -208,7 +208,11 @@ async function waitForHoleCards(page: Page, expectedCount = 2) {
   );
 }
 
-async function waitForPlayerTurn(page: Page, playerName: string) {
+async function waitForPlayerTurn(
+  page: Page,
+  playerName: string,
+  timeoutMs = 10000,
+) {
   await page.waitForFunction(
     (name) => {
       const room = (window as any).pokerDebug?.getRoom();
@@ -216,7 +220,7 @@ async function waitForPlayerTurn(page: Page, playerName: string) {
       return !!playerId && room?.currentHand?.currentPlayerTurn === playerId;
     },
     playerName,
-    { timeout: 10000 },
+    { timeout: timeoutMs },
   );
 }
 
@@ -376,13 +380,15 @@ async function completeCurrentHandWithPassiveActions(
   pageByName: Record<string, Page>,
   handNumber: number,
 ) {
-  const handCompletePromise = captureNextHandComplete(anchorPage, 30000);
+  const startedAt = Date.now();
+  const maxDurationMs = 45000;
 
-  for (let i = 0; i < 40; i++) {
+  while (Date.now() - startedAt < maxDurationMs) {
     const state = await getRoomSnapshot(anchorPage);
-    if (state.handNumber !== handNumber) {
-      break;
+    if (state.handNumber !== handNumber || state.currentPlayerTurn === null) {
+      return;
     }
+
     const actingPlayer = state.currentPlayerName;
     if (!actingPlayer) {
       await anchorPage.waitForTimeout(200);
@@ -390,7 +396,18 @@ async function completeCurrentHandWithPassiveActions(
     }
 
     const actingPage = pageByName[actingPlayer];
-    await waitForPlayerTurn(actingPage, actingPlayer);
+    if (!actingPage) {
+      await anchorPage.waitForTimeout(200);
+      continue;
+    }
+
+    try {
+      await waitForPlayerTurn(actingPage, actingPlayer, 5000);
+    } catch {
+      await anchorPage.waitForTimeout(200);
+      continue;
+    }
+
     const canCheck = await actingPage.evaluate(() => {
       const pokerDebug = (window as any).pokerDebug;
       const room = pokerDebug?.getRoom?.();
@@ -405,10 +422,13 @@ async function completeCurrentHandWithPassiveActions(
       await actingPage.evaluate(() => (window as any).pokerDebug.call());
     }
 
-    await anchorPage.waitForTimeout(200);
+    await anchorPage.waitForTimeout(150);
   }
 
-  await handCompletePromise;
+  const finalState = await getRoomSnapshot(anchorPage);
+  throw new Error(
+    `Timed out completing hand ${handNumber}; final state: hand=${finalState.handNumber}, round=${finalState.bettingRound}, turn=${finalState.currentPlayerName}`,
+  );
 }
 
 async function playCheckCheckToShowdown(alicePage: Page, bobPage: Page) {
@@ -3618,6 +3638,101 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
 
       await bobPage.click('[data-testid="dismiss-error-button"]');
       await expect(bobPage.locator('[data-testid="error-modal"]')).toHaveCount(0);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
+  test('8.12: Refresh Mid-Hand Automatically Reconnects Player Session', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser);
+
+    try {
+      const { alicePage, bobPage, roomCode } = session;
+      await startGameFromLobby(alicePage, bobPage);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      const beforeRefresh = await bobPage.evaluate(() => {
+        const room = (window as any).pokerDebug?.getRoom?.();
+        const player = (window as any).pokerDebug?.getPlayer?.();
+        return {
+          roomId: room?.id ?? null,
+          playerId: player?.id ?? null,
+          playerName: player?.name ?? null,
+          handNumber: room?.currentHand?.handNumber ?? null,
+          bettingRound: room?.currentHand?.bettingRound ?? null,
+          hasCards: Array.isArray((window as any).pokerDebug?.getCards?.())
+            ? (window as any).pokerDebug.getCards().length === 2
+            : false,
+        };
+      });
+
+      expect(beforeRefresh.roomId).toBe(roomCode);
+      expect(beforeRefresh.playerName).toBe('Bob');
+      expect(beforeRefresh.hasCards).toBe(true);
+      expect(beforeRefresh.handNumber).toBe(1);
+      expect(beforeRefresh.bettingRound).toBe('PRE_FLOP');
+
+      // Test harness serves static files without SPA fallback. Intercept room route
+      // and serve index.html so a hard reload at /room/:id behaves like production.
+      const roomRoutePattern = `${FRONTEND_URL}/room/*`;
+      await bobPage.route(roomRoutePattern, async (route) => {
+        const response = await bobPage.request.get(FRONTEND_URL);
+        const body = await response.text();
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body,
+        });
+      });
+      await bobPage.reload({ waitUntil: 'domcontentloaded' });
+      await bobPage.unroute(roomRoutePattern);
+
+      await waitForPokerDebug(bobPage);
+      await bobPage.waitForFunction(
+        () => {
+          const pd = (window as any).pokerDebug;
+          const room = pd?.getRoom?.();
+          const player = pd?.getPlayer?.();
+          return (
+            !!room?.id &&
+            !!player?.id &&
+            Array.isArray(pd?.getCards?.()) &&
+            pd.getCards().length === 2
+          );
+        },
+        { timeout: 15000 },
+      );
+
+      const afterRefresh = await bobPage.evaluate(() => {
+        const room = (window as any).pokerDebug?.getRoom?.();
+        const player = (window as any).pokerDebug?.getPlayer?.();
+        return {
+          roomId: room?.id ?? null,
+          playerId: player?.id ?? null,
+          playerName: player?.name ?? null,
+          handNumber: room?.currentHand?.handNumber ?? null,
+          bettingRound: room?.currentHand?.bettingRound ?? null,
+          currentPlayerTurn: room?.currentHand?.currentPlayerTurn ?? null,
+          status: room?.players?.find((p: any) => p.id === player?.id)?.status ?? null,
+        };
+      });
+
+      expect(afterRefresh.roomId).toBe(beforeRefresh.roomId);
+      expect(afterRefresh.playerId).toBe(beforeRefresh.playerId);
+      expect(afterRefresh.playerName).toBe('Bob');
+      expect(afterRefresh.handNumber).toBe(beforeRefresh.handNumber);
+      expect(afterRefresh.bettingRound).toBe(beforeRefresh.bettingRound);
+      expect(afterRefresh.currentPlayerTurn).toBe(afterRefresh.playerId);
+      expect(afterRefresh.status).toBe('connected');
+      await expect(bobPage).toHaveURL(new RegExp(`/room/${roomCode}$`));
+
+      // Verify recovered player can immediately continue the same hand.
+      await bobPage.click('[data-testid="action-call"]');
+      await waitForPlayerTurn(alicePage, 'Alice');
+      await alicePage.click('[data-testid="action-check"]');
+      await waitForRound(alicePage, 'FLOP', 3);
     } finally {
       await teardownTwoPlayerSession(session);
     }


### PR DESCRIPTION
## Summary
- add client session recovery flow so players can reconnect after browser refresh/disconnect and restore room/player/cards state
- surface reconnecting UI state on home screen and prevent conflicting create/join actions while recovery is in progress
- harden comprehensive e2e hand progression helper to avoid flaky waits on HAND_COMPLETE event timing
- add comprehensive e2e coverage for refresh-mid-hand auto-reconnect behavior
- align Playwright backend test server env with expected port (`PORT=3001`)

## Validation
- `./node_modules/.bin/playwright test --project=comprehensive-e2e --reporter=dot`
- result: `40 passed`
