### PR TITLE
Sync URL with entrance/room screen state

### DIFF
--- a/poker-client/src/App.tsx
+++ b/poker-client/src/App.tsx
@@ -1,30 +1,68 @@
 import { useEffect } from "react";
 import {
   BrowserRouter as Router,
+  useLocation,
   Routes,
   Route,
   useNavigate,
-  useParams,
 } from "react-router-dom";
 import { SocketProvider } from "./contexts/SocketContext";
 import { GameProvider, useGame } from "./contexts/GameContext";
 import { Home } from "./pages/Home";
 import { GameRoom } from "./components/GameRoom";
 
-const RoomRoute: React.FC = () => {
+const UrlStateSync: React.FC = () => {
   const navigate = useNavigate();
-  const { roomId } = useParams();
-  const { room, player } = useGame();
+  const location = useLocation();
+  const { room, player, isRecoveringSession } = useGame();
 
   useEffect(() => {
-    if (!room?.id) return;
-    if (roomId !== room.id) {
-      navigate(`/room/${room.id}`, { replace: true });
+    const activeRoomId = room?.id?.toUpperCase();
+    const hasActiveSession = Boolean(activeRoomId && player?.id);
+
+    if (hasActiveSession) {
+      const targetRoomPath = `/room/${activeRoomId}`;
+      if (location.pathname !== targetRoomPath) {
+        navigate(targetRoomPath, { replace: true });
+      }
+      return;
     }
-  }, [navigate, room?.id, roomId]);
+
+    if (isRecoveringSession) {
+      return;
+    }
+
+    const roomPathMatch = location.pathname.match(/^\/room\/([^/]+)$/i);
+    const isRoomPath = location.pathname === "/room" || Boolean(roomPathMatch);
+    if (!isRoomPath) {
+      return;
+    }
+
+    const roomIdFromPath = roomPathMatch?.[1]?.toUpperCase();
+    const targetPath = roomIdFromPath
+      ? `/?roomId=${encodeURIComponent(roomIdFromPath)}`
+      : "/";
+    const currentPathAndSearch = `${location.pathname}${location.search}`;
+    if (currentPathAndSearch !== targetPath) {
+      navigate(targetPath, { replace: true });
+    }
+  }, [
+    isRecoveringSession,
+    location.pathname,
+    location.search,
+    navigate,
+    player?.id,
+    room?.id,
+  ]);
+
+  return null;
+};
+
+const RoomRoute: React.FC = () => {
+  const { room, player } = useGame();
 
   if (!room || !player) {
-    return <Home prefilledRoomId={roomId} forceJoinMode={Boolean(roomId)} />;
+    return <Home />;
   }
 
   return <GameRoom />;
@@ -35,6 +73,7 @@ function App() {
     <Router>
       <SocketProvider>
         <GameProvider>
+          <UrlStateSync />
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/room" element={<RoomRoute />} />

--- a/poker-client/src/pages/Home.tsx
+++ b/poker-client/src/pages/Home.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useGame } from "../contexts/GameContext";
 import { useSocket } from "../contexts/SocketContext";
 
@@ -13,6 +13,7 @@ export const Home: React.FC<HomeProps> = ({
   forceJoinMode = false,
 }) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { connected } = useSocket();
   const {
     createRoom,
@@ -26,12 +27,22 @@ export const Home: React.FC<HomeProps> = ({
     () => prefilledRoomId?.trim().toUpperCase() ?? "",
     [prefilledRoomId],
   );
-  const defaultJoinMode = forceJoinMode || Boolean(normalizedPrefilledRoomId);
+  const queryRoomId = useMemo(
+    () => searchParams.get("roomId")?.trim().toUpperCase() ?? "",
+    [searchParams],
+  );
+  const inferredRoomId = normalizedPrefilledRoomId || queryRoomId;
+  const defaultJoinMode = forceJoinMode || Boolean(inferredRoomId);
   const [playerName, setPlayerName] = useState("");
-  const [roomId, setRoomId] = useState(normalizedPrefilledRoomId);
+  const [roomId, setRoomId] = useState(inferredRoomId);
   const [isJoining, setIsJoining] = useState(defaultJoinMode);
   const [feedback, setFeedback] = useState<string | null>(null);
-  const effectiveRoomId = normalizedPrefilledRoomId || roomId;
+  const effectiveRoomId = inferredRoomId || roomId;
+
+  useEffect(() => {
+    setRoomId(inferredRoomId);
+    setIsJoining(defaultJoinMode);
+  }, [defaultJoinMode, inferredRoomId]);
 
   const clearFeedback = () => {
     if (feedback) {
@@ -53,7 +64,6 @@ export const Home: React.FC<HomeProps> = ({
 
     clearFeedback();
     createRoom(trimmedName);
-    navigate("/room");
   };
 
   const handleJoinRoom = () => {
@@ -70,7 +80,6 @@ export const Home: React.FC<HomeProps> = ({
 
     clearFeedback();
     joinRoom(normalizedRoomId, trimmedName);
-    navigate(`/room/${normalizedRoomId}`);
   };
 
   return (
@@ -206,6 +215,7 @@ export const Home: React.FC<HomeProps> = ({
                     setIsJoining(false);
                     setRoomId("");
                     clearFeedback();
+                    navigate("/", { replace: true });
                   }}
                   data-testid="back-button"
                   className="w-full rounded-xl border border-slate-500/70 bg-slate-700/20 px-4 py-3 font-semibold text-slate-200 transition hover:bg-slate-700/40"

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -3443,6 +3443,41 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.4a: Entrance Screen Keeps URL At Root', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      await page.goto(FRONTEND_URL);
+      await page.waitForSelector('[data-testid="connection-status"]');
+      await expect(page.locator('[data-testid="connection-status"]')).toContainText(
+        'Connected',
+      );
+
+      await page.click('[data-testid="join-toggle-button"]');
+      await page.fill('[data-testid="name-input"]', 'RouteCheck');
+      await page.fill('[data-testid="room-id-input"]', 'ZZZZZZ');
+      await page.click('[data-testid="join-room-button"]');
+
+      await page.waitForSelector('[data-testid="name-input"]');
+      const pathnameAfterJoinAttempt = await page.evaluate(
+        () => window.location.pathname,
+      );
+      expect(pathnameAfterJoinAttempt).toBe('/');
+
+      await expect(page).toHaveURL(/\/(\?roomId=ZZZZZZ)?$/);
+      await page.click('[data-testid="back-button"]');
+
+      await expect(page).toHaveURL(/\/$/);
+      await expect(page.locator('[data-testid="name-input"]')).toBeVisible();
+      await expect(page.locator('[data-testid="create-room-button"]')).toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
+
   test('8.5: Host Can Start Next Hand After Break', async ({ browser }) => {
     const session = await setupTwoPlayerSession(browser);
 


### PR DESCRIPTION
## Summary
- make URL canonical from actual app screen state (entrance vs in-room)
- avoid optimistic navigation to room routes before room state is established
- preserve invite room code on entrance screen via `roomId` query param while keeping lobby pathname at `/`
- add E2E coverage for entrance-screen URL behavior

## Testing
- `npm run build` in `poker-client`
- `npm run test:e2e:playwright -- --project=comprehensive-e2e -g "8.4a: Entrance Screen Keeps URL At Root"` in `poker-server`
- `npm run test:e2e:playwright -- --project=comprehensive-e2e -g "1.1: Check/Check Scenario"` in `poker-server`
