### PR TITLE
Serialize room membership mutations to prevent player loss

### DIFF
--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -132,30 +132,37 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.socketToPlayer.delete(client.id);
 
     const { roomId, playerId } = playerInfo;
-    const room = await this.getRoom(roomId);
-    const gracePeriod = room?.config?.reconnectGracePeriod ?? 120000;
-    const playerName =
-      room?.players?.find((player) => player.id === playerId)?.name ?? '';
 
-    const existingTimer = this.disconnectTimers.get(playerId);
-    if (existingTimer) {
-      clearTimeout(existingTimer);
+    try {
+      await this.runRoomActionSequentially(roomId, async () => {
+        const room = await this.getRoom(roomId);
+        const gracePeriod = room?.config?.reconnectGracePeriod ?? 120000;
+        const playerName =
+          room?.players?.find((player) => player.id === playerId)?.name ?? '';
+
+        const existingTimer = this.disconnectTimers.get(playerId);
+        if (existingTimer) {
+          clearTimeout(existingTimer);
+        }
+
+        // Start grace period timer
+        const timer = setTimeout(async () => {
+          await this.handleDisconnectTimeout(roomId, playerId);
+        }, gracePeriod);
+
+        this.disconnectTimers.set(playerId, timer);
+        await this.gameService.markPlayerDisconnected(roomId, playerId);
+
+        // Notify room of disconnect
+        this.server.to(roomId).emit('PLAYER_DISCONNECTED', {
+          playerId,
+          playerName,
+          gracePeriod,
+        });
+      });
+    } catch (error) {
+      this.logger.error(`Disconnect handling error: ${error.message}`);
     }
-
-    // Start grace period timer
-    const timer = setTimeout(async () => {
-      await this.handleDisconnectTimeout(roomId, playerId);
-    }, gracePeriod);
-
-    this.disconnectTimers.set(playerId, timer);
-    await this.gameService.markPlayerDisconnected(roomId, playerId);
-
-    // Notify room of disconnect
-    this.server.to(roomId).emit('PLAYER_DISCONNECTED', {
-      playerId,
-      playerName,
-      gracePeriod,
-    });
   }
 
   @SubscribeMessage('CREATE_ROOM')
@@ -203,44 +210,47 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() data: JoinRoomData,
   ) {
     try {
-      const { room, player, rejoined } = await this.gameService.addPlayerToRoom(
-        data.roomId,
-        client.id,
-        data.playerName,
-        data.playerEmoji,
-      );
+      return await this.runRoomActionSequentially(data.roomId, async () => {
+        const { room, player, rejoined } =
+          await this.gameService.addPlayerToRoom(
+            data.roomId,
+            client.id,
+            data.playerName,
+            data.playerEmoji,
+          );
 
-      client.join(room.id);
+        client.join(room.id);
 
-      this.trackPlayerSocket(client.id, room.id, player.id);
+        this.trackPlayerSocket(client.id, room.id, player.id);
 
-      if (rejoined) {
-        const timer = this.disconnectTimers.get(player.id);
-        if (timer) {
-          clearTimeout(timer);
-          this.disconnectTimers.delete(player.id);
+        if (rejoined) {
+          const timer = this.disconnectTimers.get(player.id);
+          if (timer) {
+            clearTimeout(timer);
+            this.disconnectTimers.delete(player.id);
+          }
+
+          this.server.to(room.id).emit('PLAYER_RECONNECTED', {
+            playerId: player.id,
+            playerName: player.name,
+          });
+        } else {
+          // Notify all in room
+          this.server.to(room.id).emit('PLAYER_JOINED', {
+            player: this.sanitizePlayer(player),
+          } as PlayerJoinedData);
         }
 
-        this.server.to(room.id).emit('PLAYER_RECONNECTED', {
-          playerId: player.id,
-          playerName: player.name,
+        client.emit('ROOM_JOINED', {
+          player,
+          room: this.sanitizeRoom(room),
         });
-      } else {
-        // Notify all in room
-        this.server.to(room.id).emit('PLAYER_JOINED', {
-          player: this.sanitizePlayer(player),
-        } as PlayerJoinedData);
-      }
 
-      client.emit('ROOM_JOINED', {
-        player,
-        room: this.sanitizeRoom(room),
+        this.logger.log(
+          `Player ${player.name} ${rejoined ? 'rejoined' : 'joined'} room ${room.id}`,
+        );
+        return { success: true };
       });
-
-      this.logger.log(
-        `Player ${player.name} ${rejoined ? 'rejoined' : 'joined'} room ${room.id}`,
-      );
-      return { success: true };
     } catch (error) {
       this.logger.error(`Join room error: ${error.message}`);
       client.emit('ERROR', { message: error.message });
@@ -254,46 +264,48 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() data: ReconnectData,
   ) {
     try {
-      const player = await this.gameService.updatePlayerSocket(
-        data.roomId,
-        data.playerName,
-        client.id,
-        data.playerId,
-      );
+      return await this.runRoomActionSequentially(data.roomId, async () => {
+        const player = await this.gameService.updatePlayerSocket(
+          data.roomId,
+          data.playerName,
+          client.id,
+          data.playerId,
+        );
 
-      if (!player) {
-        client.emit('RECONNECT_ERROR', { reason: 'Player not found in room' });
-        return { success: false };
-      }
+        if (!player) {
+          client.emit('RECONNECT_ERROR', { reason: 'Player not found in room' });
+          return { success: false };
+        }
 
-      // Cancel disconnect timer
-      const timer = this.disconnectTimers.get(player.id);
-      if (timer) {
-        clearTimeout(timer);
-        this.disconnectTimers.delete(player.id);
-      }
+        // Cancel disconnect timer
+        const timer = this.disconnectTimers.get(player.id);
+        if (timer) {
+          clearTimeout(timer);
+          this.disconnectTimers.delete(player.id);
+        }
 
-      client.join(data.roomId);
+        client.join(data.roomId);
 
-      this.trackPlayerSocket(client.id, data.roomId, player.id);
+        this.trackPlayerSocket(client.id, data.roomId, player.id);
 
-      // Get full room state - simplified, would need full sync
-      const room = await this.getRoom(data.roomId);
-      client.emit('RECONNECT_SUCCESS', {
-        player,
-        room: this.sanitizeRoom(room),
-        yourCards: player.cards,
+        // Get full room state - simplified, would need full sync
+        const room = await this.getRoom(data.roomId);
+        client.emit('RECONNECT_SUCCESS', {
+          player,
+          room: this.sanitizeRoom(room),
+          yourCards: player.cards,
+        });
+
+        this.server.to(data.roomId).emit('PLAYER_RECONNECTED', {
+          playerId: player.id,
+          playerName: player.name,
+        });
+
+        this.logger.log(
+          `Player ${player.name} reconnected to room ${data.roomId}`,
+        );
+        return { success: true };
       });
-
-      this.server.to(data.roomId).emit('PLAYER_RECONNECTED', {
-        playerId: player.id,
-        playerName: player.name,
-      });
-
-      this.logger.log(
-        `Player ${player.name} reconnected to room ${data.roomId}`,
-      );
-      return { success: true };
     } catch (error) {
       this.logger.error(`Reconnect error: ${error.message}`);
       client.emit('RECONNECT_ERROR', { reason: error.message });
@@ -829,32 +841,37 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
       const playerInfo = this.socketToPlayer.get(client.id);
       if (!playerInfo) return { success: true };
 
-      const room = await this.gameService.removePlayerFromRoom(
+      return await this.runRoomActionSequentially(
         playerInfo.roomId,
-        playerInfo.playerId,
+        async () => {
+          const room = await this.gameService.removePlayerFromRoom(
+            playerInfo.roomId,
+            playerInfo.playerId,
+          );
+
+          client.leave(playerInfo.roomId);
+          this.socketToPlayer.delete(client.id);
+
+          if (room) {
+            this.server.to(playerInfo.roomId).emit('PLAYER_LEFT', {
+              playerId: playerInfo.playerId,
+              playerName: '', // Would need to cache
+            });
+
+            // If host changed
+            const oldHostId = playerInfo.playerId;
+            if (room.hostId !== oldHostId) {
+              const newHost = room.players.find((p) => p.id === room.hostId)!;
+              this.server.to(playerInfo.roomId).emit('HOST_CHANGED', {
+                newHostId: newHost.id,
+                newHostName: newHost.name,
+              });
+            }
+          }
+
+          return { success: true };
+        },
       );
-
-      client.leave(playerInfo.roomId);
-      this.socketToPlayer.delete(client.id);
-
-      if (room) {
-        this.server.to(playerInfo.roomId).emit('PLAYER_LEFT', {
-          playerId: playerInfo.playerId,
-          playerName: '', // Would need to cache
-        });
-
-        // If host changed
-        const oldHostId = playerInfo.playerId;
-        if (room.hostId !== oldHostId) {
-          const newHost = room.players.find((p) => p.id === room.hostId)!;
-          this.server.to(playerInfo.roomId).emit('HOST_CHANGED', {
-            newHostId: newHost.id,
-            newHostName: newHost.name,
-          });
-        }
-      }
-
-      return { success: true };
     } catch (error) {
       this.logger.error(`Leave room error: ${error.message}`);
       return { success: false };

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -1,0 +1,201 @@
+import { EventsGateway } from '../../src/events/events.gateway';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const deepClone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+describe('EventsGateway membership mutation serialization', () => {
+  let gateway: EventsGateway;
+  let roomState: any;
+  let gameService: any;
+  let storageService: any;
+
+  const createPlayer = (params: {
+    id: string;
+    socketId: string;
+    name: string;
+    status: string;
+    position: number;
+  }) => ({
+    id: params.id,
+    socketId: params.socketId,
+    name: params.name,
+    chips: 1000,
+    totalBuyIn: 1000,
+    handsPlayedCount: 0,
+    handsWonCount: 0,
+    vpipHandsCount: 0,
+    position: params.position,
+    status: params.status,
+    cards: null,
+    currentBet: 0,
+    lastAction: null,
+    lastConnectedAt: Date.now(),
+  });
+
+  const createClient = (socketId: string) => ({
+    id: socketId,
+    join: jest.fn(),
+    leave: jest.fn(),
+    emit: jest.fn(),
+    handshake: { headers: {} },
+  });
+
+  beforeEach(() => {
+    roomState = {
+      id: 'ROOM1',
+      hostId: 'p-host',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [
+        createPlayer({
+          id: 'p-host',
+          socketId: 'socket-host',
+          name: 'Host',
+          status: 'connected',
+          position: 0,
+        }),
+        createPlayer({
+          id: 'p-bob',
+          socketId: 'socket-bob-old',
+          name: 'Bob',
+          status: 'disconnected',
+          position: 1,
+        }),
+      ],
+      gameState: 'IN_PROGRESS',
+      currentHand: null,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+
+    const persistViaStaleSnapshot = async (mutate: (draft: any) => void) => {
+      const snapshot = deepClone(roomState);
+      await wait(25);
+      mutate(snapshot);
+      await wait(25);
+      roomState = snapshot;
+      return deepClone(roomState);
+    };
+
+    gameService = {
+      addPlayerToRoom: jest.fn(
+        async (roomId: string, socketId: string, playerName: string) => {
+          if (roomId !== 'ROOM1') {
+            throw new Error('Room not found');
+          }
+
+          const player = createPlayer({
+            id: `p-${playerName.toLowerCase()}`,
+            socketId,
+            name: playerName,
+            status: 'waiting',
+            position: 2,
+          });
+
+          const room = await persistViaStaleSnapshot((draft) => {
+            draft.players.push(player);
+            draft.lastActivityAt = Date.now();
+          });
+
+          return { room, player, rejoined: false };
+        },
+      ),
+      updatePlayerSocket: jest.fn(
+        async (
+          roomId: string,
+          _playerName: string,
+          newSocketId: string,
+          playerId?: string,
+        ) => {
+          if (roomId !== 'ROOM1') {
+            return null;
+          }
+
+          let updatedPlayer: any = null;
+          await persistViaStaleSnapshot((draft) => {
+            const player = draft.players.find((p: any) => p.id === playerId);
+            if (!player) {
+              return;
+            }
+
+            player.socketId = newSocketId;
+            player.status = 'connected';
+            player.lastConnectedAt = Date.now();
+            draft.lastActivityAt = Date.now();
+            updatedPlayer = deepClone(player);
+          });
+
+          return updatedPlayer;
+        },
+      ),
+    };
+
+    storageService = {
+      getRoom: jest.fn(async (roomId: string) => {
+        if (roomId !== 'ROOM1') {
+          return null;
+        }
+        return deepClone(roomState);
+      }),
+      saveRoom: jest.fn(),
+      deleteRoom: jest.fn(),
+      getAllRooms: jest.fn(),
+      roomExists: jest.fn(),
+    };
+
+    gateway = new EventsGateway(
+      gameService,
+      {} as any,
+      {} as any,
+      { isTestMode: jest.fn().mockReturnValue(false) } as any,
+      storageService,
+    );
+
+    const roomEmitter = { emit: jest.fn() };
+    gateway.server = {
+      to: jest.fn().mockReturnValue(roomEmitter),
+      sockets: { sockets: new Map() },
+    } as any;
+  });
+
+  it('does not drop players when JOIN_ROOM and RECONNECT happen concurrently', async () => {
+    const joinClient = createClient('socket-join');
+    const reconnectClient = createClient('socket-reconnect');
+
+    const [joinResult, reconnectResult] = await Promise.all([
+      gateway.handleJoinRoom(joinClient as any, {
+        roomId: 'ROOM1',
+        playerName: 'Alice',
+      }),
+      gateway.handleReconnect(reconnectClient as any, {
+        roomId: 'ROOM1',
+        playerName: 'Bob',
+        playerId: 'p-bob',
+      }),
+    ]);
+
+    expect(joinResult).toEqual({ success: true });
+    expect(reconnectResult).toEqual({ success: true });
+    expect(roomState.players).toHaveLength(3);
+
+    const playerNames = roomState.players.map((p: any) => p.name).sort();
+    expect(playerNames).toEqual(['Alice', 'Bob', 'Host']);
+
+    const bob = roomState.players.find((p: any) => p.id === 'p-bob');
+    expect(bob).toBeDefined();
+    expect(bob.status).toBe('connected');
+    expect(bob.socketId).toBe('socket-reconnect');
+
+    expect(joinClient.join).toHaveBeenCalledWith('ROOM1');
+    expect(reconnectClient.join).toHaveBeenCalledWith('ROOM1');
+    expect(gameService.addPlayerToRoom).toHaveBeenCalledTimes(1);
+    expect(gameService.updatePlayerSocket).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary\n- serialize JOIN_ROOM / RECONNECT / LEAVE_ROOM / disconnect room-membership mutations via room queue\n- prevent concurrent stale-write overwrites that can drop players from room JSON\n- add regression test for concurrent JOIN_ROOM + RECONNECT\n\n## Validation\n- npm run build (poker-server)\n- npm run test:unit -- --runInBand --runTestsByPath test/unit/events.gateway.membership-race.spec.ts