### PR TITLE
fix: make quick-action safety lock StrictMode-safe

### DIFF
--- a/poker-client/src/components/poker/turn-action-dock.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.tsx
@@ -17,6 +17,7 @@ type TrayPresetButton = {
 
 type QuickDecisionAction = "check" | "fold";
 type LegacyAction = "check" | "call" | "all-in" | "raise";
+const QUICK_DECISION_SAFETY_LOCK_MS = 2000;
 
 type TurnActionDockProps = {
   callAmount: number;
@@ -75,9 +76,13 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
   onLegacyRaiseAmountChange,
   t,
 }) => {
+  const isQuickDecisionAvailable = !isAutomationMode && isYourTurn;
   const checkActionButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const foldActionButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const quickConfirmPopoverRef = React.useRef<HTMLDivElement | null>(null);
+  const quickDecisionLockTimeoutRef = React.useRef<number | null>(null);
+  const [isQuickDecisionTemporarilyLocked, setIsQuickDecisionTemporarilyLocked] =
+    React.useState(isQuickDecisionAvailable);
   const quickConfirmAnchorRef =
     quickConfirmAction === "check" ? checkActionButtonRef : foldActionButtonRef;
   const quickConfirmStyle = useAnchoredPopover({
@@ -87,6 +92,32 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
     preferredPlacement: "top",
     align: "start",
   });
+  const isQuickDecisionLocked = isQuickDecisionAvailable && isQuickDecisionTemporarilyLocked;
+
+  React.useLayoutEffect(() => {
+    if (quickDecisionLockTimeoutRef.current !== null) {
+      window.clearTimeout(quickDecisionLockTimeoutRef.current);
+      quickDecisionLockTimeoutRef.current = null;
+    }
+
+    if (!isQuickDecisionAvailable) {
+      setIsQuickDecisionTemporarilyLocked(false);
+      return;
+    }
+
+    setIsQuickDecisionTemporarilyLocked(true);
+    quickDecisionLockTimeoutRef.current = window.setTimeout(() => {
+      setIsQuickDecisionTemporarilyLocked(false);
+      quickDecisionLockTimeoutRef.current = null;
+    }, QUICK_DECISION_SAFETY_LOCK_MS);
+
+    return () => {
+      if (quickDecisionLockTimeoutRef.current !== null) {
+        window.clearTimeout(quickDecisionLockTimeoutRef.current);
+        quickDecisionLockTimeoutRef.current = null;
+      }
+    };
+  }, [isQuickDecisionAvailable]);
 
   return (
     <div data-testid="action-dock" className="chip-composer-dock__action-area">
@@ -201,7 +232,7 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
               <button
                 ref={checkActionButtonRef}
                 onClick={() => onQuickDecisionAction("check")}
-                disabled={!canCheck}
+                disabled={!canCheck || isQuickDecisionLocked}
                 data-testid={canCheck ? "action-check" : "action-check-disabled"}
                 className="chip-action chip-action--check"
               >
@@ -210,6 +241,7 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
               <button
                 ref={foldActionButtonRef}
                 onClick={() => onQuickDecisionAction("fold")}
+                disabled={isQuickDecisionLocked}
                 data-testid="action-fold"
                 className="chip-action chip-action--fold"
               >

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -7204,10 +7204,11 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         '[data-testid="chip-load-all-in"]',
       );
       await expect(bobFoldButton).toBeVisible();
-      expect(await bobFoldButton.isEnabled()).toBe(true);
+      await expect(bobFoldButton).toBeDisabled();
       await expect(bobContinuePreset).toBeEnabled();
       await expect(bobRaisePreset).toBeEnabled();
       await expect(bobAllInPreset).toBeEnabled();
+      await expect(bobFoldButton).toBeEnabled({ timeout: 3000 });
       await bobFoldButton.click();
 
       await expect(
@@ -7230,8 +7231,10 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       );
       const aliceFoldButton = alicePage.locator('[data-testid="action-fold"]');
       await expect(aliceCheckButton).toBeVisible();
-      expect(await aliceCheckButton.isEnabled()).toBe(true);
-      expect(await aliceFoldButton.isEnabled()).toBe(true);
+      await expect(aliceCheckButton).toBeDisabled();
+      await expect(aliceFoldButton).toBeDisabled();
+      await expect(aliceCheckButton).toBeEnabled({ timeout: 3000 });
+      await expect(aliceFoldButton).toBeEnabled();
 
       await aliceCheckButton.click();
       await expect(


### PR DESCRIPTION
## Summary

- Preserve the PR #63 2-second human-mode quick-action safety lock for `Check` and `Fold`
- Make the quick-action unlock timer StrictMode-safe so dev human mode no longer stays locked indefinitely
- Restore regression coverage to assert disabled-first then enabled-after-timeout behavior while keeping preset actions usable

## Linked Issue

Closes #80

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/80#issuecomment-4190189419

## Validation

- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 npm run test:e2e:playwright -- --project comprehensive-e2e --workers=1 --grep "8\\.13b:|8\\.8:|4\\.3:|8\\.9:" --reporter=line`
- PM2 dev server runtime verification confirmed the human-mode quick-action lock now unlocks after 3.5 seconds on this branch.
