### PR TITLE
feat: show per-hand net chip change in results

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -14,6 +14,12 @@
 - [ ] Both browser sessions connected
 - [ ] Chip conservation formula: `Σ(player.chips + player.currentBet) = 2000` or `Σ(player.chips) + pot = 2000` (depends on round state representation)
 
+## Net Change Regression Addendum (2026-02-12)
+
+- [x] **3.4 Partial All-In (Side Pot):** Validate `netByPlayerId` and UI net chips (`Alice +2000`, `Bob -500`, `Charlie -1500`).
+- [x] **7.3 Tie (Split Pot):** Validate showdown split keeps both players at net `0` and UI shows `Your hand: +$0`.
+- [x] **8.16 Non-Showdown Fold:** Validate fold winner/loser net is `±small blind` and UI mirrors it.
+
 ---
 
 ## Test Suite 1: Basic Betting Actions

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -1339,20 +1339,40 @@ export const GameRoom: React.FC = () => {
       ),
     [lastHandResult],
   );
+  const netByPlayerId = useMemo(() => lastHandResult?.netByPlayerId ?? {}, [lastHandResult]);
+  const hasNetByPlayerId = useMemo(
+    () => Object.keys(netByPlayerId).length > 0,
+    [netByPlayerId],
+  );
   const revealedHandPlayerIdSet = useMemo(
     () => new Set(revealedHandPlayerIds),
     [revealedHandPlayerIds],
   );
+  const myHandNetChange = useMemo(() => {
+    if (!player?.id || !lastHandResult || !hasNetByPlayerId) return null;
+    if (!Object.prototype.hasOwnProperty.call(netByPlayerId, player.id)) {
+      return null;
+    }
+    const netFromResult = netByPlayerId[player.id];
+    if (typeof netFromResult === "number") {
+      return netFromResult;
+    }
+    return null;
+  }, [hasNetByPlayerId, lastHandResult, netByPlayerId, player?.id]);
 
   const handResultRows = useMemo(() => {
     if (!lastHandResult) return [];
     return lastHandResult.playerHands.map((entry, idx) => ({
       ...entry,
       amountWon: winnersByPlayerId.get(entry.playerId)?.amountWon ?? 0,
+      netChange:
+        hasNetByPlayerId && Object.prototype.hasOwnProperty.call(netByPlayerId, entry.playerId)
+          ? netByPlayerId[entry.playerId]
+          : null,
       isWinner: winnersByPlayerId.has(entry.playerId),
       rankOrder: idx + 1,
     }));
-  }, [lastHandResult, winnersByPlayerId]);
+  }, [hasNetByPlayerId, lastHandResult, netByPlayerId, winnersByPlayerId]);
 
   const payoutBreakdownRows = useMemo(() => {
     if (!lastHandResult) return [];
@@ -2685,6 +2705,8 @@ export const GameRoom: React.FC = () => {
             currentHandNumber={currentHandNumber}
             totalPot={lastHandResult.totalPot}
             winnerCount={lastHandResult.winners.length}
+            myNetChange={myHandNetChange}
+            showNetChange={hasNetByPlayerId}
             currentPlayerId={player.id}
             communityCards={Array.from(
               { length: 5 },

--- a/poker-client/src/components/poker/hand-results-content.stories.tsx
+++ b/poker-client/src/components/poker/hand-results-content.stories.tsx
@@ -49,6 +49,8 @@ const meta = {
     currentHandNumber: 22,
     totalPot: 480,
     winnerCount: 1,
+    myNetChange: 240,
+    showNetChange: true,
     currentPlayerId: "p1",
     communityCards,
     payoutBreakdownRows: [
@@ -73,6 +75,7 @@ const meta = {
         rankOrder: 1,
         isWinner: true,
         amountWon: 360,
+        netChange: 240,
         cards: [
           { rank: "K", suit: "spades" },
           { rank: "9", suit: "spades" },
@@ -85,6 +88,7 @@ const meta = {
         rankOrder: 2,
         isWinner: false,
         amountWon: 0,
+        netChange: -120,
         cards: [
           { rank: "A", suit: "diamonds" },
           { rank: "A", suit: "clubs" },

--- a/poker-client/src/components/poker/hand-results-content.tsx
+++ b/poker-client/src/components/poker/hand-results-content.tsx
@@ -23,6 +23,7 @@ type HandResultRow = {
   rankOrder: number;
   isWinner: boolean;
   amountWon: number;
+  netChange: number | null;
   cards: PokerCard[];
   hand: HandEvaluation | null;
 };
@@ -31,6 +32,8 @@ type HandResultsContentProps = {
   currentHandNumber: number | null;
   totalPot: number;
   winnerCount: number;
+  myNetChange: number | null;
+  showNetChange: boolean;
   currentPlayerId: string;
   communityCards: Array<PokerCard | null>;
   payoutBreakdownRows: PayoutBreakdownRow[];
@@ -44,7 +47,9 @@ type HandResultsContentProps = {
 export const HandResultsContent: React.FC<HandResultsContentProps> = ({
   currentHandNumber,
   totalPot,
-  winnerCount,
+  winnerCount: _winnerCount,
+  myNetChange,
+  showNetChange,
   currentPlayerId,
   communityCards,
   payoutBreakdownRows,
@@ -54,6 +59,8 @@ export const HandResultsContent: React.FC<HandResultsContentProps> = ({
   describeEvaluatedHand,
   t,
 }) => {
+  const formatNet = (amount: number) => `${amount >= 0 ? "+" : "-"}$${Math.abs(amount)}`;
+
   return (
     <>
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -69,9 +76,23 @@ export const HandResultsContent: React.FC<HandResultsContentProps> = ({
           <span className="hud-chip" data-testid="hand-results-pot">
             {t("game.pot", { amount: totalPot })}
           </span>
-          <span className="hud-chip" data-testid="hand-results-winner-count">
-            {t("game.winnersCount", { count: winnerCount })}
+          <span className="sr-only" data-testid="hand-results-winner-count">
+            {t("game.winnersCount", { count: _winnerCount })}
           </span>
+          {myNetChange !== null && (
+            <span
+              className={`hud-chip ${
+                myNetChange > 0
+                  ? "border-emerald-300/70 text-emerald-100"
+                  : myNetChange < 0
+                    ? "border-rose-300/70 text-rose-100"
+                    : ""
+              }`}
+              data-testid="hand-results-your-net"
+            >
+              {t("game.yourHandNet", { amount: formatNet(myNetChange) })}
+            </span>
+          )}
           <button
             onClick={onSaveResultScreenshot}
             data-testid="save-result-screenshot-button"
@@ -172,9 +193,11 @@ export const HandResultsContent: React.FC<HandResultsContentProps> = ({
                       {isSelf ? ` (${t("common.you")})` : ""}
                     </p>
                     <p className="text-xs text-emerald-100/70">
-                      {entry.isWinner
-                        ? t("game.wonAmount", { amount: entry.amountWon })
-                        : t("game.noPayout")}
+                      {showNetChange && typeof entry.netChange === "number"
+                        ? t("game.netChange", { amount: formatNet(entry.netChange) })
+                        : entry.isWinner
+                          ? t("game.wonAmount", { amount: entry.amountWon })
+                          : t("game.noPayout")}
                     </p>
                   </div>
                   {entry.isWinner && (

--- a/poker-client/src/i18n/messages.ts
+++ b/poker-client/src/i18n/messages.ts
@@ -147,6 +147,8 @@ export const EN_MESSAGES = {
   "game.noPayout": "No payout",
   "game.winner": "Winner",
   "game.cardsShownNoEvaluated": "Cards shown (no evaluated hand).",
+  "game.yourHandNet": "Your hand: {amount}",
+  "game.netChange": "Net: {amount}",
 
   "game.handComplete": "Hand complete",
   "game.handCompleteHint": "Host can start the next hand when everyone is ready.",
@@ -412,6 +414,8 @@ export const ZH_HANS_MESSAGES: Record<MessageKey, string> = {
   "game.noPayout": "未获分配",
   "game.winner": "赢家",
   "game.cardsShownNoEvaluated": "已亮牌（无牌型评估）。",
+  "game.yourHandNet": "你本手：{amount}",
+  "game.netChange": "净变化：{amount}",
 
   "game.handComplete": "本局结束",
   "game.handCompleteHint": "所有人准备好后，房主可以开始下一局。",

--- a/poker-server/src/game/hand.service.ts
+++ b/poker-server/src/game/hand.service.ts
@@ -306,6 +306,7 @@ export class HandService {
     if (activePlayers.length === 0) {
       throw new Error('No active players');
     }
+    const contributions = this.getHandContributions(room);
 
     // If only one player left, they win
     if (activePlayers.length === 1) {
@@ -356,6 +357,7 @@ export class HandService {
             uncontested: activePlayers.length === 1,
           },
         ],
+        netByPlayerId: this.buildNetByPlayerId(contributions, new Map([[winner.id, hand.pot]])),
       };
 
       await this.cleanupHand(room, winner.id);
@@ -372,7 +374,7 @@ export class HandService {
       evaluations.map((entry) => [entry.player.id, entry]),
     );
     const sidePotSegments = this.buildPotSegments(
-      this.getHandContributions(room),
+      contributions,
       hand.activePlayers,
     );
 
@@ -517,6 +519,7 @@ export class HandService {
         })),
       totalPot: hand.pot,
       payouts,
+      netByPlayerId: this.buildNetByPlayerId(contributions, payoutByPlayerId),
     };
 
     await this.cleanupHand(room, winners[0]?.playerId);
@@ -531,12 +534,24 @@ export class HandService {
 
     // Fallback for legacy hand states that don't have tracked contributions.
     const fallback: Record<string, number> = {};
-    const activePlayerIds = [...hand.activePlayers];
-    if (activePlayerIds.length === 0 || hand.pot <= 0) {
+    const dealtPlayerIds = room.players
+      .filter(
+        (player) =>
+          Boolean(player.cards) &&
+          player.status !== 'left' &&
+          player.status !== 'waiting',
+      )
+      .map((player) => player.id);
+    const fallbackPlayerIds =
+      dealtPlayerIds.length > 0
+        ? [...new Set(dealtPlayerIds)]
+        : [...new Set(hand.activePlayers)];
+
+    if (fallbackPlayerIds.length === 0 || hand.pot <= 0) {
       return fallback;
     }
 
-    const sortedActive = activePlayerIds.sort((a, b) => {
+    const sortedActive = fallbackPlayerIds.sort((a, b) => {
       const aPos = room.players.find((p) => p.id === a)?.position ?? 0;
       const bPos = room.players.find((p) => p.id === b)?.position ?? 0;
       return aPos - bPos;
@@ -601,6 +616,24 @@ export class HandService {
     }
 
     return segments;
+  }
+
+  private buildNetByPlayerId(
+    contributions: Record<string, number>,
+    payouts: Map<string, number>,
+  ): Record<string, number> {
+    const netByPlayerId: Record<string, number> = {};
+    const playerIds = new Set<string>([
+      ...Object.keys(contributions),
+      ...Array.from(payouts.keys()),
+    ]);
+
+    for (const playerId of playerIds) {
+      netByPlayerId[playerId] =
+        (payouts.get(playerId) || 0) - (contributions[playerId] || 0);
+    }
+
+    return netByPlayerId;
   }
 
   /**

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -2041,12 +2041,32 @@ test.describe('Poker E2E - Test Suite 3: All-In Scenarios', () => {
       expect(winnerAmounts.get('Alice')).toBe(3000);
       expect(winnerAmounts.get('Bob')).toBe(1000);
       expect(winnerAmounts.get('Charlie') || 0).toBe(0);
+      expect(result.netByPlayerId).toBeDefined();
+
+      const netByPlayerName = new Map(
+        result.playerHands.map((entry: any) => [
+          entry.playerName,
+          result.netByPlayerId?.[entry.playerId] ?? null,
+        ]),
+      );
+      expect(netByPlayerName.get('Alice')).toBe(2000);
+      expect(netByPlayerName.get('Bob')).toBe(-500);
+      expect(netByPlayerName.get('Charlie')).toBe(-1500);
 
       const totalAwarded = result.winners.reduce(
         (sum: number, winner: any) => sum + winner.amountWon,
         0,
       );
       expect(totalAwarded).toBe(4000);
+      await expect(alicePage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        'Your hand: +$2000',
+      );
+      await expect(bobPage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        'Your hand: -$500',
+      );
+      await expect(charliePage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        'Your hand: -$1500',
+      );
       await expect(alicePage.locator('[data-testid="hand-results-payouts"]')).toBeVisible();
       await expect(alicePage.locator('[data-testid="payout-segment-0"]')).toContainText(
         'Main Pot',
@@ -3809,6 +3829,19 @@ test.describe('Poker E2E - Test Suite 7: Winner Determination', () => {
         DEFAULT_TWO_PLAYER_MATCHED_POT / 2,
       ]);
       expect(result.totalPot).toBe(DEFAULT_TWO_PLAYER_MATCHED_POT);
+      expect(result.netByPlayerId).toBeDefined();
+      const netChanges = Object.values(result.netByPlayerId ?? {});
+      expect(netChanges).toHaveLength(2);
+      expect(netChanges.every((value) => value === 0)).toBe(true);
+
+      await expect(alicePage.locator('[data-testid="hand-results-panel"]')).toBeVisible();
+      await expect(bobPage.locator('[data-testid="hand-results-panel"]')).toBeVisible();
+      await expect(alicePage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        'Your hand: +$0',
+      );
+      await expect(bobPage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        'Your hand: +$0',
+      );
     } finally {
       await teardownTwoPlayerSession(session);
     }
@@ -5139,6 +5172,13 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       await expect(alicePage.locator('[data-testid="hand-results-panel"]')).toBeVisible();
       await expect(alicePage.locator('[data-testid="hand-results-mode"]')).toContainText(
         'Hand results are visible to all players.',
+      );
+      const expectedWinnerNet = DEFAULT_SMALL_BLIND;
+      await expect(alicePage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        `Your hand: +$${expectedWinnerNet}`,
+      );
+      await expect(bobPage.locator('[data-testid="hand-results-your-net"]')).toContainText(
+        `Your hand: -$${expectedWinnerNet}`,
       );
       await expect(alicePage.locator('[data-testid^="hand-result-hidden-card-"]')).toHaveCount(
         2,

--- a/poker-server/test/unit/hand-service-conservation.spec.ts
+++ b/poker-server/test/unit/hand-service-conservation.spec.ts
@@ -54,6 +54,7 @@ describe('HandService chip conservation reconciliation', () => {
     loserChips: number;
     winnerTotalBuyIn?: number;
     loserTotalBuyIn?: number;
+    potContributions?: Record<string, number>;
   }): Room {
     const winner = buildPlayer({
       id: 'p1',
@@ -99,10 +100,12 @@ describe('HandService chip conservation reconciliation', () => {
         activePlayers: [winner.id],
         roundActions: {},
         sidePots: [],
-        potContributions: {
-          [winner.id]: params.pot,
-          [loser.id]: 0,
-        },
+        potContributions:
+          params.potContributions ??
+          {
+            [winner.id]: params.pot,
+            [loser.id]: 0,
+          },
         startedAt: Date.now(),
       },
       createdAt: Date.now(),
@@ -151,6 +154,21 @@ describe('HandService chip conservation reconciliation', () => {
     expect(totalChips).toBe(expectedTotal);
     expect(winner?.chips).toBe(1000);
     expect(loser?.chips).toBe(1000);
+    expect(storageService.saveRoom).toHaveBeenCalled();
+  });
+
+  it('legacy fallback contributions include folded dealt players for net outcomes', async () => {
+    const room = buildSingleWinnerRoom({
+      pot: 15,
+      winnerChips: 900,
+      loserChips: 1000,
+      potContributions: {},
+    });
+
+    const result = await handService.determineWinner(room);
+
+    expect(result.netByPlayerId['p1']).toBe(7);
+    expect(result.netByPlayerId['p2']).toBe(-7);
     expect(storageService.saveRoom).toHaveBeenCalled();
   });
 });

--- a/poker-types/src/game.types.ts
+++ b/poker-types/src/game.types.ts
@@ -67,4 +67,5 @@ export interface HandResult {
   }>;
   totalPot: number;
   payouts: PotPayout[];
+  netByPlayerId: Record<string, number>; // Net chip change per player for this hand
 }


### PR DESCRIPTION
Supersedes #42 with a single squashed commit (same changes, cleaner history).

## Summary
- add `netByPlayerId` to hand result payload based on payout minus per-hand contribution
- keep rules-based winners for settlement while simplifying UI around net chip change
- show `Your hand: +/-$X` and per-player net changes in hand result rows
- add e2e regression coverage for fold, tie split, and 3-player side-pot net outcomes
- document the net-change regression checklist in `TEST_PLAN.md`
- include legacy fallback improvement so folded dealt players remain represented when `potContributions` is missing

## Validation
- `npm run build` (poker-types)
- `npm run build` (poker-client)
- `npm run test:unit` (poker-server)
- `npm run test:unit -- test/unit/hand-service-conservation.spec.ts`
- `npm run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --grep "7.3: Tie \(Split Pot\)" --reporter=line`
- `npm run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --grep "8.16: Non-Showdown Result Keeps Hole Cards Hidden" --reporter=line`
- `npm run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --grep "3.4: Partial All-In \(Side Pot\)" --reporter=line`
