### PR TITLE
Allow mid-game joins and persist player names

### DIFF
--- a/poker-client/src/App.tsx
+++ b/poker-client/src/App.tsx
@@ -12,6 +12,8 @@ import { LocalizationProvider } from "./contexts/LocalizationContext";
 import { Home } from "./pages/Home";
 import { GameRoom } from "./components/GameRoom";
 
+const JUST_LEFT_ROOM_STORAGE_KEY = "poker.justLeftRoom";
+
 const UrlStateSync: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -39,10 +41,19 @@ const UrlStateSync: React.FC = () => {
       return;
     }
 
+    const justLeftRoom =
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(JUST_LEFT_ROOM_STORAGE_KEY) === "1";
+    if (justLeftRoom && typeof window !== "undefined") {
+      window.sessionStorage.removeItem(JUST_LEFT_ROOM_STORAGE_KEY);
+    }
+
     const roomIdFromPath = roomPathMatch?.[1]?.toUpperCase();
-    const targetPath = roomIdFromPath
-      ? `/?roomId=${encodeURIComponent(roomIdFromPath)}`
-      : "/";
+    const targetPath = justLeftRoom
+      ? "/"
+      : roomIdFromPath
+        ? `/?roomId=${encodeURIComponent(roomIdFromPath)}`
+        : "/";
     const currentPathAndSearch = `${location.pathname}${location.search}`;
     if (currentPathAndSearch !== targetPath) {
       navigate(targetPath, { replace: true });

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -389,6 +389,8 @@ export const GameRoom: React.FC = () => {
       currentHand.currentPlayerTurn === resolvedPlayerId,
   );
   const hasHoleCards = Boolean(yourCards && yourCards.length > 0);
+  const isWaitingForNextHand =
+    Boolean(isGameStarted) && currentPlayer?.status === "waiting" && !hasHoleCards;
   const currentHandNumber = currentHand?.handNumber ?? null;
 
   const isHandPausedForNext =
@@ -830,6 +832,12 @@ export const GameRoom: React.FC = () => {
   }, [room?.id, currentHandNumber]);
 
   useEffect(() => {
+    // Reset hand-level UI state for each new hand.
+    setShowRankingsModal(false);
+    setIsCardsFlyoutOpen(true);
+  }, [room?.id, currentHandNumber]);
+
+  useEffect(() => {
     const previousIsYourTurn = previousIsYourTurnRef.current;
     if (previousIsYourTurn === null) {
       if (isYourTurn) {
@@ -1257,6 +1265,12 @@ export const GameRoom: React.FC = () => {
         </section>
       </header>
 
+      {isWaitingForNextHand && (
+        <section className="mx-3 mt-2 rounded-xl border border-cyan-400/45 bg-cyan-900/25 px-3 py-2 text-xs font-semibold text-cyan-100">
+          {t("game.cardsAppearWhenHandStarts")}
+        </section>
+      )}
+
       {turnAlertToken !== null && (
         <div
           className="turn-center-alert-layer"
@@ -1289,18 +1303,24 @@ export const GameRoom: React.FC = () => {
               <h3 className="your-cards-flyout__title">{t("game.yourCards")}</h3>
             </div>
 
-            <div className="your-cards-flyout__cards">
-              {(yourCards ?? []).map((card, idx) => (
-                <Card key={idx} card={card} size="small" dataTestId={`your-card-${idx}`} />
-              ))}
-            </div>
+            {isCardsFlyoutOpen ? (
+              <div className="your-cards-flyout__cards">
+                {(yourCards ?? []).map((card, idx) => (
+                  <Card key={idx} card={card} size="small" dataTestId={`your-card-${idx}`} />
+                ))}
+              </div>
+            ) : (
+              <div className="your-cards-flyout__empty-state" data-testid="hole-cards-hidden-state">
+                {t("game.hide")} {t("game.yourCards")}
+              </div>
+            )}
           </div>
 
           <button
             type="button"
             onClick={() => setIsCardsFlyoutOpen((prev) => !prev)}
             className="your-cards-flyout__toggle"
-            data-testid="your-cards-flyout-toggle"
+            data-testid="toggle-hole-cards"
             aria-label={`${isCardsFlyoutOpen ? t("game.hide") : t("game.show")} ${t("game.yourCards")}`}
           >
             {isCardsFlyoutOpen ? "<" : ">"}
@@ -1402,6 +1422,7 @@ export const GameRoom: React.FC = () => {
               const isFolded = seatPlayer?.status === "folded";
               const isAllIn = seatPlayer?.status === "all-in";
               const isDisconnected = seatPlayer?.status === "disconnected";
+              const isWaiting = seatPlayer?.status === "waiting";
 
               return (
                 <div
@@ -1451,6 +1472,12 @@ export const GameRoom: React.FC = () => {
                       <div className="seat-pod__stack text-green-400 text-sm">${seatPlayer.chips}</div>
                     </div>
 
+                    <div className="seat-pod__row">
+                      <div className="text-[11px] text-emerald-100/65">
+                        Buy-in: ${seatPlayer.totalBuyIn ?? 0}
+                      </div>
+                    </div>
+
                     <div className="seat-pod__row seat-pod__row--bet">
                       <div
                         className={`seat-pod__bet ${
@@ -1467,6 +1494,11 @@ export const GameRoom: React.FC = () => {
                       {isDisconnected && (
                         <span className="seat-pod__state seat-pod__state--disconnected">
                           {t("game.status.disconnected")}
+                        </span>
+                      )}
+                      {isWaiting && (
+                        <span className="seat-pod__state seat-pod__state--disconnected">
+                          {t("game.status.waiting")}
                         </span>
                       )}
                       {isFolded && (

--- a/poker-client/src/contexts/GameContext.tsx
+++ b/poker-client/src/contexts/GameContext.tsx
@@ -18,6 +18,7 @@ import type {
   ClientToServerEvents,
 } from "poker-types";
 import { useSocket } from "./SocketContext";
+import { writeLastPlayerName } from "../utils/player-name-storage";
 
 export interface PlayerActionFlashEvent {
   id: string;
@@ -98,6 +99,7 @@ type StoredSession = {
 };
 
 const SESSION_STORAGE_KEY = "poker.activeSession";
+const JUST_LEFT_ROOM_STORAGE_KEY = "poker.justLeftRoom";
 const createActionId = () =>
   typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
     ? crypto.randomUUID()
@@ -177,6 +179,11 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
       playerName: player.name,
     });
   }, [player?.id, player?.name, room?.id]);
+
+  useEffect(() => {
+    if (!player?.name) return;
+    writeLastPlayerName(player.name);
+  }, [player?.name]);
 
   useEffect(() => {
     if (!socket) return;
@@ -680,17 +687,22 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
   }, [socket]);
 
   const leaveRoom = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(JUST_LEFT_ROOM_STORAGE_KEY, "1");
+    }
+    clearStoredSession();
+    setRoom(null);
+    setPlayer(null);
+    setYourCards(null);
+    setLastHandResult(null);
+    setLastPlayerActionEvent(null);
+    setRevealedHandPlayerIds([]);
+    setIsRecoveringSession(false);
+    setLastError(null);
+
     if (!socket) return;
     socket.emit("LEAVE_ROOM", () => {
-      clearStoredSession();
-      setRoom(null);
-      setPlayer(null);
-      setYourCards(null);
-      setLastHandResult(null);
-      setLastPlayerActionEvent(null);
-      setRevealedHandPlayerIds([]);
-      setIsRecoveringSession(false);
-      setLastError(null);
+      // Local state is already cleared optimistically.
     });
   }, [socket]);
 

--- a/poker-client/src/i18n/messages.ts
+++ b/poker-client/src/i18n/messages.ts
@@ -75,6 +75,7 @@ export const EN_MESSAGES = {
   "game.status.allIn": "ALL-IN",
   "game.status.disconnected": "DISCONNECTED",
   "game.status.folded": "FOLDED",
+  "game.status.waiting": "WAITING",
 
   "game.handResults": "Hand #{handNumber} Results",
   "game.showdownComplete": "Showdown complete: hands are automatically revealed.",
@@ -246,6 +247,7 @@ export const ZH_HANS_MESSAGES: Record<MessageKey, string> = {
   "game.status.allIn": "全下",
   "game.status.disconnected": "已断线",
   "game.status.folded": "已弃牌",
+  "game.status.waiting": "等待中",
 
   "game.handResults": "第 #{handNumber} 局结果",
   "game.showdownComplete": "摊牌完成：手牌已自动展示。",

--- a/poker-client/src/pages/Home.tsx
+++ b/poker-client/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useGame } from "../contexts/GameContext";
 import { useSocket } from "../contexts/SocketContext";
 import { useLocalization } from "../contexts/LocalizationContext";
+import { readLastPlayerName, writeLastPlayerName } from "../utils/player-name-storage";
 
 interface HomeProps {
   prefilledRoomId?: string;
@@ -35,7 +36,7 @@ export const Home: React.FC<HomeProps> = ({
   );
   const inferredRoomId = normalizedPrefilledRoomId || queryRoomId;
   const defaultJoinMode = forceJoinMode || Boolean(inferredRoomId);
-  const [playerName, setPlayerName] = useState("");
+  const [playerName, setPlayerName] = useState(() => readLastPlayerName());
   const [roomId, setRoomId] = useState("");
   const [joinModeOverride, setJoinModeOverride] = useState<boolean | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -63,6 +64,7 @@ export const Home: React.FC<HomeProps> = ({
     }
 
     clearFeedback();
+    writeLastPlayerName(trimmedName);
     createRoom(trimmedName);
   };
 
@@ -79,6 +81,7 @@ export const Home: React.FC<HomeProps> = ({
     }
 
     clearFeedback();
+    writeLastPlayerName(trimmedName);
     joinRoom(normalizedRoomId, trimmedName);
   };
 

--- a/poker-client/src/utils/player-name-storage.ts
+++ b/poker-client/src/utils/player-name-storage.ts
@@ -1,0 +1,25 @@
+const LAST_PLAYER_NAME_STORAGE_KEY = "poker.lastPlayerName";
+
+export function readLastPlayerName(): string {
+  if (typeof window === "undefined") return "";
+
+  try {
+    const savedName = window.localStorage.getItem(LAST_PLAYER_NAME_STORAGE_KEY);
+    return savedName?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function writeLastPlayerName(name: string): void {
+  if (typeof window === "undefined") return;
+
+  const trimmedName = name.trim();
+  if (!trimmedName) return;
+
+  try {
+    window.localStorage.setItem(LAST_PLAYER_NAME_STORAGE_KEY, trimmedName);
+  } catch {
+    // Ignore write errors (for example private browsing storage restrictions).
+  }
+}

--- a/poker-server/src/game/game.service.ts
+++ b/poker-server/src/game/game.service.ts
@@ -77,8 +77,8 @@ export class GameService {
       throw new Error('Room not found');
     }
 
-    if (room.gameState !== 'WAITING') {
-      throw new Error('Cannot join room - game already in progress');
+    if (room.gameState === 'ENDED') {
+      throw new Error('Cannot join room - game has ended');
     }
 
     // Check if name is taken
@@ -91,15 +91,18 @@ export class GameService {
       throw new Error('Room is full');
     }
 
+    const joinsDuringActiveGame = room.gameState === 'IN_PROGRESS';
     const playerId = generatePlayerId();
     const position = this.findNextAvailablePosition(room);
+    const initialChips = joinsDuringActiveGame ? room.config.startingChips : 0;
+    const initialBuyIn = joinsDuringActiveGame ? room.config.startingChips : 0;
 
     const player: Player = {
       id: playerId,
       socketId,
       name: playerName,
-      chips: 0,
-      totalBuyIn: 0,
+      chips: initialChips,
+      totalBuyIn: initialBuyIn,
       position,
       status: 'waiting' as PlayerStatus,
       cards: null,

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -3704,6 +3704,107 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.4b: Home Prefills Last Used Player Name', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      await page.goto(FRONTEND_URL);
+      await page.waitForSelector('[data-testid="connection-status"]');
+      await expect(page.locator('[data-testid="connection-status"]')).toContainText(
+        'Connected',
+      );
+
+      await page.fill('[data-testid="name-input"]', 'RememberMe');
+      await page.click('[data-testid="create-room-button"]');
+      await page.waitForSelector('[data-testid="room-title"]');
+
+      await page.click('[data-testid="leave-room-button"]');
+      await expect(page).toHaveURL(/\/$/);
+      await expect(page.locator('[data-testid="name-input"]')).toHaveValue(
+        'RememberMe',
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('8.4c: Player Can Join Mid-Hand And Wait For Next Hand', async ({ browser }) => {
+    const session = await setupTwoPlayerSession(browser);
+    let charlieContext: BrowserContext | null = null;
+
+    try {
+      const { alicePage, bobPage, roomCode } = session;
+      await startGameFromLobby(alicePage, bobPage);
+
+      charlieContext = await browser.newContext();
+      const charliePage = await charlieContext.newPage();
+      await charliePage.goto(FRONTEND_URL);
+      await charliePage.waitForSelector('[data-testid="connection-status"]');
+      await expect(charliePage.locator('[data-testid="connection-status"]')).toContainText(
+        'Connected',
+      );
+
+      await charliePage.click('[data-testid="join-toggle-button"]');
+      await charliePage.fill('[data-testid="name-input"]', 'Charlie');
+      await charliePage.fill('[data-testid="room-id-input"]', roomCode);
+      await charliePage.click('[data-testid="join-room-button"]');
+      await charliePage.waitForSelector(
+        '[data-testid="room-player-count"]:has-text("Players: 3/")',
+      );
+
+      const waitingState = await charliePage.evaluate(() => {
+        const pokerDebug = (window as any).pokerDebug;
+        const room = pokerDebug?.getRoom?.();
+        const player = pokerDebug?.getPlayer?.();
+        const cards = pokerDebug?.getCards?.();
+        const activePlayers = room?.currentHand?.activePlayers ?? [];
+
+        return {
+          status: player?.status ?? null,
+          chips: player?.chips ?? 0,
+          totalBuyIn: player?.totalBuyIn ?? 0,
+          cardsCount: Array.isArray(cards) ? cards.length : 0,
+          inActiveHand: Boolean(player?.id && activePlayers.includes(player.id)),
+        };
+      });
+      expect(waitingState.status).toBe('waiting');
+      expect(waitingState.cardsCount).toBe(0);
+      expect(waitingState.inActiveHand).toBe(false);
+      expect(waitingState.chips).toBe(1000);
+      expect(waitingState.totalBuyIn).toBe(1000);
+
+      await waitForPlayerTurn(bobPage, 'Bob');
+      await bobPage.click('[data-testid="action-fold"]');
+
+      await expect(
+        alicePage.locator('[data-testid="start-next-hand-button"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="start-next-hand-button"]');
+
+      await waitForHoleCards(charliePage);
+      const nextHandState = await charliePage.evaluate(() => {
+        const pokerDebug = (window as any).pokerDebug;
+        const player = pokerDebug?.getPlayer?.();
+        const cards = pokerDebug?.getCards?.();
+
+        return {
+          status: player?.status ?? null,
+          totalBuyIn: player?.totalBuyIn ?? 0,
+          cardsCount: Array.isArray(cards) ? cards.length : 0,
+        };
+      });
+      expect(nextHandState.status).toBe('connected');
+      expect(nextHandState.cardsCount).toBe(2);
+      expect(nextHandState.totalBuyIn).toBe(1000);
+    } finally {
+      await Promise.allSettled([
+        charlieContext?.close(),
+        teardownTwoPlayerSession(session),
+      ]);
+    }
+  });
+
   test('@critical 8.5: Host Can Start Next Hand After Break', async ({ browser }) => {
     const session = await setupTwoPlayerSession(browser);
 

--- a/poker-server/test/unit/game.service.spec.ts
+++ b/poker-server/test/unit/game.service.spec.ts
@@ -1,0 +1,211 @@
+import { GameService } from '../../src/game/game.service';
+import { IStorageService } from '../../src/common/interfaces/storage.interface';
+import { Room, Player, GameStateType } from 'poker-types';
+
+describe('GameService addPlayerToRoom', () => {
+  let storageService: jest.Mocked<IStorageService>;
+  let gameService: GameService;
+
+  beforeEach(() => {
+    storageService = {
+      saveRoom: jest.fn().mockResolvedValue(undefined),
+      getRoom: jest.fn().mockResolvedValue(null),
+      deleteRoom: jest.fn().mockResolvedValue(undefined),
+      getAllRooms: jest.fn().mockResolvedValue([]),
+      roomExists: jest.fn().mockResolvedValue(false),
+    };
+
+    gameService = new GameService(storageService);
+  });
+
+  function createPlayer(params: {
+    id: string;
+    socketId: string;
+    name: string;
+    position: number;
+    chips: number;
+    totalBuyIn: number;
+    status: Player['status'];
+  }): Player {
+    return {
+      id: params.id,
+      socketId: params.socketId,
+      name: params.name,
+      chips: params.chips,
+      totalBuyIn: params.totalBuyIn,
+      position: params.position,
+      status: params.status,
+      cards: null,
+      currentBet: 0,
+      lastAction: null,
+      lastConnectedAt: Date.now(),
+    };
+  }
+
+  function createRoom(params: {
+    gameState: GameStateType;
+    players: Player[];
+    maxPlayers?: number;
+    startingChips?: number;
+  }): Room {
+    return {
+      id: 'ROOM01',
+      hostId: params.players[0]?.id ?? 'host-id',
+      config: {
+        startingChips: params.startingChips ?? 1000,
+        smallBlind: 10,
+        bigBlind: 20,
+        maxPlayers: params.maxPlayers ?? 10,
+        reconnectGracePeriod: 30000,
+      },
+      players: params.players,
+      gameState: params.gameState,
+      currentHand: null,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+  }
+
+  it('adds joiner with zero chips while table is waiting', async () => {
+    const room = createRoom({
+      gameState: 'WAITING',
+      players: [
+        createPlayer({
+          id: 'p-host',
+          socketId: 's-host',
+          name: 'Alice',
+          position: 0,
+          chips: 0,
+          totalBuyIn: 0,
+          status: 'waiting',
+        }),
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    const { player } = await gameService.addPlayerToRoom('ROOM01', 's-bob', 'Bob');
+
+    expect(player.name).toBe('Bob');
+    expect(player.chips).toBe(0);
+    expect(player.totalBuyIn).toBe(0);
+    expect(player.status).toBe('waiting');
+    expect(room.players).toHaveLength(2);
+    expect(storageService.saveRoom).toHaveBeenCalledWith(room);
+  });
+
+  it('allows join while game is in progress and assigns starting chips as buy-in', async () => {
+    const room = createRoom({
+      gameState: 'IN_PROGRESS',
+      startingChips: 1500,
+      players: [
+        createPlayer({
+          id: 'p-host',
+          socketId: 's-host',
+          name: 'Alice',
+          position: 0,
+          chips: 1200,
+          totalBuyIn: 2000,
+          status: 'connected',
+        }),
+        createPlayer({
+          id: 'p-bob',
+          socketId: 's-bob',
+          name: 'Bob',
+          position: 1,
+          chips: 800,
+          totalBuyIn: 1000,
+          status: 'connected',
+        }),
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    const { player } = await gameService.addPlayerToRoom('ROOM01', 's-charlie', 'Charlie');
+
+    expect(player.name).toBe('Charlie');
+    expect(player.status).toBe('waiting');
+    expect(player.chips).toBe(1500);
+    expect(player.totalBuyIn).toBe(1500);
+    expect(room.players).toHaveLength(3);
+    expect(storageService.saveRoom).toHaveBeenCalledWith(room);
+  });
+
+  it('rejects join when game has ended', async () => {
+    const room = createRoom({
+      gameState: 'ENDED',
+      players: [
+        createPlayer({
+          id: 'p-host',
+          socketId: 's-host',
+          name: 'Alice',
+          position: 0,
+          chips: 0,
+          totalBuyIn: 0,
+          status: 'waiting',
+        }),
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    await expect(
+      gameService.addPlayerToRoom('ROOM01', 's-bob', 'Bob'),
+    ).rejects.toThrow('Cannot join room - game has ended');
+    expect(storageService.saveRoom).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate player names', async () => {
+    const room = createRoom({
+      gameState: 'IN_PROGRESS',
+      players: [
+        createPlayer({
+          id: 'p-host',
+          socketId: 's-host',
+          name: 'Alice',
+          position: 0,
+          chips: 1000,
+          totalBuyIn: 1000,
+          status: 'connected',
+        }),
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    await expect(
+      gameService.addPlayerToRoom('ROOM01', 's-other', 'Alice'),
+    ).rejects.toThrow('Name already taken');
+    expect(storageService.saveRoom).not.toHaveBeenCalled();
+  });
+
+  it('rejects join when room is full', async () => {
+    const room = createRoom({
+      gameState: 'WAITING',
+      maxPlayers: 2,
+      players: [
+        createPlayer({
+          id: 'p-host',
+          socketId: 's-host',
+          name: 'Alice',
+          position: 0,
+          chips: 0,
+          totalBuyIn: 0,
+          status: 'waiting',
+        }),
+        createPlayer({
+          id: 'p-bob',
+          socketId: 's-bob',
+          name: 'Bob',
+          position: 1,
+          chips: 0,
+          totalBuyIn: 0,
+          status: 'waiting',
+        }),
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    await expect(
+      gameService.addPlayerToRoom('ROOM01', 's-charlie', 'Charlie'),
+    ).rejects.toThrow('Room is full');
+    expect(storageService.saveRoom).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- allow players to join rooms while a hand is in progress (still reject joins when game is ended)
- initialize mid-game joiners with starting chips and starting buy-in, keep them in waiting until next hand
- persist last used player name in localStorage and prefill it on Home
- show waiting status + buy-in in the seat UI, and restore card-toggle compatibility used by e2e tests
- make leave-room navigation deterministic by forcing root URL after explicit leave while preserving invite deep-link conversion

## Validation
- npm --prefix poker-server run test:unit -- --runInBand
- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm --prefix poker-server run test:e2e:playwright:smoke
- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm --prefix poker-server run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --reporter=line (50 passed)
- targeted regression rerun for 8.4, 8.6, 8.7, 8.9 (all passed)
