### PR TITLE
Auto-assign random emoji on game entry

### DIFF
--- a/poker-client/src/pages/Home.tsx
+++ b/poker-client/src/pages/Home.tsx
@@ -4,7 +4,6 @@ import { useGame } from "../contexts/GameContext";
 import { useSocket } from "../contexts/SocketContext";
 import { useLocalization } from "../contexts/LocalizationContext";
 import {
-  readLastPlayerEmoji,
   readLastPlayerName,
   writeLastPlayerEmoji,
   writeLastPlayerName,
@@ -46,7 +45,7 @@ export const Home: React.FC<HomeProps> = ({
   const inferredRoomId = normalizedPrefilledRoomId || queryRoomId;
   const defaultJoinMode = forceJoinMode || Boolean(inferredRoomId);
   const [playerName, setPlayerName] = useState(() => readLastPlayerName());
-  const [playerEmoji, setPlayerEmoji] = useState(() => readLastPlayerEmoji());
+  const [playerEmoji, setPlayerEmoji] = useState(() => getRandomPlayerEmoji());
   const [isEmojiPopoverOpen, setIsEmojiPopoverOpen] = useState(false);
   const [roomId, setRoomId] = useState("");
   const [joinModeOverride, setJoinModeOverride] = useState<boolean | null>(null);


### PR DESCRIPTION
## Summary
- auto-assign a random emoji on entry instead of reading the previously saved emoji
- keep the manual randomize button for rerolling

## Validation
- npm --prefix poker-client run lint
- npm --prefix poker-client run build
