### PR TITLE
fix(turn-sync): per-tab identity reconnect + compact seat layout

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -164,26 +164,26 @@ const resolveDropIntent = ({
 const getSeatAnchors = (capacity: number): SeatAnchor[] => {
   if (capacity > 6) {
     return [
-      { top: "84%", left: "50%" },
-      { top: "78%", left: "73%" },
-      { top: "64%", left: "87%" },
-      { top: "44%", left: "90%" },
+      { top: "73%", left: "50%" },
+      { top: "69%", left: "70%" },
+      { top: "57%", left: "84%" },
+      { top: "42%", left: "90%" },
       { top: "24%", left: "79%" },
       { top: "15%", left: "59%" },
       { top: "15%", left: "41%" },
       { top: "24%", left: "21%" },
-      { top: "44%", left: "10%" },
-      { top: "64%", left: "13%" },
+      { top: "42%", left: "10%" },
+      { top: "57%", left: "16%" },
     ];
   }
 
   return [
-    { top: "84%", left: "50%" },
-    { top: "74%", left: "79%" },
+    { top: "73%", left: "50%" },
+    { top: "66%", left: "78%" },
     { top: "44%", left: "90%" },
     { top: "17%", left: "50%" },
     { top: "44%", left: "10%" },
-    { top: "74%", left: "21%" },
+    { top: "66%", left: "22%" },
   ];
 };
 
@@ -271,7 +271,12 @@ export const GameRoom: React.FC = () => {
 
   const maxStack = currentPlayer?.chips ?? 0;
   const canCheck = callAmount === 0;
-  const isYourTurn = currentHand?.currentPlayerTurn === player?.id;
+  const resolvedPlayerId = currentPlayer?.id ?? player?.id ?? null;
+  const isYourTurn = Boolean(
+    currentHand?.currentPlayerTurn &&
+      resolvedPlayerId &&
+      currentHand.currentPlayerTurn === resolvedPlayerId,
+  );
   const currentHandNumber = currentHand?.handNumber ?? null;
   const showHoleCards =
     currentHandNumber === null || hiddenCardsHandNumber !== currentHandNumber;
@@ -332,6 +337,7 @@ export const GameRoom: React.FC = () => {
   }, [room]);
 
   const seatAnchors = useMemo(() => getSeatAnchors(orbitCapacity), [orbitCapacity]);
+  const seatSlotWidth = orbitCapacity > 6 ? "min(24vw, 6.8rem)" : "min(28vw, 7.6rem)";
   const playerRankings = useMemo(
     () => {
       if (!room) return [];
@@ -891,7 +897,7 @@ export const GameRoom: React.FC = () => {
               const seatPlayerId = seatPlayer?.id ?? null;
               const isCurrentTurnSeat =
                 seatPlayerId !== null && currentHand?.currentPlayerTurn === seatPlayerId;
-              const isSelfSeat = seatPlayer?.id === player.id;
+              const isSelfSeat = seatPlayer?.id === resolvedPlayerId;
               const isFolded = seatPlayer?.status === "folded";
               const isAllIn = seatPlayer?.status === "all-in";
 
@@ -902,6 +908,7 @@ export const GameRoom: React.FC = () => {
                   style={{
                     top: slot.anchor.top,
                     left: slot.anchor.left,
+                    width: seatSlotWidth,
                     transform: "translate(-50%, -50%)",
                   }}
                 >

--- a/poker-client/src/contexts/GameContext.tsx
+++ b/poker-client/src/contexts/GameContext.tsx
@@ -89,7 +89,7 @@ const SESSION_STORAGE_KEY = "poker.activeSession";
 function readStoredSession(): StoredSession | null {
   if (typeof window === "undefined") return null;
 
-  const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+  const raw = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
   if (!raw) return null;
 
   try {
@@ -112,11 +112,12 @@ function readStoredSession(): StoredSession | null {
 
 function writeStoredSession(session: StoredSession) {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+  window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
 }
 
 function clearStoredSession() {
   if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
   window.localStorage.removeItem(SESSION_STORAGE_KEY);
 }
 
@@ -506,8 +507,12 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
       const roomState = roomRef.current;
       const playerState = playerRef.current;
       const fromState =
-        roomState?.id && playerState?.name
-          ? { roomId: roomState.id, playerName: playerState.name }
+        roomState?.id && playerState?.name && playerState?.id
+          ? {
+              roomId: roomState.id,
+              playerName: playerState.name,
+              playerId: playerState.id,
+            }
           : null;
       const fromStorage = readStoredSession();
       const payload = fromState ?? fromStorage;

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -244,7 +244,7 @@ body {
 
 .seat-orbit__slot {
   position: absolute;
-  width: min(35vw, 9.6rem);
+  width: min(28vw, 7.6rem);
 }
 
 .seat-pod {
@@ -252,8 +252,8 @@ body {
   border-radius: 0.9rem;
   background: rgba(6, 34, 24, 0.84);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
-  padding: 0.4rem 0.5rem;
-  min-height: 4.15rem;
+  padding: 0.34rem 0.42rem;
+  min-height: 3.32rem;
 }
 
 .seat-pod--turn {
@@ -270,7 +270,7 @@ body {
 .seat-pod--empty {
   border-style: dashed;
   background: rgba(4, 35, 25, 0.45);
-  min-height: 3.65rem;
+  min-height: 2.95rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -288,7 +288,7 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.65rem;
+  font-size: 0.6rem;
   font-weight: 700;
   color: #f8fafc;
 }
@@ -298,20 +298,20 @@ body {
 }
 
 .seat-pod__stack {
-  font-size: 0.68rem;
+  font-size: 0.61rem;
   color: #6ee7b7;
   font-weight: 700;
 }
 
 .seat-pod__bet {
-  font-size: 0.62rem;
+  font-size: 0.58rem;
   color: #fde68a;
   font-weight: 600;
 }
 
 .seat-pod__buyin {
   margin-top: 0.15rem;
-  font-size: 0.54rem;
+  font-size: 0.5rem;
   color: rgba(209, 250, 229, 0.6);
 }
 
@@ -326,14 +326,14 @@ body {
   border: 1px solid rgba(147, 197, 253, 0.55);
   background: rgba(37, 99, 235, 0.18);
   color: #dbeafe;
-  font-size: 0.5rem;
+  font-size: 0.45rem;
   line-height: 1;
   padding: 0.12rem 0.28rem;
   font-weight: 700;
 }
 
 .seat-pod__state {
-  font-size: 0.52rem;
+  font-size: 0.47rem;
   font-weight: 800;
 }
 
@@ -346,22 +346,22 @@ body {
 }
 
 .seat-pod__empty-label {
-  font-size: 0.62rem;
+  font-size: 0.56rem;
   color: rgba(209, 250, 229, 0.55);
 }
 
 .your-cards-tray {
   position: absolute;
   left: 50%;
-  bottom: 0.75rem;
+  bottom: 0.45rem;
   transform: translateX(-50%);
-  width: min(92%, 16rem);
+  width: min(84%, 13.8rem);
   border: 1px solid rgba(6, 95, 70, 0.68);
   border-radius: 0.95rem;
   background: rgba(5, 43, 30, 0.86);
   backdrop-filter: blur(4px);
-  padding: 0.45rem 0.55rem 0.52rem;
-  z-index: 30;
+  padding: 0.4rem 0.5rem 0.45rem;
+  z-index: 24;
 }
 
 .chip-composer-dock {
@@ -613,7 +613,7 @@ body {
   }
 
   .seat-orbit__slot {
-    width: min(20vw, 11.8rem);
+    width: min(17vw, 10rem);
   }
 
   .seat-pod {

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -226,6 +226,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
         data.roomId,
         data.playerName,
         client.id,
+        data.playerId,
       );
 
       if (!player) {

--- a/poker-server/src/game/game.service.ts
+++ b/poker-server/src/game/game.service.ts
@@ -166,6 +166,7 @@ export class GameService {
     roomId: string,
     playerName: string,
     newSocketId: string,
+    playerId?: string,
   ): Promise<Player | null> {
     const room = await this.storageService.getRoom(roomId);
 
@@ -173,7 +174,9 @@ export class GameService {
       return null;
     }
 
-    const player = room.players.find((p) => p.name === playerName);
+    const player = playerId
+      ? room.players.find((p) => p.id === playerId)
+      : room.players.find((p) => p.name === playerName);
     if (!player) {
       return null;
     }
@@ -184,7 +187,7 @@ export class GameService {
     room.lastActivityAt = Date.now();
 
     await this.storageService.saveRoom(room);
-    this.logger.log(`Player ${playerName} reconnected in room ${roomId}`);
+    this.logger.log(`Player ${player.name} reconnected in room ${roomId}`);
 
     return player;
   }

--- a/poker-types/src/events.types.ts
+++ b/poker-types/src/events.types.ts
@@ -20,6 +20,7 @@ export interface JoinRoomData {
 export interface ReconnectData {
   roomId: string;
   playerName: string;
+  playerId?: string;
 }
 
 export interface PlayerActionData {


### PR DESCRIPTION
## Summary
- fix turn ownership desync by reconnecting with `playerId` and moving active session state to per-tab `sessionStorage`
- tighten seat orbit sizing/anchors for iPhone layout to avoid seat overlap
- shrink and reposition the Your Cards tray so it does not obstruct seat content
- add stronger `isYourTurn` resolution based on resolved player identity

## Validation
- npm run build (poker-types)
- npm run build (poker-server)
- npm run lint (poker-client)
- npm run build (poker-client)
- playwright comprehensive-e2e: 42 passed