### PR TITLE
fix(ui): keep waiting tag outside seat and simplify label

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -2722,16 +2722,26 @@ export const GameRoom: React.FC = () => {
                 isFolded,
                 isWaiting,
               });
-              const seatStatusLabel =
+              const seatInlineStatusLabel =
                 seatMainState === "disconnected"
                   ? t("game.status.disconnected")
                   : seatMainState === "all-in"
                     ? t("game.status.allIn")
                     : seatMainState === "folded"
                       ? t("game.status.folded")
-                      : seatMainState === "waiting"
-                        ? t("game.status.waitingNextHand")
-                        : null;
+                      : null;
+              const seatExternalStatusLabel =
+                seatMainState === "turn"
+                  ? t("game.status.acting")
+                  : seatMainState === "waiting"
+                    ? t("game.status.waiting")
+                    : null;
+              const seatExternalStatusToneClass =
+                seatMainState === "turn"
+                  ? "seat-pod__status-badge--turn"
+                  : seatMainState === "waiting"
+                    ? "seat-pod__status-badge--waiting"
+                    : "";
               const isForcedBlind = Boolean(
                 currentHand?.bettingRound === "PRE_FLOP" &&
                   seatPlayer.currentBet > 0 &&
@@ -2806,11 +2816,11 @@ export const GameRoom: React.FC = () => {
                         {roleIcon === "dealer" ? "D" : "SB"}
                       </span>
                     )}
-                    {seatMainState === "turn" && (
+                    {seatExternalStatusLabel && (
                       <span
-                        className="seat-pod__status-badge seat-pod__status-badge--turn seat-pod__status-badge--turn-external"
+                        className={`seat-pod__status-badge seat-pod__status-badge--external ${seatExternalStatusToneClass}`}
                       >
-                        {t("game.status.acting")}
+                        {seatExternalStatusLabel}
                       </span>
                     )}
                     <div className="seat-pod__row">
@@ -2822,21 +2832,19 @@ export const GameRoom: React.FC = () => {
                       <span className="seat-pod__name">
                         {seatPlayer.name}
                       </span>
-                      {seatStatusLabel && (
+                      {seatInlineStatusLabel && (
                         <span
                           className={`seat-pod__status-badge ${
                             seatMainState === "folded"
                               ? "seat-pod__status-badge--folded"
                               : seatMainState === "disconnected"
                                 ? "seat-pod__status-badge--disconnected"
-                                : seatMainState === "waiting"
-                                  ? "seat-pod__status-badge--waiting"
-                                  : seatMainState === "all-in"
+                                : seatMainState === "all-in"
                                     ? "seat-pod__status-badge--allin"
                                     : ""
                           }`}
                         >
-                          {seatStatusLabel}
+                          {seatInlineStatusLabel}
                         </span>
                       )}
                     </div>

--- a/poker-client/src/i18n/messages.ts
+++ b/poker-client/src/i18n/messages.ts
@@ -111,7 +111,7 @@ export const EN_MESSAGES = {
   "game.status.disconnected": "DISCONNECTED",
   "game.status.folded": "FOLDED",
   "game.status.waiting": "WAITING",
-  "game.status.waitingNextHand": "WAITING (NEXT HAND)",
+  "game.status.waitingNextHand": "WAITING",
   "game.status.acting": "ACTING",
 
   "game.handResults": "Hand #{handNumber} Results",
@@ -375,7 +375,7 @@ export const ZH_HANS_MESSAGES: Record<MessageKey, string> = {
   "game.status.disconnected": "已断线",
   "game.status.folded": "已弃牌",
   "game.status.waiting": "等待中",
-  "game.status.waitingNextHand": "等待中（下手入局）",
+  "game.status.waitingNextHand": "等待中",
   "game.status.acting": "行动中",
 
   "game.handResults": "第 #{handNumber} 局结果",

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -622,7 +622,7 @@ body {
   background: rgba(120, 53, 15, 0.48);
 }
 
-.seat-pod__status-badge--turn-external {
+.seat-pod__status-badge--external {
   position: absolute;
   left: 0;
   top: 0;

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -17,6 +17,19 @@ async function waitForPokerDebug(page: Page) {
   });
 }
 
+async function assertWaitingBadgeExternalForSeat(page: Page, playerId: string) {
+  const seat = page.locator(`[data-testid="player-seat-${playerId}"]`);
+  await expect(
+    seat.locator(
+      '.seat-pod__status-badge--external.seat-pod__status-badge--waiting',
+    ),
+  ).toHaveCount(1);
+  await expect(
+    seat.locator('.seat-pod__row .seat-pod__status-badge--waiting'),
+  ).toHaveCount(0);
+  await expect(seat).not.toContainText(/NEXT HAND|下手入局/);
+}
+
 // Helper to verify chip conservation (chips only, not including current bets)
 async function verifyChipConservation(page: Page, expected: number = 2000) {
   const state = await page.evaluate(() => {
@@ -4181,6 +4194,61 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.4c1: Mid-Hand Waiting Badge Stays Outside Seat', async ({ browser }) => {
+    const session = await setupTwoPlayerSession(browser);
+    let charlieContext: BrowserContext | null = null;
+
+    try {
+      const { alicePage, bobPage, roomCode } = session;
+      await startGameFromLobby(alicePage, bobPage);
+
+      charlieContext = await browser.newContext();
+      const charliePage = await charlieContext.newPage();
+      await charliePage.goto(FRONTEND_URL);
+      await charliePage.waitForSelector('[data-testid="connection-status"]');
+      await expect(charliePage.locator('[data-testid="connection-status"]')).toContainText(
+        'Connected',
+      );
+
+      await charliePage.click('[data-testid="join-toggle-button"]');
+      await charliePage.fill('[data-testid="name-input"]', 'Charlie');
+      await charliePage.fill('[data-testid="room-id-input"]', roomCode);
+      await charliePage.click('[data-testid="join-room-button"]');
+      await charliePage.waitForSelector(
+        '[data-testid="room-player-count"]:has-text("Players: 3/")',
+      );
+
+      const waitingState = await charliePage.evaluate(() => {
+        const pokerDebug = (window as any).pokerDebug;
+        const room = pokerDebug?.getRoom?.();
+        const player = pokerDebug?.getPlayer?.();
+        const cards = pokerDebug?.getCards?.();
+        const activePlayers = room?.currentHand?.activePlayers ?? [];
+
+        return {
+          playerId: player?.id ?? null,
+          status: player?.status ?? null,
+          cardsCount: Array.isArray(cards) ? cards.length : 0,
+          inActiveHand: Boolean(player?.id && activePlayers.includes(player.id)),
+        };
+      });
+      expect(waitingState.status).toBe('waiting');
+      expect(waitingState.cardsCount).toBe(0);
+      expect(waitingState.inActiveHand).toBe(false);
+      expect(waitingState.playerId).not.toBeNull();
+
+      await assertWaitingBadgeExternalForSeat(
+        charliePage,
+        waitingState.playerId as string,
+      );
+    } finally {
+      await Promise.allSettled([
+        charlieContext?.close(),
+        teardownTwoPlayerSession(session),
+      ]);
+    }
+  });
+
   test('8.4c: Player Can Join Mid-Hand And Wait For Next Hand', async ({ browser }) => {
     const session = await setupTwoPlayerSession(browser);
     let charlieContext: BrowserContext | null = null;
@@ -4213,6 +4281,7 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         const activePlayers = room?.currentHand?.activePlayers ?? [];
 
         return {
+          playerId: player?.id ?? null,
           status: player?.status ?? null,
           chips: player?.chips ?? 0,
           totalBuyIn: player?.totalBuyIn ?? 0,
@@ -4225,6 +4294,12 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       expect(waitingState.inActiveHand).toBe(false);
       expect(waitingState.chips).toBe(1000);
       expect(waitingState.totalBuyIn).toBe(1000);
+      expect(waitingState.playerId).not.toBeNull();
+
+      await assertWaitingBadgeExternalForSeat(
+        charliePage,
+        waitingState.playerId as string,
+      );
 
       await waitForPlayerTurn(bobPage, 'Bob');
       await bobPage.click('[data-testid="action-fold"]');


### PR DESCRIPTION
## Summary\n- keep waiting status badge rendered outside the seat card, aligned with acting badge behavior\n- stop rendering waiting badge inline in the seat name row\n- remove parenthetical `(NEXT HAND)` / `（下手入局）` wording from waiting status copy\n- add dedicated Playwright UI regression coverage for mid-hand join waiting badge placement and text\n\n## Validation\n- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 NO_PROXY='*' TEST_MODE=true ./node_modules/.bin/playwright test --project comprehensive-e2e --workers=1 --grep "8.4c1: Mid-Hand Waiting Badge Stays Outside Seat" --reporter=line\n- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm run test:e2e:playwright:smoke\n