### PR TITLE
fix(client): show check action in seat second row

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -1271,6 +1271,10 @@ const resolveSeatPrimaryActionLabel = ({
   latestSeatActionEvent: PlayerActionFlashEvent | null;
   t: Translate;
 }): SeatActionLabel | null => {
+  if (seatPlayer.status === "folded" || seatPlayer.status === "disconnected") {
+    return null;
+  }
+
   if (latestSeatActionEvent?.displayKind === "check") {
     return {
       text: t("common.check"),
@@ -1282,11 +1286,7 @@ const resolveSeatPrimaryActionLabel = ({
     return null;
   }
 
-  if (seatPlayer.status === "folded" || seatPlayer.status === "disconnected") {
-    return null;
-  }
-
-  if (seatPlayer.lastAction === "check" || seatPlayer.lastAction === "fold") {
+  if (seatPlayer.lastAction === "fold") {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- fix seat action label resolution for check actions
- ensure check appears in Seat View second row instead of blank

## Root Cause
- check actions have zero current bet and were filtered out by early currentBet <= 0 return

## Validation
- verified logic path in resolveSeatPrimaryActionLabel
- attempted local build but environment is missing tsc binary