### PR TITLE
feat(auth): remove redundant copy and expand emoji picker

### DIFF
--- a/poker-client/src/pages/Auth.tsx
+++ b/poker-client/src/pages/Auth.tsx
@@ -106,20 +106,12 @@ export const AuthPage: React.FC = () => {
           <div className="space-y-2 text-center">
             <p className="text-xs uppercase tracking-[0.2em] text-emerald-300/80">{t("auth.systemBadge")}</p>
             <h1 className="text-3xl font-black tracking-tight text-white">{t("auth.title")}</h1>
-            <p className="text-sm text-emerald-100/75">
-              {t("auth.subtitle")}
-            </p>
           </div>
 
           <div className="space-y-4 rounded-xl border border-emerald-700/60 bg-emerald-950/40 p-4">
             <h2 className="text-sm font-semibold text-emerald-100">
               {requiresRegistrationProfile ? t("auth.passkeyRegisterTitle") : t("auth.passkeyLoginTitle")}
             </h2>
-            <p className="text-xs text-emerald-100/70">
-              {requiresRegistrationProfile
-                ? t("auth.passkeySingleButtonHint")
-                : t("auth.passkeyLoginHint")}
-            </p>
 
             {requiresRegistrationProfile && (
               <>
@@ -130,12 +122,17 @@ export const AuthPage: React.FC = () => {
                   className="w-full rounded-xl border border-emerald-700/60 bg-emerald-950/60 px-4 py-3 text-white outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
                 />
 
-                <div className="grid grid-cols-10 gap-1">
-                  {PLAYER_EMOJI_OPTIONS.slice(0, 30).map((emoji) => (
+                <div
+                  data-testid="auth-emoji-grid"
+                  className="grid max-h-52 grid-cols-10 gap-1 overflow-y-auto rounded-xl border border-emerald-700/60 bg-emerald-950/40 p-2"
+                >
+                  {PLAYER_EMOJI_OPTIONS.map((emoji) => (
                     <button
                       key={emoji}
                       type="button"
                       onClick={() => setAvatarEmoji(emoji)}
+                      data-testid="auth-emoji-option"
+                      data-emoji={emoji}
                       className={`h-9 rounded-lg text-xl transition ${
                         avatarEmoji === emoji
                           ? "bg-emerald-400/25 ring-1 ring-emerald-300/80"

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -5019,6 +5019,59 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.4aa: Auth Removes Redundant Copy And Supports Full Emoji Selection', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      await page.goto(FRONTEND_URL);
+      await page.waitForSelector('[data-testid="auth-page"]');
+
+      const authPage = page.locator('[data-testid="auth-page"]');
+      await expect(authPage).not.toContainText(
+        'Passkey is recommended. Password login is enabled for test accounts (test1/test2/test3).',
+      );
+      await expect(authPage).not.toContainText(
+        'Register with Passkey first. If you already have one, use the login button below.',
+      );
+
+      await page.getByRole('button', {
+        name: /Register and sign in with Passkey|用 Passkey 注册并登录/,
+      }).click();
+      await expect(page.locator('[data-testid="auth-emoji-grid"]')).toBeVisible();
+
+      const emojiGrid = page.locator('[data-testid="auth-emoji-grid"]');
+      const extendedEmojiOption = page.locator(
+        '[data-testid="auth-emoji-option"][data-emoji="👾"]',
+      );
+      await extendedEmojiOption.scrollIntoViewIfNeeded();
+      await extendedEmojiOption.click();
+      await expect(extendedEmojiOption).toHaveClass(/ring-emerald-300\/80/);
+
+      const isScrollable = await emojiGrid.evaluate(
+        (element) => element.scrollHeight > element.clientHeight,
+      );
+      expect(isScrollable).toBe(true);
+
+      await page.evaluate(() => {
+        window.localStorage.setItem('poker.locale', 'zh_hans');
+      });
+      await page.goto(FRONTEND_URL);
+      await page.waitForSelector('[data-testid="auth-page"]');
+
+      await expect(authPage).not.toContainText(
+        '默认推荐使用 Passkey。测试环境支持账号密码（test1/test2/test3）。',
+      );
+      await expect(authPage).not.toContainText(
+        '新用户请先注册 Passkey；已有 Passkey 可点击下方登录按钮。',
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
   test('8.4ab: Host can create short-deck room from lobby and keep short-deck state in game', async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary
- remove redundant auth copy blocks in login card header and passkey section
- expand auth passkey registration emoji picker from first 30 to full option set
- make auth emoji picker fixed-height and scrollable
- add e2e test coverage for copy removal and full emoji selection behavior

## Validation
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --grep "8.4aa: Auth Removes Redundant Copy And Supports Full Emoji Selection" --reporter=line` (run in `poker-server`)
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm run test:e2e:playwright:smoke` (run in `poker-server`)
- `npm run build` (run in `poker-client`)

## Notes
- i18n keys remain in `poker-client/src/i18n/messages.ts`; rendering is removed only to keep `MessageKey` compatibility.