### PR TITLE
fix(chat): correct outgoing voice alignment and add e2e guard

### DIFF
--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -1574,6 +1574,11 @@ body {
   width: min(100%, 30rem);
 }
 
+.chat-panel__item--self.chat-panel__item--voice {
+  width: fit-content;
+  max-width: min(94%, 30rem);
+}
+
 .chat-panel__meta {
   display: flex;
   align-items: baseline;
@@ -1582,6 +1587,10 @@ body {
   font-size: 0.62rem;
   color: rgba(186, 230, 253, 0.75);
   margin-bottom: 0.14rem;
+}
+
+.chat-panel__item--self.chat-panel__item--voice .chat-panel__meta {
+  justify-content: flex-end;
 }
 
 .chat-panel__sender {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -5695,6 +5695,71 @@ test.describe('Poker E2E - Test Suite 10: Chat History & Concurrency', () => {
       await teardownTwoPlayerSession(session);
     }
   });
+
+  test('10.6: Outgoing voice message stays right-aligned without full-width stretch', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser);
+
+    try {
+      const { alicePage } = session;
+
+      await sendVoiceMessageViaUpload(alicePage, 'voice-self-align');
+      await openChatPanel(alicePage);
+
+      const selfVoiceItems = alicePage.locator(
+        '[data-testid="chat-message-list"] .chat-panel__item--self.chat-panel__item--voice',
+      );
+      await expect(selfVoiceItems).toHaveCount(1);
+
+      const layoutMetrics = await alicePage.evaluate(() => {
+        const list = document.querySelector('[data-testid="chat-message-list"]') as HTMLElement | null;
+        const selfVoiceItem = document.querySelector(
+          '[data-testid="chat-message-list"] .chat-panel__item--self.chat-panel__item--voice',
+        ) as HTMLElement | null;
+        const voiceBubble = selfVoiceItem?.querySelector('.chat-panel__bubble--voice') as
+          | HTMLElement
+          | null;
+        const voicePlayer = selfVoiceItem?.querySelector('.chat-panel__voice-player') as
+          | HTMLElement
+          | null;
+
+        if (!list || !selfVoiceItem || !voiceBubble || !voicePlayer) {
+          return null;
+        }
+
+        const listRect = list.getBoundingClientRect();
+        const itemRect = selfVoiceItem.getBoundingClientRect();
+        const bubbleRect = voiceBubble.getBoundingClientRect();
+        const playerRect = voicePlayer.getBoundingClientRect();
+
+        const computedStyle = window.getComputedStyle(list);
+        const paddingLeft = Number.parseFloat(computedStyle.paddingLeft || '0');
+        const paddingRight = Number.parseFloat(computedStyle.paddingRight || '0');
+        const contentWidth = listRect.width - paddingLeft - paddingRight;
+        const contentRight = listRect.right - paddingRight;
+
+        return {
+          contentWidth,
+          contentRight,
+          itemWidth: itemRect.width,
+          itemRight: itemRect.right,
+          playerRight: playerRect.right,
+        };
+      });
+
+      expect(layoutMetrics).not.toBeNull();
+      if (!layoutMetrics) {
+        throw new Error('Failed to resolve chat layout metrics');
+      }
+
+      expect(layoutMetrics.itemWidth).toBeLessThan(layoutMetrics.contentWidth - 16);
+      expect(Math.abs(layoutMetrics.contentRight - layoutMetrics.itemRight)).toBeLessThanOrEqual(2);
+      expect(layoutMetrics.playerRight).toBeGreaterThanOrEqual(layoutMetrics.contentRight - 20);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
 });
 
 


### PR DESCRIPTION
## Summary\n- fix outgoing voice message alignment in chat panel so self messages are right-anchored\n- prevent self voice rows from stretching full width\n- add e2e regression test to guard outgoing voice alignment\n\n## Validation\n- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --grep "10\.(3|6):" --reporter=line\n\n## Notes\n- existing unrelated lint issue remains in poker-client/src/components/IosInstallPrompt.tsx (pre-existing)