### PR TITLE
feat: reshape desktop table into a fixed two-column layout with click-first betting

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -31,6 +31,7 @@ import {
   HandResultsModal,
   LeaveRoomConfirmModal,
   LiveAudioModal,
+  LiveAudioPanel,
   NextHandActionArea,
   OperationActionBar,
   ReadyActionArea,
@@ -48,6 +49,7 @@ import type { SeatBadge, SeatLiveAudioBadge } from "@/components/poker/seat-pod"
 import { buildEqualArcEllipsePoints } from "@/components/poker/seat-orbit-layout";
 
 const DRAG_SNAP_RADIUS_PX = 32;
+const DRAG_DROP_ZONE_RECT_MARGIN_PX = 18;
 const ACTION_ALERT_VISIBLE_MS = 1300;
 const ACTION_ALERT_TOTAL_MS = 1600;
 const TURN_ALERT_VISIBLE_MS = 1650;
@@ -2180,6 +2182,8 @@ const useGameRoomElement = () => {
   const shouldShowChatPanel = isDesktopSideDock || isChatPanelOpen;
   const shouldAnchorCardsFlyoutToBottomBar =
     showOperationBar || showReadyActionArea || (showTurnActionDock && !isDesktopSideDock);
+  const shouldRenderCardsBesideDesktopDock =
+    shouldRenderCardsFlyout && isDesktopSideDock && showTurnActionDock;
   const cardsFlyoutPlacement = isDesktopSideDock
     ? "felt-right"
     : shouldAnchorCardsFlyoutToBottomBar
@@ -3293,13 +3297,26 @@ const useGameRoomElement = () => {
     if (!dropZone) return false;
 
     const rect = dropZone.getBoundingClientRect();
+    const hoveredNode = document.elementFromPoint(clientX, clientY);
+    const isHoveringDropZone =
+      hoveredNode instanceof Element &&
+      Boolean(hoveredNode.closest('[data-testid="pot-drop-zone"]'));
     const centerX = rect.left + rect.width / 2;
     const centerY = rect.top + rect.height / 2;
     const radius = Math.max(rect.width, rect.height) / 2 + DRAG_SNAP_RADIUS_PX;
     const deltaX = clientX - centerX;
     const deltaY = clientY - centerY;
+    const isWithinExpandedRect =
+      clientX >= rect.left - DRAG_DROP_ZONE_RECT_MARGIN_PX &&
+      clientX <= rect.right + DRAG_DROP_ZONE_RECT_MARGIN_PX &&
+      clientY >= rect.top - DRAG_DROP_ZONE_RECT_MARGIN_PX &&
+      clientY <= rect.bottom + DRAG_DROP_ZONE_RECT_MARGIN_PX;
 
-    return deltaX * deltaX + deltaY * deltaY <= radius * radius;
+    return (
+      isHoveringDropZone ||
+      isWithinExpandedRect ||
+      deltaX * deltaX + deltaY * deltaY <= radius * radius
+    );
   }, []);
 
   const commitTrayDrop = useCallback(() => {
@@ -3912,7 +3929,7 @@ const useGameRoomElement = () => {
           )}
 
           <div className="table-shell__board-stage">
-            {shouldRenderCardsFlyout && (
+            {shouldRenderCardsFlyout && !shouldRenderCardsBesideDesktopDock && (
               <YourCardsFlyout
                 isOpen={isCardsFlyoutOpen}
                 hasHoleCards={hasHoleCards}
@@ -4103,109 +4120,107 @@ const useGameRoomElement = () => {
           )}
 
           {showTurnActionDock && (
-            <ChipComposerDock ref={bottomBarOverlayRef} className={desktopMainDockClassName}>
-              <TurnActionDock
-                callAmount={callAmount}
-                minRaise={minRaise}
-                maxStack={maxStack}
-                trayAmount={trayAmount}
-                trayInputValue={trayInputValue}
-                isDesktopClickBetting={isDesktopSideDock}
-                canStartDrag={canStartDrag}
-                isDragActive={dragState.active}
-                isYourTurn={isYourTurn}
-                canCheck={canCheck}
-                isAutomationMode={isAutomationMode}
-                legacyRaiseAmount={legacyRaiseAmount}
-                trayPresetButtons={trayPresetButtons}
-                onDragStart={handleDragStart}
-                onDragMove={handleDragMove}
-                onDragEnd={handleDragEnd}
-                onSetTrayDirectly={setTrayDirectly}
-                onTrayInputChange={handleCustomTrayInputChange}
-                onTrayInputBlur={handleCustomTrayInputBlur}
-                onClearTray={clearTray}
-                onSubmitTray={requestTraySubmit}
-                onQuickDecisionAction={handleQuickDecisionAction}
-                quickConfirmAction={!isAutomationMode ? quickConfirmAction : null}
-                onQuickConfirmDismiss={() => setQuickConfirmAction(null)}
-                onQuickConfirmAccept={(action) => {
-                  setQuickConfirmAction(null);
-                  performAction(action);
-                }}
-                traySubmitLabel={desktopTraySubmitIntent?.label ?? null}
-                showTrayConfirm={showTrayConfirm}
-                onTrayConfirmDismiss={() => setShowTrayConfirm(false)}
-                onTrayConfirmAccept={acceptTraySubmit}
-                onLegacyAction={handleLegacyAction}
-                onLegacyRaiseAmountChange={setLegacyRaiseAmount}
-                t={t}
-              />
-            </ChipComposerDock>
+            <div className={isDesktopSideDock ? "desktop-dock-cluster" : undefined}>
+              {shouldRenderCardsBesideDesktopDock && (
+                <YourCardsFlyout
+                  isOpen={isCardsFlyoutOpen}
+                  hasHoleCards={hasHoleCards}
+                  cards={displayHoleCards ?? []}
+                  shouldAnchorToBottomBar={false}
+                  bottomBarHeight={bottomBarHeight}
+                  placement="dock-left"
+                  title={t("game.yourCards")}
+                  emptyOpenStateLabel={t("game.cardsAppearWhenHandStarts")}
+                  emptyClosedStateLabel={`${t("game.hide")} ${t("game.yourCards")}`}
+                  hideLabel={t("game.hide")}
+                  showLabel={t("game.show")}
+                  onToggle={() => setIsCardsFlyoutOpen((prev) => !prev)}
+                />
+              )}
+              <ChipComposerDock ref={bottomBarOverlayRef} className={desktopMainDockClassName}>
+                <TurnActionDock
+                  callAmount={callAmount}
+                  minRaise={minRaise}
+                  maxStack={maxStack}
+                  trayAmount={trayAmount}
+                  trayInputValue={trayInputValue}
+                  isDesktopClickBetting={isDesktopSideDock}
+                  canStartDrag={canStartDrag}
+                  isDragActive={dragState.active}
+                  isYourTurn={isYourTurn}
+                  canCheck={canCheck}
+                  isAutomationMode={isAutomationMode}
+                  legacyRaiseAmount={legacyRaiseAmount}
+                  trayPresetButtons={trayPresetButtons}
+                  onDragStart={handleDragStart}
+                  onDragMove={handleDragMove}
+                  onDragEnd={handleDragEnd}
+                  onSetTrayDirectly={setTrayDirectly}
+                  onTrayInputChange={handleCustomTrayInputChange}
+                  onTrayInputBlur={handleCustomTrayInputBlur}
+                  onClearTray={clearTray}
+                  onSubmitTray={requestTraySubmit}
+                  onQuickDecisionAction={handleQuickDecisionAction}
+                  quickConfirmAction={!isAutomationMode ? quickConfirmAction : null}
+                  onQuickConfirmDismiss={() => setQuickConfirmAction(null)}
+                  onQuickConfirmAccept={(action) => {
+                    setQuickConfirmAction(null);
+                    performAction(action);
+                  }}
+                  traySubmitLabel={desktopTraySubmitIntent?.label ?? null}
+                  showTrayConfirm={showTrayConfirm}
+                  onTrayConfirmDismiss={() => setShowTrayConfirm(false)}
+                  onTrayConfirmAccept={acceptTraySubmit}
+                  onLegacyAction={handleLegacyAction}
+                  onLegacyRaiseAmountChange={setLegacyRaiseAmount}
+                  t={t}
+                />
+              </ChipComposerDock>
+            </div>
           )}
         </div>
 
         {shouldShowDesktopRail && (
           <aside className="desktop-right-rail" data-testid="desktop-right-rail">
+            <div className="desktop-rail-live-audio" data-testid="desktop-rail-live-audio">
+              <LiveAudioPanel
+                title={t("game.audio.title")}
+                subtitle={t("game.audio.subtitle")}
+                joinLabel={t("game.audio.join")}
+                leaveLabel={t("game.audio.leave")}
+                muteLabel={t("game.audio.mute")}
+                unmuteLabel={t("game.audio.unmute")}
+                enableAudioLabel={t("game.audio.enableAudio")}
+                connectingLabel={t("game.audio.connecting")}
+                connectedLabel={t("game.audio.connected")}
+                reconnectingLabel={t("game.audio.reconnecting")}
+                mutedLabel={t("game.audio.muted")}
+                unavailableLabel={t("game.audio.unavailable")}
+                rosterLabel={t("game.audio.roster")}
+                localParticipantLabel={t("game.audio.you")}
+                error={
+                  liveAudioError?.startsWith("game.audio.error.")
+                    ? t(liveAudioError as MessageKey)
+                    : liveAudioError
+                }
+                available={isLiveAudioAvailable}
+                isConfigLoaded={isLiveAudioConfigLoaded}
+                isConnecting={isLiveAudioConnecting}
+                isJoined={isLiveAudioJoined}
+                isMuted={isLiveAudioMuted}
+                isAudioPlaybackBlocked={isLiveAudioPlaybackBlocked}
+                isReconnecting={isLiveAudioReconnecting}
+                participants={liveAudioParticipants}
+                onJoin={joinAudio}
+                onLeave={leaveAudio}
+                onMute={muteAudio}
+                onUnmute={unmuteAudio}
+                onEnableAudio={enableAudio}
+              />
+            </div>
             <div className="chat-panel-shell chat-panel-shell--desktop-rail">
               <ChatPanel onClose={() => undefined} showCloseButton={false} />
             </div>
-            <section className="surface-panel desktop-side-panel" data-testid="desktop-side-status">
-              <div className="desktop-side-panel__header">
-                <h3>{t("game.confirmActions")}</h3>
-                <span className="desktop-side-panel__meta">
-                  {t("game.playersCount", {
-                    count: tablePlayers.length,
-                    max: room.config.maxPlayers,
-                  })}
-                </span>
-              </div>
-              <div className="desktop-side-panel__stats">
-                <div>
-                  <span className="desktop-side-panel__label">{t("game.ruleVariant.standard")}</span>
-                  <strong>{ruleVariantLabel}</strong>
-                </div>
-                <div>
-                  <span className="desktop-side-panel__label">{t("game.potCenter")}</span>
-                  <strong>{`$${animatedPotValue}`}</strong>
-                </div>
-                {hiddenHudCopy.roundLabel && (
-                  <div>
-                    <span className="desktop-side-panel__label">{t("game.confirmAction.roundLabel")}</span>
-                    <strong>{hiddenHudCopy.roundLabel}</strong>
-                  </div>
-                )}
-                {hiddenHudCopy.turnLabel && (
-                  <div>
-                    <span className="desktop-side-panel__label">{t("game.confirmAction.turnLabel")}</span>
-                    <strong>{hiddenHudCopy.turnLabel}</strong>
-                  </div>
-                )}
-              </div>
-              <div className="desktop-side-panel__actions">
-                <button
-                  type="button"
-                  onClick={() => setShowRulesModal(true)}
-                  className="desktop-side-panel__button"
-                >
-                  {rulesCopy.buttonLabel}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowRankingsModal(true)}
-                  className="desktop-side-panel__button"
-                >
-                  {t("game.rankings")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowLiveAudioModal(true)}
-                  className="desktop-side-panel__button"
-                >
-                  {t("game.audio.title")}
-                </button>
-              </div>
-            </section>
           </aside>
         )}
       </div>

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -1766,6 +1766,7 @@ const useGameRoomElement = () => {
     playerCount: number;
   } | null>(null);
   const [quickConfirmAction, setQuickConfirmAction] = useState<QuickConfirmAction | null>(null);
+  const [showTrayConfirm, setShowTrayConfirm] = useState(false);
   const [legacyRaiseAmount, setLegacyRaiseAmount] = useState(0);
   const [dragState, setDragState] = useState<DragState>(EMPTY_DRAG_STATE);
   const [actionCenterAlert, setActionCenterAlert] = useState<ActionCenterAlert | null>(null);
@@ -1789,6 +1790,7 @@ const useGameRoomElement = () => {
   const lastDisplayedHandResultRef = useRef<HandResult | null>(null);
   const bottomBarOverlayRef = useRef<HTMLElement | null>(null);
   const actionCenterAlertRef = useRef<HTMLDivElement | null>(null);
+  const chatForcedByDesktopRef = useRef(false);
   const feltOvalRef = useRef<HTMLDivElement | null>(null);
   const boardCenterStackRef = useRef<HTMLDivElement | null>(null);
   const communityLaneRef = useRef<HTMLDivElement | null>(null);
@@ -2174,8 +2176,15 @@ const useGameRoomElement = () => {
       ? "streetReveal"
       : null;
   const showTurnActionDock = isYourTurn && !showOperationBar && !showReadyActionArea;
+  const shouldShowDesktopRail = isDesktopSideDock;
+  const shouldShowChatPanel = isDesktopSideDock || isChatPanelOpen;
   const shouldAnchorCardsFlyoutToBottomBar =
     showOperationBar || showReadyActionArea || (showTurnActionDock && !isDesktopSideDock);
+  const cardsFlyoutPlacement = isDesktopSideDock
+    ? "felt-right"
+    : shouldAnchorCardsFlyoutToBottomBar
+      ? "bottom"
+      : "left-edge";
   const activeBottomBarMode = showOperationBar
     ? "operation"
     : showReadyActionArea
@@ -2836,6 +2845,13 @@ const useGameRoomElement = () => {
 
   const isAutomationMode =
     typeof window !== "undefined" && Boolean(window.navigator.webdriver);
+  const desktopTraySubmitIntent =
+    !isAutomationMode &&
+    isDesktopSideDock &&
+    dropResolution.intent &&
+    dropResolution.intent.action !== "call"
+      ? dropResolution.intent
+      : null;
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -2852,6 +2868,21 @@ const useGameRoomElement = () => {
 
     return () => window.removeEventListener("resize", updateDockMode);
   }, []);
+
+  useEffect(() => {
+    if (!isDesktopSideDock) {
+      if (chatForcedByDesktopRef.current && isChatPanelOpen) {
+        chatForcedByDesktopRef.current = false;
+        setChatPanelOpen(false);
+      }
+      return;
+    }
+
+    if (!isChatPanelOpen) {
+      chatForcedByDesktopRef.current = true;
+      setChatPanelOpen(true);
+    }
+  }, [isChatPanelOpen, isDesktopSideDock, setChatPanelOpen]);
 
   const clearActionAlertTimers = useCallback(() => {
     if (actionAlertHideTimeoutRef.current !== null) {
@@ -2973,6 +3004,7 @@ const useGameRoomElement = () => {
   const resetTurnInteractionState = useCallback(() => {
     setTrayAmount(0);
     setQuickConfirmAction(null);
+    setShowTrayConfirm(false);
     setDragState(EMPTY_DRAG_STATE);
   }, []);
 
@@ -3017,6 +3049,14 @@ const useGameRoomElement = () => {
   useEffect(() => {
     setTrayInputValue(String(trayAmount));
   }, [trayAmount]);
+
+  useEffect(() => {
+    if (!showTrayConfirm || desktopTraySubmitIntent) {
+      return;
+    }
+
+    setShowTrayConfirm(false);
+  }, [desktopTraySubmitIntent, showTrayConfirm]);
 
   useEffect(() => {
     animatedPotRef.current = animatedPotValue;
@@ -3189,11 +3229,13 @@ const useGameRoomElement = () => {
     if (showHandResultsModal) setShowHandResultsModal(false);
     if (showFinalSummaryModal && !isGameEnded) setShowFinalSummaryModal(false);
     if (quickConfirmAction) setQuickConfirmAction(null);
+    if (showTrayConfirm) setShowTrayConfirm(false);
   }, [
     clearError,
     isGameEnded,
     lastError,
     quickConfirmAction,
+    showTrayConfirm,
     setShowLeaveConfirmModal,
     setShowEndGameConfirmModal,
     showHandResultsModal,
@@ -3219,7 +3261,8 @@ const useGameRoomElement = () => {
       !showEndGameConfirmModal &&
       !showHandResultsModal &&
       !showFinalSummaryModal &&
-      !quickConfirmAction
+      !quickConfirmAction &&
+      !showTrayConfirm
     ) {
       return;
     }
@@ -3242,6 +3285,7 @@ const useGameRoomElement = () => {
     showRulesModal,
     showSettingsModal,
     showLiveAudioModal,
+    showTrayConfirm,
   ]);
 
   const isPointInDropZone = useCallback((clientX: number, clientY: number) => {
@@ -3268,9 +3312,29 @@ const useGameRoomElement = () => {
     }
 
     setQuickConfirmAction(null);
+    setShowTrayConfirm(false);
     performAction(dropResolution.intent.action, dropResolution.intent.amount);
     setTrayAmount(0);
   }, [dropResolution.intent, isYourTurn, performAction]);
+
+  const requestTraySubmit = useCallback(() => {
+    if (!desktopTraySubmitIntent) {
+      return;
+    }
+
+    setQuickConfirmAction(null);
+    setShowTrayConfirm(true);
+  }, [desktopTraySubmitIntent]);
+
+  const acceptTraySubmit = useCallback(() => {
+    if (!desktopTraySubmitIntent) {
+      return;
+    }
+
+    setShowTrayConfirm(false);
+    performAction(desktopTraySubmitIntent.action, desktopTraySubmitIntent.amount);
+    setTrayAmount(0);
+  }, [desktopTraySubmitIntent, performAction]);
 
   const setTrayDirectly = (nextAmount: number) => {
     if (!isYourTurn) return;
@@ -3637,6 +3701,7 @@ const useGameRoomElement = () => {
       }
 
       setQuickConfirmAction(null);
+      setShowTrayConfirm(false);
       performAction("raise", legacyRaiseAmount);
       return;
     }
@@ -3644,6 +3709,7 @@ const useGameRoomElement = () => {
     if (action !== "check" && action !== "fold") {
       setQuickConfirmAction(null);
     }
+    setShowTrayConfirm(false);
     performAction(action);
   };
 
@@ -3652,10 +3718,12 @@ const useGameRoomElement = () => {
     if (action === "check" && !canCheck) return;
 
     if (isAutomationMode) {
+      setShowTrayConfirm(false);
       performAction(action);
       return;
     }
 
+    setShowTrayConfirm(false);
     setQuickConfirmAction(action);
   };
 
@@ -3716,6 +3784,35 @@ const useGameRoomElement = () => {
     [locale, rulesVariant],
   );
 
+  const hiddenHudCopy = {
+    potLabel: t("game.pot", { amount: displayPot }),
+    chipsLabel: t("game.yourChips", { amount: currentPlayer?.chips ?? 0 }),
+    roundLabel: currentHand
+      ? t("game.round", { round: currentHand.bettingRound })
+      : null,
+    turnLabel: currentTurnPlayer
+      ? t("game.turn", { name: currentTurnPlayer.name })
+      : null,
+  };
+  const chatPreview =
+    !activePreviewMessage || isDesktopSideDock
+      ? null
+      : {
+          title: t("game.chat.preview.title"),
+          senderName: activePreviewMessage.sender.playerName,
+          senderEmoji: activePreviewMessage.sender.playerEmoji,
+          message: toChatPreviewText(activePreviewMessage, t),
+          timeIso: new Date(activePreviewMessage.createdAt).toISOString(),
+          timeLabel: formatRelativeTime(activePreviewMessage.createdAt, locale, relativeNow),
+          dismissLabel: t("game.chat.preview.dismiss"),
+        };
+  const desktopMainDockClassName = isDesktopSideDock
+    ? "chip-composer-dock--desktop-main"
+    : undefined;
+  const desktopOperationDockClassName = isDesktopSideDock
+    ? "chip-composer-dock--operation chip-composer-dock--desktop-main"
+    : "chip-composer-dock--operation";
+
   if (!room || !player) {
     return (
       <main className="min-h-screen px-4 py-10">
@@ -3737,148 +3834,387 @@ const useGameRoomElement = () => {
 
   return (
     <TableShell
+      isDesktopTwoColumn={isDesktopSideDock}
       showDesktopTurnDock={showTurnActionDock && isDesktopSideDock}
       showDesktopOperationDock={(showOperationBar || showReadyActionArea) && isDesktopSideDock}
       desktopBottomBarHeight={bottomBarHeight}
-      isChatPanelOpen={isChatPanelOpen}
+      isChatPanelOpen={shouldShowChatPanel}
     >
-      <TableTopBar
-        roomTitle={t("game.room", { roomId: room.id })}
-        playerCountLabel={t("game.playersCount", {
-          count: tablePlayers.length,
-          max: room.config.maxPlayers,
-        })}
-        ruleVariantLabel={ruleVariantLabel}
-        inviteCopyLabel={t("game.copyInvite")}
-        inviteCopyStatus={inviteCopyStatus}
-        inviteCopyStatusTone={inviteCopyStatusTone}
-        leaveLabel={t("common.leave")}
-        settingsLabel={t("common.settings")}
-        rulesLabel={rulesCopy.buttonLabel}
-        rankingsLabel={t("game.rankings")}
-        chatLabel={
-          chatUnreadCount > 0
-            ? t("game.chat.buttonWithUnread", { count: chatUnreadCount })
-            : t("game.chat.button")
-        }
-        liveAudioLabel={t("game.audio.title")}
-        liveAudioJoined={isLiveAudioJoined}
-        finalResultsLabel={t("game.final.title")}
-        startLabel={hasReadiedCurrentPhase ? t("game.ready.waitingOthers") : t("common.ready")}
-        startDisabled={hasReadiedCurrentPhase}
-        hiddenHudCopy={{
-          potLabel: t("game.pot", { amount: displayPot }),
-          chipsLabel: t("game.yourChips", { amount: currentPlayer?.chips ?? 0 }),
-          roundLabel: currentHand
-            ? t("game.round", { round: currentHand.bettingRound })
-            : null,
-          turnLabel: currentTurnPlayer
-            ? t("game.turn", { name: currentTurnPlayer.name })
-            : null,
-        }}
-        isChatPanelOpen={isChatPanelOpen}
-        chatPreview={
-          !activePreviewMessage
-            ? null
-            : {
-                title: t("game.chat.preview.title"),
-                senderName: activePreviewMessage.sender.playerName,
-                senderEmoji: activePreviewMessage.sender.playerEmoji,
-                message: toChatPreviewText(activePreviewMessage, t),
-                timeIso: new Date(activePreviewMessage.createdAt).toISOString(),
-                timeLabel: formatRelativeTime(activePreviewMessage.createdAt, locale, relativeNow),
-                dismissLabel: t("game.chat.preview.dismiss"),
+      <div className="table-shell__desktop-layout">
+        <div
+          className="table-shell__game-column"
+          data-testid={shouldShowDesktopRail ? "desktop-game-column" : undefined}
+        >
+          <TableTopBar
+            roomTitle={t("game.room", { roomId: room.id })}
+            playerCountLabel={t("game.playersCount", {
+              count: tablePlayers.length,
+              max: room.config.maxPlayers,
+            })}
+            ruleVariantLabel={ruleVariantLabel}
+            inviteCopyLabel={t("game.copyInvite")}
+            inviteCopyStatus={inviteCopyStatus}
+            inviteCopyStatusTone={inviteCopyStatusTone}
+            leaveLabel={t("common.leave")}
+            settingsLabel={t("common.settings")}
+            rulesLabel={rulesCopy.buttonLabel}
+            rankingsLabel={t("game.rankings")}
+            chatLabel={
+              chatUnreadCount > 0
+                ? t("game.chat.buttonWithUnread", { count: chatUnreadCount })
+                : t("game.chat.button")
+            }
+            liveAudioLabel={t("game.audio.title")}
+            liveAudioJoined={isLiveAudioJoined}
+            finalResultsLabel={t("game.final.title")}
+            startLabel={hasReadiedCurrentPhase ? t("game.ready.waitingOthers") : t("common.ready")}
+            startDisabled={hasReadiedCurrentPhase}
+            hiddenHudCopy={hiddenHudCopy}
+            isChatPanelOpen={shouldShowChatPanel}
+            showChatButton={!isDesktopSideDock}
+            showChatPreview={!isDesktopSideDock}
+            chatPreview={chatPreview}
+            showFinalResultsButton={isGameEnded && Boolean(finalGameResult)}
+            showStartGameButton={false}
+            onCopyInvite={handleCopyInviteLink}
+            onLeave={handleRequestLeave}
+            onOpenSettings={() => {
+              if (user) {
+                setProfileDisplayNameDraft(user.displayName);
+                setProfileAvatarEmojiDraft(user.avatarEmoji);
               }
-        }
-        showFinalResultsButton={isGameEnded && Boolean(finalGameResult)}
-        showStartGameButton={false}
-        onCopyInvite={handleCopyInviteLink}
-        onLeave={handleRequestLeave}
-        onOpenSettings={() => {
-          if (user) {
-            setProfileDisplayNameDraft(user.displayName);
-            setProfileAvatarEmojiDraft(user.avatarEmoji);
-          }
-          setProfileFeedback(null);
-          setShowSettingsModal(true);
-        }}
-        onOpenRules={() => setShowRulesModal(true)}
-        onOpenRankings={() => setShowRankingsModal(true)}
-        onToggleChat={() => setChatPanelOpen(!isChatPanelOpen)}
-        onOpenLiveAudio={() => setShowLiveAudioModal(true)}
-        onOpenFinalResults={() => setShowFinalSummaryModal(true)}
-        onStartGame={markReady}
-        onOpenChatFromPreview={handleOpenChatFromPreview}
-        onDismissPreview={handleDismissPreview}
-      />
+              setProfileFeedback(null);
+              setShowSettingsModal(true);
+            }}
+            onOpenRules={() => setShowRulesModal(true)}
+            onOpenRankings={() => setShowRankingsModal(true)}
+            onToggleChat={() => setChatPanelOpen(!isChatPanelOpen)}
+            onOpenLiveAudio={() => setShowLiveAudioModal(true)}
+            onOpenFinalResults={() => setShowFinalSummaryModal(true)}
+            onStartGame={markReady}
+            onOpenChatFromPreview={handleOpenChatFromPreview}
+            onDismissPreview={handleDismissPreview}
+          />
 
-      {isChatPanelOpen && (
+          {isWaitingForNextHand && (
+            <section className="mx-3 mt-2 rounded-xl border border-cyan-400/45 bg-cyan-900/25 px-3 py-2 text-xs font-semibold text-cyan-100">
+              {t("game.cardsAppearWhenHandStarts")}
+            </section>
+          )}
+
+          {turnAlertToken !== null && (
+            <div aria-live="assertive" key={`turn-alert-${turnAlertToken}`}>
+              <TurnCenterAlert
+                eyebrow={t("game.turnAlert.eyebrow")}
+                title={t("game.turnAlert.title")}
+              />
+            </div>
+          )}
+
+          <div className="table-shell__board-stage">
+            {shouldRenderCardsFlyout && (
+              <YourCardsFlyout
+                isOpen={isCardsFlyoutOpen}
+                hasHoleCards={hasHoleCards}
+                cards={displayHoleCards ?? []}
+                shouldAnchorToBottomBar={shouldAnchorCardsFlyoutToBottomBar}
+                bottomBarHeight={bottomBarHeight}
+                placement={cardsFlyoutPlacement}
+                title={t("game.yourCards")}
+                emptyOpenStateLabel={t("game.cardsAppearWhenHandStarts")}
+                emptyClosedStateLabel={`${t("game.hide")} ${t("game.yourCards")}`}
+                hideLabel={t("game.hide")}
+                showLabel={t("game.show")}
+                onToggle={() => setIsCardsFlyoutOpen((prev) => !prev)}
+              />
+            )}
+
+            {actionCenterAlert !== null && (
+              <ActionCenterAlertOverlay
+                key={`action-alert-${actionCenterAlert.id}`}
+                pointerVector={actionPointerVector}
+                eyebrow={t("game.actionAlert.eyebrow")}
+                actor={actionCenterAlert.playerName}
+                title={actionCenterAlert.text}
+                tone={actionCenterAlert.tone}
+                exiting={actionCenterAlert.exiting}
+                cardRef={actionCenterAlertRef}
+              />
+            )}
+
+            <TableBoard
+              feltOvalRef={feltOvalRef}
+              boardCenterStackRef={boardCenterStackRef}
+              communityLaneRef={communityLaneRef}
+              potDropZoneRef={potDropZoneRef}
+              setSeatNodeRef={(playerId, node) => {
+                seatNodeRefs.current[playerId] = node;
+              }}
+              communitySlots={communitySlots}
+              isYourTurn={isYourTurn}
+              isDragOverDropZone={dragState.overDropZone}
+              potLabel={t("game.potCenter")}
+              potValue={`$${animatedPotValue}`}
+              potHint={isYourTurn ? t("game.dragHint") : null}
+              potPulse={potAnimationTick >= 0}
+              seatOrbitItems={seatOrbitItems}
+            />
+          </div>
+
+          {operationBarMode !== null && (
+            <ChipComposerDock
+              ref={bottomBarOverlayRef}
+              className={desktopOperationDockClassName}
+              testId="operation-overlay"
+            >
+              {showResolvedRunoutBoardsPreview && (
+                <section className="showdown-revealed-hands" data-testid="showdown-runout-boards">
+                  <div className="showdown-revealed-hands__header">
+                    <h4 className="showdown-revealed-hands__title">{t("game.runouts.title")}</h4>
+                  </div>
+                  <div className="showdown-revealed-hands__list">
+                    {resolvedRunoutBoards.map((board, runIndex) => (
+                      <div
+                        key={`showdown-runout-board-${runIndex}`}
+                        className="showdown-revealed-hands__item"
+                        data-testid={`showdown-runout-board-${runIndex}`}
+                      >
+                        <span className="showdown-revealed-hands__name">
+                          {t("game.runouts.runLabel", { index: runIndex + 1 })}
+                        </span>
+                        <div className="showdown-revealed-hands__cards">
+                          {board.map((card, cardIndex) => (
+                            <Card
+                              key={`showdown-runout-card-${runIndex}-${card.suit}-${card.rank}-${cardIndex}`}
+                              card={card}
+                              size="small"
+                              dataTestId={`showdown-runout-card-${runIndex}-${cardIndex}`}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+              {operationBarMode === "showdown" && revealedShowdownHands.length > 0 && (
+                <section className="showdown-revealed-hands" data-testid="showdown-revealed-hands">
+                  <div className="showdown-revealed-hands__header">
+                    <h4 className="showdown-revealed-hands__title">{t("game.showdown.revealedHandsTitle")}</h4>
+                  </div>
+                  <div className="showdown-revealed-hands__list">
+                    {revealedShowdownHands.map((entry) => (
+                      <div
+                        key={entry.playerId}
+                        className="showdown-revealed-hands__item"
+                        data-testid={`showdown-revealed-hand-${entry.playerId}`}
+                      >
+                        <span className="showdown-revealed-hands__name">{entry.playerName}</span>
+                        <div className="showdown-revealed-hands__cards">
+                          {entry.cards.map((card, cardIndex) => (
+                            <Card
+                              key={`${entry.playerId}-${card.suit}-${card.rank}-${cardIndex}`}
+                              card={card}
+                              size="small"
+                              dataTestId={`showdown-revealed-card-${entry.playerId}-${cardIndex}`}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+              <OperationActionBar
+                mode={operationBarMode}
+                isAutomationMode={isAutomationMode}
+                runCountCanChoose={canChooseRunCount}
+                runCountHasChosenTwice={hasChosenRunTwice}
+                runCountReadyCount={runCountTwiceAgreedPlayerIdSet.size}
+                runCountTotalCount={runCountDecisionState?.eligiblePlayerIds.length ?? 0}
+                runCountWaitingPlayerNames={runCountWaitingPlayerNames}
+                isResultRevealStep={isResultRevealStep}
+                canRevealNextStreet={canRevealNextStreet}
+                hasRevealedNextStreet={hasRevealedNextStreet}
+                canShowMyHand={canShowMyHandAtShowdown}
+                hasShownMyHand={hasShownMyHandAtShowdown}
+                canFoldMyHand={canFoldMyHandAtShowdown}
+                hasFoldedMyHand={hasFoldedMyHandAtShowdown}
+                showdownIsDecisionTurn={isMyShowdownDecisionTurn}
+                showdownWaitingPlayerName={showdownDecisionWaitingPlayerName}
+                showdownIsForcedRevealTurn={isShowdownForcedRevealTurn}
+                onChooseRunOnce={() => decideRunCount(1)}
+                onChooseRunTwice={() => decideRunCount(2)}
+                onRevealNextStreet={revealNextStreet}
+                onShowMyHand={showMyHand}
+                onFoldMyHand={muckMyHand}
+                t={t}
+              />
+            </ChipComposerDock>
+          )}
+
+          {showPreGameReadyArea && (
+            <ChipComposerDock
+              ref={bottomBarOverlayRef}
+              className={desktopOperationDockClassName}
+              testId="operation-overlay"
+            >
+              <ReadyActionArea
+                phase={readyActionPhase}
+                canReady={canReadyInReadyActionArea}
+                hasReadied={hasReadiedCurrentPhase}
+                canEndGame={canHostEndGame}
+                isHost={isHost}
+                robots={robotPlayers.map((entry) => ({
+                  id: entry.id,
+                  name: entry.name,
+                  emoji: entry.emoji,
+                }))}
+                onReady={markReady}
+                onOpenEndGameConfirm={() => {
+                  if (!canHostEndGame) return;
+                  setShowEndGameConfirmModal(true);
+                }}
+                onAddRobot={() => addRobotPlayer()}
+                onRemoveRobot={(robotPlayerId) => removeRobotPlayer(robotPlayerId)}
+                t={t}
+              />
+            </ChipComposerDock>
+          )}
+
+          {showNextHandActionArea && !showHandResultsModal && (
+            <ChipComposerDock
+              ref={bottomBarOverlayRef}
+              className={desktopOperationDockClassName}
+              testId="operation-overlay"
+            >
+              <NextHandActionArea
+                canReadyNextHand={canReadyNextHand}
+                hasReadiedNextHand={hasReadiedCurrentPhase}
+                canEndGame={canHostEndGame}
+                onReadyNextHand={markReady}
+                onOpenEndGameConfirm={() => {
+                  if (!canHostEndGame) return;
+                  setShowEndGameConfirmModal(true);
+                }}
+                t={t}
+              />
+            </ChipComposerDock>
+          )}
+
+          {showTurnActionDock && (
+            <ChipComposerDock ref={bottomBarOverlayRef} className={desktopMainDockClassName}>
+              <TurnActionDock
+                callAmount={callAmount}
+                minRaise={minRaise}
+                maxStack={maxStack}
+                trayAmount={trayAmount}
+                trayInputValue={trayInputValue}
+                isDesktopClickBetting={isDesktopSideDock}
+                canStartDrag={canStartDrag}
+                isDragActive={dragState.active}
+                isYourTurn={isYourTurn}
+                canCheck={canCheck}
+                isAutomationMode={isAutomationMode}
+                legacyRaiseAmount={legacyRaiseAmount}
+                trayPresetButtons={trayPresetButtons}
+                onDragStart={handleDragStart}
+                onDragMove={handleDragMove}
+                onDragEnd={handleDragEnd}
+                onSetTrayDirectly={setTrayDirectly}
+                onTrayInputChange={handleCustomTrayInputChange}
+                onTrayInputBlur={handleCustomTrayInputBlur}
+                onClearTray={clearTray}
+                onSubmitTray={requestTraySubmit}
+                onQuickDecisionAction={handleQuickDecisionAction}
+                quickConfirmAction={!isAutomationMode ? quickConfirmAction : null}
+                onQuickConfirmDismiss={() => setQuickConfirmAction(null)}
+                onQuickConfirmAccept={(action) => {
+                  setQuickConfirmAction(null);
+                  performAction(action);
+                }}
+                traySubmitLabel={desktopTraySubmitIntent?.label ?? null}
+                showTrayConfirm={showTrayConfirm}
+                onTrayConfirmDismiss={() => setShowTrayConfirm(false)}
+                onTrayConfirmAccept={acceptTraySubmit}
+                onLegacyAction={handleLegacyAction}
+                onLegacyRaiseAmountChange={setLegacyRaiseAmount}
+                t={t}
+              />
+            </ChipComposerDock>
+          )}
+        </div>
+
+        {shouldShowDesktopRail && (
+          <aside className="desktop-right-rail" data-testid="desktop-right-rail">
+            <div className="chat-panel-shell chat-panel-shell--desktop-rail">
+              <ChatPanel onClose={() => undefined} showCloseButton={false} />
+            </div>
+            <section className="surface-panel desktop-side-panel" data-testid="desktop-side-status">
+              <div className="desktop-side-panel__header">
+                <h3>{t("game.confirmActions")}</h3>
+                <span className="desktop-side-panel__meta">
+                  {t("game.playersCount", {
+                    count: tablePlayers.length,
+                    max: room.config.maxPlayers,
+                  })}
+                </span>
+              </div>
+              <div className="desktop-side-panel__stats">
+                <div>
+                  <span className="desktop-side-panel__label">{t("game.ruleVariant.standard")}</span>
+                  <strong>{ruleVariantLabel}</strong>
+                </div>
+                <div>
+                  <span className="desktop-side-panel__label">{t("game.potCenter")}</span>
+                  <strong>{`$${animatedPotValue}`}</strong>
+                </div>
+                {hiddenHudCopy.roundLabel && (
+                  <div>
+                    <span className="desktop-side-panel__label">{t("game.confirmAction.roundLabel")}</span>
+                    <strong>{hiddenHudCopy.roundLabel}</strong>
+                  </div>
+                )}
+                {hiddenHudCopy.turnLabel && (
+                  <div>
+                    <span className="desktop-side-panel__label">{t("game.confirmAction.turnLabel")}</span>
+                    <strong>{hiddenHudCopy.turnLabel}</strong>
+                  </div>
+                )}
+              </div>
+              <div className="desktop-side-panel__actions">
+                <button
+                  type="button"
+                  onClick={() => setShowRulesModal(true)}
+                  className="desktop-side-panel__button"
+                >
+                  {rulesCopy.buttonLabel}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowRankingsModal(true)}
+                  className="desktop-side-panel__button"
+                >
+                  {t("game.rankings")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowLiveAudioModal(true)}
+                  className="desktop-side-panel__button"
+                >
+                  {t("game.audio.title")}
+                </button>
+              </div>
+            </section>
+          </aside>
+        )}
+      </div>
+
+      {!shouldShowDesktopRail && shouldShowChatPanel && (
         <div className="chat-panel-shell">
           <ChatPanel onClose={() => setChatPanelOpen(false)} />
         </div>
       )}
-
-      {isWaitingForNextHand && (
-        <section className="mx-3 mt-2 rounded-xl border border-cyan-400/45 bg-cyan-900/25 px-3 py-2 text-xs font-semibold text-cyan-100">
-          {t("game.cardsAppearWhenHandStarts")}
-        </section>
-      )}
-
-      {turnAlertToken !== null && (
-        <div aria-live="assertive" key={`turn-alert-${turnAlertToken}`}>
-          <TurnCenterAlert
-            eyebrow={t("game.turnAlert.eyebrow")}
-            title={t("game.turnAlert.title")}
-          />
-        </div>
-      )}
-
-      {shouldRenderCardsFlyout && (
-        <YourCardsFlyout
-          isOpen={isCardsFlyoutOpen}
-          hasHoleCards={hasHoleCards}
-          cards={displayHoleCards ?? []}
-          shouldAnchorToBottomBar={shouldAnchorCardsFlyoutToBottomBar}
-          bottomBarHeight={bottomBarHeight}
-          title={t("game.yourCards")}
-          emptyOpenStateLabel={t("game.cardsAppearWhenHandStarts")}
-          emptyClosedStateLabel={`${t("game.hide")} ${t("game.yourCards")}`}
-          hideLabel={t("game.hide")}
-          showLabel={t("game.show")}
-          onToggle={() => setIsCardsFlyoutOpen((prev) => !prev)}
-        />
-      )}
-
-      {actionCenterAlert !== null && (
-        <ActionCenterAlertOverlay
-          key={`action-alert-${actionCenterAlert.id}`}
-          pointerVector={actionPointerVector}
-          eyebrow={t("game.actionAlert.eyebrow")}
-          actor={actionCenterAlert.playerName}
-          title={actionCenterAlert.text}
-          tone={actionCenterAlert.tone}
-          exiting={actionCenterAlert.exiting}
-          cardRef={actionCenterAlertRef}
-        />
-      )}
-
-      <TableBoard
-        feltOvalRef={feltOvalRef}
-        boardCenterStackRef={boardCenterStackRef}
-        communityLaneRef={communityLaneRef}
-        potDropZoneRef={potDropZoneRef}
-        setSeatNodeRef={(playerId, node) => {
-          seatNodeRefs.current[playerId] = node;
-        }}
-        communitySlots={communitySlots}
-        isYourTurn={isYourTurn}
-        isDragOverDropZone={dragState.overDropZone}
-        potLabel={t("game.potCenter")}
-        potValue={`$${animatedPotValue}`}
-        potHint={isYourTurn ? t("game.dragHint") : null}
-        potPulse={potAnimationTick >= 0}
-        seatOrbitItems={seatOrbitItems}
-      />
 
       {showHandResultsModal && lastHandResult && !finalGameResult && (
         <HandResultsModal
@@ -3940,183 +4276,6 @@ const useGameRoomElement = () => {
             t={t}
           />
         </HandResultsModal>
-      )}
-
-      {operationBarMode !== null && (
-        <ChipComposerDock
-          ref={bottomBarOverlayRef}
-          className="chip-composer-dock--operation"
-          testId="operation-overlay"
-        >
-          {showResolvedRunoutBoardsPreview && (
-            <section className="showdown-revealed-hands" data-testid="showdown-runout-boards">
-              <div className="showdown-revealed-hands__header">
-                <h4 className="showdown-revealed-hands__title">{t("game.runouts.title")}</h4>
-              </div>
-              <div className="showdown-revealed-hands__list">
-                {resolvedRunoutBoards.map((board, runIndex) => (
-                  <div
-                    key={`showdown-runout-board-${runIndex}`}
-                    className="showdown-revealed-hands__item"
-                    data-testid={`showdown-runout-board-${runIndex}`}
-                  >
-                    <span className="showdown-revealed-hands__name">
-                      {t("game.runouts.runLabel", { index: runIndex + 1 })}
-                    </span>
-                    <div className="showdown-revealed-hands__cards">
-                      {board.map((card, cardIndex) => (
-                        <Card
-                          key={`showdown-runout-card-${runIndex}-${card.suit}-${card.rank}-${cardIndex}`}
-                          card={card}
-                          size="small"
-                          dataTestId={`showdown-runout-card-${runIndex}-${cardIndex}`}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-          {operationBarMode === "showdown" && revealedShowdownHands.length > 0 && (
-            <section className="showdown-revealed-hands" data-testid="showdown-revealed-hands">
-              <div className="showdown-revealed-hands__header">
-                <h4 className="showdown-revealed-hands__title">{t("game.showdown.revealedHandsTitle")}</h4>
-              </div>
-              <div className="showdown-revealed-hands__list">
-                {revealedShowdownHands.map((entry) => (
-                  <div
-                    key={entry.playerId}
-                    className="showdown-revealed-hands__item"
-                    data-testid={`showdown-revealed-hand-${entry.playerId}`}
-                  >
-                    <span className="showdown-revealed-hands__name">{entry.playerName}</span>
-                    <div className="showdown-revealed-hands__cards">
-                      {entry.cards.map((card, cardIndex) => (
-                        <Card
-                          key={`${entry.playerId}-${card.suit}-${card.rank}-${cardIndex}`}
-                          card={card}
-                          size="small"
-                          dataTestId={`showdown-revealed-card-${entry.playerId}-${cardIndex}`}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-          <OperationActionBar
-            mode={operationBarMode}
-            isAutomationMode={isAutomationMode}
-            runCountCanChoose={canChooseRunCount}
-            runCountHasChosenTwice={hasChosenRunTwice}
-            runCountReadyCount={runCountTwiceAgreedPlayerIdSet.size}
-            runCountTotalCount={runCountDecisionState?.eligiblePlayerIds.length ?? 0}
-            runCountWaitingPlayerNames={runCountWaitingPlayerNames}
-            isResultRevealStep={isResultRevealStep}
-            canRevealNextStreet={canRevealNextStreet}
-            hasRevealedNextStreet={hasRevealedNextStreet}
-            canShowMyHand={canShowMyHandAtShowdown}
-            hasShownMyHand={hasShownMyHandAtShowdown}
-            canFoldMyHand={canFoldMyHandAtShowdown}
-            hasFoldedMyHand={hasFoldedMyHandAtShowdown}
-            showdownIsDecisionTurn={isMyShowdownDecisionTurn}
-            showdownWaitingPlayerName={showdownDecisionWaitingPlayerName}
-            showdownIsForcedRevealTurn={isShowdownForcedRevealTurn}
-            onChooseRunOnce={() => decideRunCount(1)}
-            onChooseRunTwice={() => decideRunCount(2)}
-            onRevealNextStreet={revealNextStreet}
-            onShowMyHand={showMyHand}
-            onFoldMyHand={muckMyHand}
-            t={t}
-          />
-        </ChipComposerDock>
-      )}
-
-      {showPreGameReadyArea && (
-        <ChipComposerDock
-          ref={bottomBarOverlayRef}
-          className="chip-composer-dock--operation"
-          testId="operation-overlay"
-        >
-          <ReadyActionArea
-            phase={readyActionPhase}
-            canReady={canReadyInReadyActionArea}
-            hasReadied={hasReadiedCurrentPhase}
-            canEndGame={canHostEndGame}
-            isHost={isHost}
-            robots={robotPlayers.map((entry) => ({
-              id: entry.id,
-              name: entry.name,
-              emoji: entry.emoji,
-            }))}
-            onReady={markReady}
-            onOpenEndGameConfirm={() => {
-              if (!canHostEndGame) return;
-              setShowEndGameConfirmModal(true);
-            }}
-            onAddRobot={() => addRobotPlayer()}
-            onRemoveRobot={(robotPlayerId) => removeRobotPlayer(robotPlayerId)}
-            t={t}
-          />
-        </ChipComposerDock>
-      )}
-
-      {showNextHandActionArea && !showHandResultsModal && (
-        <ChipComposerDock
-          ref={bottomBarOverlayRef}
-          className="chip-composer-dock--operation"
-          testId="operation-overlay"
-        >
-          <NextHandActionArea
-            canReadyNextHand={canReadyNextHand}
-            hasReadiedNextHand={hasReadiedCurrentPhase}
-            canEndGame={canHostEndGame}
-            onReadyNextHand={markReady}
-            onOpenEndGameConfirm={() => {
-              if (!canHostEndGame) return;
-              setShowEndGameConfirmModal(true);
-            }}
-            t={t}
-          />
-        </ChipComposerDock>
-      )}
-
-      {showTurnActionDock && (
-        <ChipComposerDock ref={bottomBarOverlayRef}>
-          <TurnActionDock
-            callAmount={callAmount}
-            minRaise={minRaise}
-            maxStack={maxStack}
-            trayAmount={trayAmount}
-            trayInputValue={trayInputValue}
-            canStartDrag={canStartDrag}
-            isDragActive={dragState.active}
-            isYourTurn={isYourTurn}
-            canCheck={canCheck}
-            isAutomationMode={isAutomationMode}
-            legacyRaiseAmount={legacyRaiseAmount}
-            trayPresetButtons={trayPresetButtons}
-            onDragStart={handleDragStart}
-            onDragMove={handleDragMove}
-            onDragEnd={handleDragEnd}
-            onSetTrayDirectly={setTrayDirectly}
-            onTrayInputChange={handleCustomTrayInputChange}
-            onTrayInputBlur={handleCustomTrayInputBlur}
-            onClearTray={clearTray}
-            onQuickDecisionAction={handleQuickDecisionAction}
-            quickConfirmAction={!isAutomationMode ? quickConfirmAction : null}
-            onQuickConfirmDismiss={() => setQuickConfirmAction(null)}
-            onQuickConfirmAccept={(action) => {
-              setQuickConfirmAction(null);
-              performAction(action);
-            }}
-            onLegacyAction={handleLegacyAction}
-            onLegacyRaiseAmountChange={setLegacyRaiseAmount}
-            t={t}
-          />
-        </ChipComposerDock>
       )}
 
       {dragState.active && (

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -45,6 +45,10 @@ import {
   TurnCenterAlert,
   YourCardsFlyout,
 } from "@/components/poker";
+import {
+  resolveCardsFlyoutDesktopLayout,
+  shouldRenderCardsFlyoutInBoardStage,
+} from "@/components/poker/game-room-layout";
 import type { SeatBadge, SeatLiveAudioBadge } from "@/components/poker/seat-pod";
 import { buildEqualArcEllipsePoints } from "@/components/poker/seat-orbit-layout";
 
@@ -1801,6 +1805,8 @@ const useGameRoomElement = () => {
   const actionAlertClearTimeoutRef = useRef<number | null>(null);
   const turnAlertTimeoutRef = useRef<number | null>(null);
   const previousIsYourTurnRef = useRef<boolean | null>(null);
+  const dragStateRef = useRef<DragState>(EMPTY_DRAG_STATE);
+  const dragActivatorRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     if (!user) {
@@ -2182,8 +2188,25 @@ const useGameRoomElement = () => {
   const shouldShowChatPanel = isDesktopSideDock || isChatPanelOpen;
   const shouldAnchorCardsFlyoutToBottomBar =
     showOperationBar || showReadyActionArea || (showTurnActionDock && !isDesktopSideDock);
+  const desktopCardsFlyoutLayout = resolveCardsFlyoutDesktopLayout({
+    shouldRenderCardsFlyout,
+    isDesktopSideDock,
+    showTurnActionDock,
+  });
   const shouldRenderCardsBesideDesktopDock =
-    shouldRenderCardsFlyout && isDesktopSideDock && showTurnActionDock;
+    desktopCardsFlyoutLayout.renderInDesktopDockCluster && showTurnActionDock;
+  const shouldRenderCardsInDesktopDockCluster =
+    desktopCardsFlyoutLayout.renderInDesktopDockCluster;
+  const shouldRenderStandaloneDesktopCardsFlyout =
+    shouldRenderCardsInDesktopDockCluster &&
+    !showTurnActionDock &&
+    !showOperationBar &&
+    !showReadyActionArea;
+  const shouldRenderCardsInBoardStage = shouldRenderCardsFlyoutInBoardStage({
+    shouldRenderCardsFlyout,
+    isDesktopSideDock,
+    showTurnActionDock,
+  });
   const cardsFlyoutPlacement = isDesktopSideDock
     ? "felt-right"
     : shouldAnchorCardsFlyoutToBottomBar
@@ -3005,12 +3028,32 @@ const useGameRoomElement = () => {
     });
   }, [maxStack]);
 
+  const updateDragState = useCallback((nextState: DragState) => {
+    dragStateRef.current = nextState;
+    setDragState(nextState);
+  }, []);
+
+  const clearDragState = useCallback((pointerId?: number | null) => {
+    const dragActivatorNode = dragActivatorRef.current;
+    if (
+      dragActivatorNode &&
+      pointerId !== null &&
+      pointerId !== undefined &&
+      dragActivatorNode.hasPointerCapture(pointerId)
+    ) {
+      dragActivatorNode.releasePointerCapture(pointerId);
+    }
+
+    dragActivatorRef.current = null;
+    updateDragState(EMPTY_DRAG_STATE);
+  }, [updateDragState]);
+
   const resetTurnInteractionState = useCallback(() => {
     setTrayAmount(0);
     setQuickConfirmAction(null);
     setShowTrayConfirm(false);
-    setDragState(EMPTY_DRAG_STATE);
-  }, []);
+    clearDragState(dragStateRef.current.pointerId);
+  }, [clearDragState]);
 
   useEffect(() => {
     if (!showTurnActionDock) {
@@ -3334,6 +3377,92 @@ const useGameRoomElement = () => {
     setTrayAmount(0);
   }, [dropResolution.intent, isYourTurn, performAction]);
 
+  const updateDragPointer = useCallback((pointerId: number, clientX: number, clientY: number) => {
+    const currentDragState = dragStateRef.current;
+    if (!currentDragState.active || currentDragState.pointerId !== pointerId) {
+      return;
+    }
+
+    const nextOverDropZone = isPointInDropZone(clientX, clientY);
+    if (
+      currentDragState.clientX === clientX &&
+      currentDragState.clientY === clientY &&
+      currentDragState.overDropZone === nextOverDropZone
+    ) {
+      return;
+    }
+
+    updateDragState({
+      ...currentDragState,
+      clientX,
+      clientY,
+      overDropZone: nextOverDropZone,
+    });
+  }, [isPointInDropZone, updateDragState]);
+
+  const finishDragPointer = useCallback(({
+    pointerId,
+    clientX,
+    clientY,
+    cancelled,
+  }: {
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    cancelled: boolean;
+  }) => {
+    const currentDragState = dragStateRef.current;
+    if (!currentDragState.active || currentDragState.pointerId !== pointerId) {
+      return;
+    }
+
+    const shouldCommit =
+      !cancelled &&
+      (currentDragState.overDropZone || isPointInDropZone(clientX, clientY));
+
+    clearDragState(pointerId);
+
+    if (shouldCommit) {
+      commitTrayDrop();
+    }
+  }, [clearDragState, commitTrayDrop, isPointInDropZone]);
+
+  useEffect(() => {
+    if (!dragState.active || dragState.pointerId === null) {
+      return;
+    }
+
+    const handleWindowPointerMove = (event: PointerEvent) => {
+      updateDragPointer(event.pointerId, event.clientX, event.clientY);
+    };
+    const handleWindowPointerUp = (event: PointerEvent) => {
+      finishDragPointer({
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        cancelled: false,
+      });
+    };
+    const handleWindowPointerCancel = (event: PointerEvent) => {
+      finishDragPointer({
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        cancelled: true,
+      });
+    };
+
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerUp, true);
+    window.addEventListener("pointercancel", handleWindowPointerCancel, true);
+
+    return () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerUp, true);
+      window.removeEventListener("pointercancel", handleWindowPointerCancel, true);
+    };
+  }, [dragState.active, dragState.pointerId, finishDragPointer, updateDragPointer]);
+
   const requestTraySubmit = useCallback(() => {
     if (!desktopTraySubmitIntent) {
       return;
@@ -3397,8 +3526,9 @@ const useGameRoomElement = () => {
 
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
+    dragActivatorRef.current = event.currentTarget;
 
-    setDragState({
+    updateDragState({
       active: true,
       pointerId: event.pointerId,
       clientX: event.clientX,
@@ -3408,39 +3538,16 @@ const useGameRoomElement = () => {
   };
 
   const handleDragMove = (event: React.PointerEvent<HTMLButtonElement>) => {
-    setDragState((prev) => {
-      if (!prev.active || prev.pointerId !== event.pointerId) {
-        return prev;
-      }
-
-      return {
-        ...prev,
-        clientX: event.clientX,
-        clientY: event.clientY,
-        overDropZone: isPointInDropZone(event.clientX, event.clientY),
-      };
-    });
+    updateDragPointer(event.pointerId, event.clientX, event.clientY);
   };
 
   const handleDragEnd = (event: React.PointerEvent<HTMLButtonElement>) => {
-    const isSamePointer = dragState.active && dragState.pointerId === event.pointerId;
-    const isCancelled = event.type === "pointercancel";
-    const shouldCommit =
-      isSamePointer &&
-      !isCancelled &&
-      (dragState.overDropZone || isPointInDropZone(event.clientX, event.clientY));
-
-    setDragState((prev) =>
-      !prev.active || prev.pointerId !== event.pointerId ? prev : EMPTY_DRAG_STATE,
-    );
-
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-
-    if (shouldCommit) {
-      commitTrayDrop();
-    }
+    finishDragPointer({
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      cancelled: event.type === "pointercancel",
+    });
   };
 
   const handleCopyInviteLink = async () => {
@@ -3929,7 +4036,7 @@ const useGameRoomElement = () => {
           )}
 
           <div className="table-shell__board-stage">
-            {shouldRenderCardsFlyout && !shouldRenderCardsBesideDesktopDock && (
+            {shouldRenderCardsInBoardStage && (
               <YourCardsFlyout
                 isOpen={isCardsFlyoutOpen}
                 hasHoleCards={hasHoleCards}
@@ -4119,6 +4226,30 @@ const useGameRoomElement = () => {
             </ChipComposerDock>
           )}
 
+          {shouldRenderStandaloneDesktopCardsFlyout && (
+            <div className="desktop-dock-cluster desktop-dock-cluster--cards-only">
+              <YourCardsFlyout
+                isOpen={isCardsFlyoutOpen}
+                hasHoleCards={hasHoleCards}
+                cards={displayHoleCards ?? []}
+                shouldAnchorToBottomBar={false}
+                bottomBarHeight={bottomBarHeight}
+                placement={desktopCardsFlyoutLayout.placement ?? "dock-left"}
+                title={t("game.yourCards")}
+                emptyOpenStateLabel={t("game.cardsAppearWhenHandStarts")}
+                emptyClosedStateLabel={`${t("game.hide")} ${t("game.yourCards")}`}
+                hideLabel={t("game.hide")}
+                showLabel={t("game.show")}
+                onToggle={() => setIsCardsFlyoutOpen((prev) => !prev)}
+              />
+              <div
+                className="desktop-dock-cluster__anchor"
+                data-testid="desktop-dock-anchor"
+                aria-hidden="true"
+              />
+            </div>
+          )}
+
           {showTurnActionDock && (
             <div className={isDesktopSideDock ? "desktop-dock-cluster" : undefined}>
               {shouldRenderCardsBesideDesktopDock && (
@@ -4128,7 +4259,7 @@ const useGameRoomElement = () => {
                   cards={displayHoleCards ?? []}
                   shouldAnchorToBottomBar={false}
                   bottomBarHeight={bottomBarHeight}
-                  placement="dock-left"
+                  placement={desktopCardsFlyoutLayout.placement ?? "dock-left"}
                   title={t("game.yourCards")}
                   emptyOpenStateLabel={t("game.cardsAppearWhenHandStarts")}
                   emptyClosedStateLabel={`${t("game.hide")} ${t("game.yourCards")}`}

--- a/poker-client/src/components/poker/chat-panel.tsx
+++ b/poker-client/src/components/poker/chat-panel.tsx
@@ -22,6 +22,7 @@ const VOICE_RELEASE_TAIL_MS = 300;
 
 type ChatPanelProps = {
   onClose: () => void;
+  showCloseButton?: boolean;
 };
 
 type ChatPanelBindings = {
@@ -115,6 +116,7 @@ const VoicePlaybackBar: React.FC<VoicePlaybackBarProps> = ({
 
 const useChatPanelViewElement = ({
   onClose,
+  showCloseButton = true,
   locale,
   t,
   room,
@@ -567,14 +569,16 @@ const useChatPanelViewElement = ({
     <section className="chat-panel" data-testid="chat-panel">
       <header className="chat-panel__header">
         <h3>{t("game.chat.title")}</h3>
-        <button
-          type="button"
-          onClick={onClose}
-          data-testid="close-chat-button"
-          className="chat-panel__close"
-        >
-          {t("common.close")}
-        </button>
+        {showCloseButton && (
+          <button
+            type="button"
+            onClick={onClose}
+            data-testid="close-chat-button"
+            className="chat-panel__close"
+          >
+            {t("common.close")}
+          </button>
+        )}
       </header>
 
       <div
@@ -636,7 +640,10 @@ const useChatPanelViewElement = ({
 export const ChatPanelView: React.FC<ChatPanelViewProps> = (props) =>
   useChatPanelViewElement(props);
 
-export const ChatPanel: React.FC<ChatPanelProps> = ({ onClose }) => {
+export const ChatPanel: React.FC<ChatPanelProps> = ({
+  onClose,
+  showCloseButton = true,
+}) => {
   const { locale, t } = useLocalization();
   const {
     room,
@@ -653,6 +660,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onClose }) => {
   return (
     <ChatPanelView
       onClose={onClose}
+      showCloseButton={showCloseButton}
       locale={locale}
       t={t}
       room={room}

--- a/poker-client/src/components/poker/game-room-layout.spec.ts
+++ b/poker-client/src/components/poker/game-room-layout.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCardsFlyoutDesktopLayout,
+  shouldRenderCardsFlyoutInBoardStage,
+} from "./game-room-layout";
+
+describe("game-room-layout", () => {
+  it("keeps desktop flyout dock-aligned even when the turn dock is hidden", () => {
+    expect(
+      resolveCardsFlyoutDesktopLayout({
+        shouldRenderCardsFlyout: true,
+        isDesktopSideDock: true,
+        showTurnActionDock: false,
+      }),
+    ).toEqual({
+      renderInDesktopDockCluster: true,
+      placement: "dock-left",
+    });
+
+    expect(
+      shouldRenderCardsFlyoutInBoardStage({
+        shouldRenderCardsFlyout: true,
+        isDesktopSideDock: true,
+        showTurnActionDock: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses the board-stage flyout on non-desktop layouts", () => {
+    expect(
+      resolveCardsFlyoutDesktopLayout({
+        shouldRenderCardsFlyout: true,
+        isDesktopSideDock: false,
+        showTurnActionDock: true,
+      }),
+    ).toEqual({
+      renderInDesktopDockCluster: false,
+      placement: null,
+    });
+
+    expect(
+      shouldRenderCardsFlyoutInBoardStage({
+        shouldRenderCardsFlyout: true,
+        isDesktopSideDock: false,
+        showTurnActionDock: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/poker-client/src/components/poker/game-room-layout.ts
+++ b/poker-client/src/components/poker/game-room-layout.ts
@@ -1,0 +1,31 @@
+type ResolveCardsFlyoutDesktopLayoutArgs = {
+  shouldRenderCardsFlyout: boolean;
+  isDesktopSideDock: boolean;
+  showTurnActionDock: boolean;
+};
+
+export const resolveCardsFlyoutDesktopLayout = ({
+  shouldRenderCardsFlyout,
+  isDesktopSideDock,
+}: ResolveCardsFlyoutDesktopLayoutArgs): {
+  renderInDesktopDockCluster: boolean;
+  placement: "dock-left" | null;
+} => {
+  if (!shouldRenderCardsFlyout || !isDesktopSideDock) {
+    return {
+      renderInDesktopDockCluster: false,
+      placement: null,
+    };
+  }
+
+  return {
+    renderInDesktopDockCluster: true,
+    placement: "dock-left",
+  };
+};
+
+export const shouldRenderCardsFlyoutInBoardStage = ({
+  shouldRenderCardsFlyout,
+  isDesktopSideDock,
+}: ResolveCardsFlyoutDesktopLayoutArgs): boolean =>
+  shouldRenderCardsFlyout && !isDesktopSideDock;

--- a/poker-client/src/components/poker/table-shell.tsx
+++ b/poker-client/src/components/poker/table-shell.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 
 type TableShellProps = {
   children: React.ReactNode;
+  isDesktopTwoColumn?: boolean;
   showDesktopTurnDock: boolean;
   showDesktopOperationDock: boolean;
   desktopBottomBarHeight: number;
@@ -11,6 +12,7 @@ type TableShellProps = {
 
 export const TableShell: React.FC<TableShellProps> = ({
   children,
+  isDesktopTwoColumn = false,
   showDesktopTurnDock,
   showDesktopOperationDock,
   desktopBottomBarHeight,
@@ -25,6 +27,7 @@ export const TableShell: React.FC<TableShellProps> = ({
       }
       className={cn(
         "table-shell",
+        isDesktopTwoColumn && "table-shell--desktop-two-column",
         showDesktopTurnDock && "table-shell--desktop-turn-dock",
         showDesktopOperationDock && "table-shell--desktop-operation-dock",
         isChatPanelOpen && "table-shell--chat-open",

--- a/poker-client/src/components/poker/table-top-bar.tsx
+++ b/poker-client/src/components/poker/table-top-bar.tsx
@@ -37,6 +37,8 @@ type TableTopBarProps = {
   startDisabled?: boolean;
   hiddenHudCopy: HiddenHudCopy;
   isChatPanelOpen: boolean;
+  showChatButton?: boolean;
+  showChatPreview?: boolean;
   chatPreview: ChatPreview | null;
   showFinalResultsButton: boolean;
   showStartGameButton: boolean;
@@ -72,6 +74,8 @@ export const TableTopBar: React.FC<TableTopBarProps> = ({
   startDisabled = false,
   hiddenHudCopy,
   isChatPanelOpen,
+  showChatButton = true,
+  showChatPreview = true,
   chatPreview,
   showFinalResultsButton,
   showStartGameButton,
@@ -180,13 +184,15 @@ export const TableTopBar: React.FC<TableTopBarProps> = ({
         >
           {rankingsLabel}
         </button>
-        <button
-          onClick={onToggleChat}
-          data-testid="open-chat-button"
-          className="rounded-full border border-cyan-300/65 bg-cyan-900/35 px-3 py-1 text-xs font-semibold text-cyan-100 transition hover:bg-cyan-800/45"
-        >
-          {chatLabel}
-        </button>
+        {showChatButton && (
+          <button
+            onClick={onToggleChat}
+            data-testid="open-chat-button"
+            className="rounded-full border border-cyan-300/65 bg-cyan-900/35 px-3 py-1 text-xs font-semibold text-cyan-100 transition hover:bg-cyan-800/45"
+          >
+            {chatLabel}
+          </button>
+        )}
         <button
           onClick={onOpenLiveAudio}
           data-testid="open-live-audio-button"
@@ -224,7 +230,7 @@ export const TableTopBar: React.FC<TableTopBarProps> = ({
         </div>
       </section>
 
-      {!isChatPanelOpen && chatPreview && (
+      {showChatPreview && !isChatPanelOpen && chatPreview && (
         <div className="chat-preview-strip" data-testid="chat-preview-strip">
           <button
             type="button"

--- a/poker-client/src/components/poker/turn-action-dock.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.tsx
@@ -25,6 +25,7 @@ type TurnActionDockProps = {
   maxStack: number;
   trayAmount: number;
   trayInputValue: string;
+  isDesktopClickBetting?: boolean;
   canStartDrag: boolean;
   isDragActive: boolean;
   isYourTurn: boolean;
@@ -39,10 +40,15 @@ type TurnActionDockProps = {
   onTrayInputChange: React.ChangeEventHandler<HTMLInputElement>;
   onTrayInputBlur: React.FocusEventHandler<HTMLInputElement>;
   onClearTray: () => void;
+  onSubmitTray?: () => void;
   onQuickDecisionAction: (action: QuickDecisionAction) => void;
   quickConfirmAction: QuickDecisionAction | null;
   onQuickConfirmDismiss: () => void;
   onQuickConfirmAccept: (action: QuickDecisionAction) => void;
+  traySubmitLabel?: string | null;
+  showTrayConfirm?: boolean;
+  onTrayConfirmDismiss?: () => void;
+  onTrayConfirmAccept?: () => void;
   onLegacyAction: (action: LegacyAction) => void;
   onLegacyRaiseAmountChange: (amount: number) => void;
   t: Translate;
@@ -54,6 +60,7 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
   maxStack,
   trayAmount,
   trayInputValue,
+  isDesktopClickBetting = false,
   canStartDrag,
   isDragActive,
   isYourTurn,
@@ -68,10 +75,15 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
   onTrayInputChange,
   onTrayInputBlur,
   onClearTray,
+  onSubmitTray = () => {},
   onQuickDecisionAction,
   quickConfirmAction,
   onQuickConfirmDismiss,
   onQuickConfirmAccept,
+  traySubmitLabel = null,
+  showTrayConfirm = false,
+  onTrayConfirmDismiss = () => {},
+  onTrayConfirmAccept = () => {},
   onLegacyAction,
   onLegacyRaiseAmountChange,
   t,
@@ -80,6 +92,8 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
   const checkActionButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const foldActionButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const quickConfirmPopoverRef = React.useRef<HTMLDivElement | null>(null);
+  const traySubmitButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const trayConfirmPopoverRef = React.useRef<HTMLDivElement | null>(null);
   const quickDecisionLockTimeoutRef = React.useRef<number | null>(null);
   const [isQuickDecisionTemporarilyLocked, setIsQuickDecisionTemporarilyLocked] =
     React.useState(isQuickDecisionAvailable);
@@ -92,7 +106,16 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
     preferredPlacement: "top",
     align: "start",
   });
+  const trayConfirmStyle = useAnchoredPopover({
+    isOpen: !isAutomationMode && showTrayConfirm,
+    anchorRef: traySubmitButtonRef,
+    popoverRef: trayConfirmPopoverRef,
+    preferredPlacement: "top",
+    align: "end",
+  });
   const isQuickDecisionLocked = isQuickDecisionAvailable && isQuickDecisionTemporarilyLocked;
+  const showDesktopSubmitTrayButton =
+    !isAutomationMode && isDesktopClickBetting && Boolean(traySubmitLabel);
 
   React.useLayoutEffect(() => {
     if (quickDecisionLockTimeoutRef.current !== null) {
@@ -228,16 +251,62 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
               </div>
             )}
 
-            <div className="chip-composer-dock__footer">
-              <button
-                ref={checkActionButtonRef}
-                onClick={() => onQuickDecisionAction("check")}
-                disabled={!canCheck || isQuickDecisionLocked}
-                data-testid={canCheck ? "action-check" : "action-check-disabled"}
-                className="chip-action chip-action--check"
+            {showDesktopSubmitTrayButton && showTrayConfirm && traySubmitLabel && (
+              <div
+                ref={trayConfirmPopoverRef}
+                role="dialog"
+                aria-label={t("game.confirmAction.title")}
+                data-testid="bet-action-confirm-popover"
+                className="action-quick-confirm-popover action-quick-confirm-popover--wide"
+                style={trayConfirmStyle}
               >
-                {t("common.check")}
-              </button>
+                <p className="text-xs font-semibold text-emerald-50">
+                  {t("game.quickConfirm.prompt", {
+                    action: traySubmitLabel,
+                  })}
+                </p>
+                <div className="mt-2 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={onTrayConfirmDismiss}
+                    data-testid="bet-action-confirm-cancel"
+                    className="rounded-lg border border-emerald-500/60 bg-emerald-900/35 px-2.5 py-1 text-[11px] font-semibold text-emerald-100 transition hover:bg-emerald-800/45"
+                  >
+                    {t("common.cancel")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onTrayConfirmAccept}
+                    data-testid="bet-action-confirm-accept"
+                    className="rounded-lg bg-amber-400 px-2.5 py-1 text-[11px] font-semibold text-amber-950 transition hover:bg-amber-300"
+                  >
+                    {t("common.confirm")}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            <div className="chip-composer-dock__footer">
+              {canCheck ? (
+                <button
+                  ref={checkActionButtonRef}
+                  onClick={() => onQuickDecisionAction("check")}
+                  disabled={!canCheck || isQuickDecisionLocked}
+                  data-testid={canCheck ? "action-check" : "action-check-disabled"}
+                  className="chip-action chip-action--check"
+                >
+                  {t("common.check")}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onLegacyAction("call")}
+                  data-testid="action-call"
+                  className="chip-action chip-action--call"
+                >
+                  {t("game.callWithAmount", { amount: callAmount })}
+                </button>
+              )}
               <button
                 ref={foldActionButtonRef}
                 onClick={() => onQuickDecisionAction("fold")}
@@ -247,6 +316,17 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
               >
                 {t("common.fold")}
               </button>
+              {showDesktopSubmitTrayButton && traySubmitLabel && (
+                <button
+                  ref={traySubmitButtonRef}
+                  type="button"
+                  onClick={onSubmitTray}
+                  data-testid="action-submit-tray"
+                  className="chip-action chip-action--review"
+                >
+                  {t("game.trayReviewAction", { action: traySubmitLabel })}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/poker-client/src/components/poker/turn-action-dock.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.tsx
@@ -305,8 +305,8 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
                 <button
                   ref={checkActionButtonRef}
                   onClick={() => onQuickDecisionAction("check")}
-                  disabled={!canCheck || isQuickDecisionLocked}
-                  data-testid={canCheck ? "action-check" : "action-check-disabled"}
+                  disabled={isQuickDecisionLocked}
+                  data-testid="action-check"
                   className="chip-action chip-action--check"
                 >
                   {t("common.check")}

--- a/poker-client/src/components/poker/turn-action-dock.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.tsx
@@ -152,25 +152,39 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
 
       <div className="chip-composer-dock__tray-row">
         <div className="chip-composer-dock__tray-panel">
-          <button
-            type="button"
-            onPointerDown={onDragStart}
-            onPointerMove={onDragMove}
-            onPointerUp={onDragEnd}
-            onPointerCancel={onDragEnd}
-            data-testid="chip-stack-draggable"
-            disabled={!canStartDrag}
-            className={`chip-stack chip-stack--hero ${isDragActive ? "chip-stack--dragging" : ""}`}
-          >
-            <span className="chip-stack__label">{t("game.tray")}</span>
-            <span
-              key={trayAmount}
-              className="chip-stack__value chip-stack__value--animated"
-              data-testid="tray-amount-value"
+          <div className="chip-composer-dock__tray-stack">
+            <button
+              type="button"
+              onPointerDown={onDragStart}
+              onPointerMove={onDragMove}
+              onPointerUp={onDragEnd}
+              onPointerCancel={onDragEnd}
+              data-testid="chip-stack-draggable"
+              disabled={!canStartDrag}
+              className={`chip-stack chip-stack--hero ${isDragActive ? "chip-stack--dragging" : ""}`}
             >
-              ${trayAmount}
-            </span>
-          </button>
+              <span className="chip-stack__label">{t("game.tray")}</span>
+              <span
+                key={trayAmount}
+                className="chip-stack__value chip-stack__value--animated"
+                data-testid="tray-amount-value"
+              >
+                ${trayAmount}
+              </span>
+            </button>
+
+            {showDesktopSubmitTrayButton && traySubmitLabel && (
+              <button
+                ref={traySubmitButtonRef}
+                type="button"
+                onClick={onSubmitTray}
+                data-testid="action-submit-tray"
+                className="chip-action chip-action--review chip-action--tray-review"
+              >
+                {t("game.trayReviewAction", { action: traySubmitLabel })}
+              </button>
+            )}
+          </div>
         </div>
 
         <div className="chip-composer-dock__control-panel">
@@ -316,17 +330,6 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
               >
                 {t("common.fold")}
               </button>
-              {showDesktopSubmitTrayButton && traySubmitLabel && (
-                <button
-                  ref={traySubmitButtonRef}
-                  type="button"
-                  onClick={onSubmitTray}
-                  data-testid="action-submit-tray"
-                  className="chip-action chip-action--review"
-                >
-                  {t("game.trayReviewAction", { action: traySubmitLabel })}
-                </button>
-              )}
             </div>
           </div>
         </div>

--- a/poker-client/src/components/poker/turn-action-dock.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.tsx
@@ -301,7 +301,7 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
                 <button
                   type="button"
                   onClick={() => onLegacyAction("call")}
-                  data-testid="action-call"
+                  data-testid={isAutomationMode ? "action-call-modern" : "action-call"}
                   className="chip-action chip-action--call"
                 >
                   {t("game.callWithAmount", { amount: callAmount })}

--- a/poker-client/src/components/poker/your-cards-flyout.tsx
+++ b/poker-client/src/components/poker/your-cards-flyout.tsx
@@ -8,6 +8,7 @@ type YourCardsFlyoutProps = {
   cards: PokerCard[];
   shouldAnchorToBottomBar: boolean;
   bottomBarHeight: number;
+  placement?: "left-edge" | "bottom" | "felt-right";
   title: string;
   emptyOpenStateLabel: string;
   emptyClosedStateLabel: string;
@@ -22,6 +23,7 @@ export const YourCardsFlyout: React.FC<YourCardsFlyoutProps> = ({
   cards,
   shouldAnchorToBottomBar,
   bottomBarHeight,
+  placement,
   title,
   emptyOpenStateLabel,
   emptyClosedStateLabel,
@@ -29,13 +31,22 @@ export const YourCardsFlyout: React.FC<YourCardsFlyoutProps> = ({
   showLabel,
   onToggle,
 }) => {
+  const resolvedPlacement =
+    placement ?? (shouldAnchorToBottomBar ? "bottom" : "left-edge");
+
   return (
     <section
       className={`your-cards-flyout ${
         isOpen ? "your-cards-flyout--open" : "your-cards-flyout--closed"
-      } ${shouldAnchorToBottomBar ? "your-cards-flyout--anchored" : "your-cards-flyout--bottom"}`}
+      } ${
+        resolvedPlacement === "felt-right"
+          ? "your-cards-flyout--felt-right"
+          : resolvedPlacement === "bottom"
+            ? "your-cards-flyout--bottom"
+            : "your-cards-flyout--left-edge"
+      } ${shouldAnchorToBottomBar ? "your-cards-flyout--anchored" : ""}`}
       style={
-        shouldAnchorToBottomBar
+        shouldAnchorToBottomBar && resolvedPlacement !== "felt-right"
           ? {
               bottom: `calc(0.55rem + env(safe-area-inset-bottom, 0px) + ${bottomBarHeight}px + 16px)`,
             }

--- a/poker-client/src/components/poker/your-cards-flyout.tsx
+++ b/poker-client/src/components/poker/your-cards-flyout.tsx
@@ -8,7 +8,7 @@ type YourCardsFlyoutProps = {
   cards: PokerCard[];
   shouldAnchorToBottomBar: boolean;
   bottomBarHeight: number;
-  placement?: "left-edge" | "bottom" | "felt-right";
+  placement?: "left-edge" | "bottom" | "felt-right" | "dock-left";
   title: string;
   emptyOpenStateLabel: string;
   emptyClosedStateLabel: string;
@@ -41,6 +41,8 @@ export const YourCardsFlyout: React.FC<YourCardsFlyoutProps> = ({
       } ${
         resolvedPlacement === "felt-right"
           ? "your-cards-flyout--felt-right"
+          : resolvedPlacement === "dock-left"
+            ? "your-cards-flyout--dock-left"
           : resolvedPlacement === "bottom"
             ? "your-cards-flyout--bottom"
             : "your-cards-flyout--left-edge"

--- a/poker-client/src/i18n/messages.ts
+++ b/poker-client/src/i18n/messages.ts
@@ -335,6 +335,7 @@ export const EN_MESSAGES = {
   "game.callWithAmount": "Call ${amount}",
   "game.allInWithAmount": "All-In ${amount}",
   "game.raise": "Raise",
+  "game.trayReviewAction": "Review {action}",
 
   "game.rankings.title": "Player Rankings",
   "game.rankings.sortedBy": "Sorted by net income (`stack - buy-in`).",
@@ -779,6 +780,7 @@ const ZH_HANS_MESSAGES: Record<MessageKey, string> = {
   "game.callWithAmount": "跟注 ${amount}",
   "game.allInWithAmount": "全下 ${amount}",
   "game.raise": "加注",
+  "game.trayReviewAction": "确认{action}",
 
   "game.rankings.title": "玩家排行榜",
   "game.rankings.sortedBy": "按净收益（`桌面筹码 - 买入`）排序。",

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -1446,6 +1446,19 @@ body {
   transform: translateY(-50%) translateX(calc(100% - 1.85rem));
 }
 
+.your-cards-flyout--dock-left {
+  position: relative;
+  left: auto;
+  top: auto;
+  width: clamp(10.4rem, 15vw, 12rem);
+  transform: none;
+  align-self: end;
+}
+
+.your-cards-flyout--dock-left.your-cards-flyout--closed {
+  transform: translateX(calc(-100% + 1.85rem));
+}
+
 .your-cards-flyout__panel {
   border: 1px solid rgba(6, 95, 70, 0.78);
   border-right: none;
@@ -1680,6 +1693,11 @@ body {
   flex: 0 0 8.9rem;
 }
 
+.chip-composer-dock__tray-stack {
+  display: grid;
+  gap: 0.32rem;
+}
+
 .chip-composer-dock__control-panel {
   min-width: 0;
   flex: 1;
@@ -1801,6 +1819,14 @@ body {
   border-color: rgba(16, 185, 129, 0.65);
   background: rgba(16, 185, 129, 0.22);
   color: #d1fae5;
+}
+
+.chip-action--tray-review {
+  width: 100%;
+  min-height: 2.45rem;
+  font-size: 0.76rem;
+  padding: 0.5rem 0.58rem;
+  border-radius: 0.72rem;
 }
 
 .chip-composer-dock__denoms {
@@ -2107,8 +2133,13 @@ body {
   right: auto;
   bottom: auto;
   width: auto;
-  height: min(52vh, 34rem);
-  max-height: min(52vh, 34rem);
+  height: 100%;
+  min-height: 20rem;
+  max-height: none;
+}
+
+.desktop-rail-live-audio > [data-testid="live-audio-panel"] {
+  margin: 0;
 }
 
 .desktop-side-panel {
@@ -2539,10 +2570,23 @@ body {
 
   .table-shell--desktop-two-column .desktop-right-rail {
     display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
     gap: 0.85rem;
     align-self: start;
     position: sticky;
     top: 1rem;
+    min-height: calc(100vh - 2rem);
+  }
+
+  .table-shell--desktop-two-column .desktop-dock-cluster {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: end;
+  }
+
+  .table-shell--desktop-two-column .desktop-dock-cluster .chip-composer-dock {
+    min-width: 0;
   }
 
   .table-shell--desktop-two-column .chip-composer-dock--desktop-main {

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -2585,6 +2585,15 @@ body {
     align-items: end;
   }
 
+  .table-shell--desktop-two-column .desktop-dock-cluster--cards-only {
+    min-height: 0;
+  }
+
+  .table-shell--desktop-two-column .desktop-dock-cluster__anchor {
+    min-width: 0;
+    min-height: 1px;
+  }
+
   .table-shell--desktop-two-column .desktop-dock-cluster .chip-composer-dock {
     min-width: 0;
   }

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -289,6 +289,23 @@ body {
     linear-gradient(170deg, #071d14 0%, #04130d 70%);
 }
 
+.table-shell__desktop-layout {
+  min-width: 0;
+}
+
+.table-shell__game-column {
+  min-width: 0;
+}
+
+.table-shell__board-stage {
+  position: relative;
+  min-width: 0;
+}
+
+.desktop-right-rail {
+  display: none;
+}
+
 .table-micro-hud {
   position: sticky;
   top: 0.5rem;
@@ -1400,6 +1417,10 @@ body {
   transform: translateY(var(--your-cards-flyout-y-shift)) translateX(calc(-100% + 1.85rem));
 }
 
+.your-cards-flyout--left-edge {
+  left: max(0px, env(safe-area-inset-left, 0px));
+}
+
 .your-cards-flyout--anchored {
   --your-cards-flyout-y-shift: 0%;
   top: auto;
@@ -1409,6 +1430,20 @@ body {
   --your-cards-flyout-y-shift: 0%;
   top: auto;
   bottom: calc(0.55rem + env(safe-area-inset-bottom, 0px));
+}
+
+.your-cards-flyout--felt-right {
+  position: absolute;
+  right: 0.75rem;
+  left: auto;
+  top: 50%;
+  width: clamp(10.4rem, 15vw, 12rem);
+  grid-template-columns: 1.85rem minmax(0, 1fr);
+  transform: translateY(-50%);
+}
+
+.your-cards-flyout--felt-right.your-cards-flyout--closed {
+  transform: translateY(-50%) translateX(calc(100% - 1.85rem));
 }
 
 .your-cards-flyout__panel {
@@ -1488,6 +1523,20 @@ body {
 
 .your-cards-flyout__toggle:active {
   transform: scale(0.97);
+}
+
+.your-cards-flyout--felt-right .your-cards-flyout__panel {
+  order: 2;
+  border-left: none;
+  border-right: 1px solid rgba(6, 95, 70, 0.78);
+  border-radius: 0 0.85rem 0.85rem 0;
+}
+
+.your-cards-flyout--felt-right .your-cards-flyout__toggle {
+  order: 1;
+  border-left: 1px solid rgba(16, 185, 129, 0.65);
+  border-right: none;
+  border-radius: 0.72rem 0 0 0.72rem;
 }
 
 .chip-composer-dock {
@@ -1686,7 +1735,7 @@ body {
 .chip-composer-dock__footer {
   margin-top: 0;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: 0.32rem;
 }
 
@@ -1746,6 +1795,12 @@ body {
   border-color: rgba(251, 146, 60, 0.64);
   background: rgba(194, 65, 12, 0.58);
   color: #ffedd5;
+}
+
+.chip-action--review {
+  border-color: rgba(16, 185, 129, 0.65);
+  background: rgba(16, 185, 129, 0.22);
+  color: #d1fae5;
 }
 
 .chip-composer-dock__denoms {
@@ -2044,6 +2099,78 @@ body {
   max-height: min(60vh, 34rem);
   overscroll-behavior: contain;
   z-index: 65;
+}
+
+.chat-panel-shell--desktop-rail {
+  position: static;
+  left: auto;
+  right: auto;
+  bottom: auto;
+  width: auto;
+  height: min(52vh, 34rem);
+  max-height: min(52vh, 34rem);
+}
+
+.desktop-side-panel {
+  padding: 0.85rem;
+}
+
+.desktop-side-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.desktop-side-panel__header h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 800;
+  color: #ecfdf5;
+}
+
+.desktop-side-panel__meta {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: rgba(209, 250, 229, 0.78);
+}
+
+.desktop-side-panel__stats {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.desktop-side-panel__stats strong {
+  display: block;
+  margin-top: 0.16rem;
+  font-size: 0.84rem;
+  color: #f0fdf4;
+}
+
+.desktop-side-panel__label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(167, 243, 208, 0.74);
+}
+
+.desktop-side-panel__actions {
+  margin-top: 0.85rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.desktop-side-panel__button {
+  border: 1px solid rgba(16, 185, 129, 0.42);
+  border-radius: 0.72rem;
+  background: rgba(4, 120, 87, 0.28);
+  color: #d1fae5;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.55rem 0.6rem;
 }
 
 .chat-panel {
@@ -2370,6 +2497,77 @@ body {
 }
 
 @media (min-width: 1024px) {
+  .table-shell--desktop-two-column {
+    padding: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .table-shell--desktop-two-column.table-shell--desktop-turn-dock {
+    padding-right: 1rem;
+  }
+
+  .table-shell--desktop-two-column .table-shell__desktop-layout {
+    max-width: min(96vw, 96rem);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) clamp(19rem, 24vw, 24rem);
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .table-shell--desktop-two-column .table-shell__game-column {
+    display: grid;
+    gap: 0.8rem;
+    align-content: start;
+  }
+
+  .table-shell--desktop-two-column .table-shell__board-stage {
+    padding-right: clamp(10rem, 16vw, 12.5rem);
+  }
+
+  .table-shell--desktop-two-column .table-micro-hud {
+    margin: 0;
+    max-width: none;
+    top: 0;
+  }
+
+  .table-shell--desktop-two-column .table-board-wrap {
+    margin-top: 0;
+    max-width: none;
+    padding: 0;
+  }
+
+  .table-shell--desktop-two-column .desktop-right-rail {
+    display: grid;
+    gap: 0.85rem;
+    align-self: start;
+    position: sticky;
+    top: 1rem;
+  }
+
+  .table-shell--desktop-two-column .chip-composer-dock--desktop-main {
+    position: relative;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    transform: none;
+    width: auto;
+    max-width: none;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .table-shell--desktop-two-column .chat-panel-shell--desktop-rail {
+    position: static;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    width: auto;
+    height: min(52vh, 34rem);
+    max-height: min(52vh, 34rem);
+    z-index: auto;
+  }
+
   .chat-panel-shell {
     left: auto;
     right: calc(0.85rem + env(safe-area-inset-right, 0px));

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -732,6 +732,42 @@ async function expectYourCardsFlyoutAboveActionArea(
   );
 }
 
+async function expectYourCardsFlyoutLeftOfActionArea(
+  page: Page,
+  actionAreaTestId: string,
+) {
+  await expect(
+    page.locator('[data-testid="your-cards-section"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator(`[data-testid="${actionAreaTestId}"]`),
+  ).toBeVisible();
+
+  const layout = await page.evaluate((targetActionAreaTestId) => {
+    const cardsPanel = document.querySelector<HTMLElement>(
+      '[data-testid="your-cards-section"]',
+    );
+    const actionArea = document.querySelector<HTMLElement>(
+      `[data-testid="${targetActionAreaTestId}"]`,
+    );
+    if (!cardsPanel || !actionArea) {
+      return null;
+    }
+
+    const cardsRect = cardsPanel.getBoundingClientRect();
+    const actionRect = actionArea.getBoundingClientRect();
+    return {
+      cardsRight: cardsRect.right,
+      actionLeft: actionRect.left,
+    };
+  }, actionAreaTestId);
+
+  expect(layout).not.toBeNull();
+  expect(layout?.cardsRight ?? Infinity).toBeLessThanOrEqual(
+    layout?.actionLeft ?? -Infinity,
+  );
+}
+
 async function getRoomSnapshot(page: Page) {
   return page.evaluate(() => {
     const room = (window as any).pokerDebug?.getRoom();
@@ -1822,9 +1858,13 @@ async function assertSeatCardsWithinTableBounds(
   ).toEqual([]);
 }
 
-async function dragTrayToPot(page: Page) {
+async function dragTrayToPot(
+  page: Page,
+  dropOffset: { x: number; y: number } = { x: 0, y: 0 },
+) {
   const tray = page.locator('[data-testid="chip-stack-draggable"]');
   const pot = page.locator('[data-testid="pot-drop-zone"]');
+  const trayAmount = page.locator('[data-testid="tray-amount-value"]');
   const trayBox = await tray.boundingBox();
   const potBox = await pot.boundingBox();
 
@@ -1838,11 +1878,13 @@ async function dragTrayToPot(page: Page) {
   );
   await page.mouse.down();
   await page.mouse.move(
-    potBox.x + potBox.width / 2,
-    potBox.y + potBox.height / 2,
+    potBox.x + potBox.width / 2 + potBox.width * dropOffset.x,
+    potBox.y + potBox.height / 2 + potBox.height * dropOffset.y,
     { steps: 12 },
   );
+  await expect(pot).toHaveClass(/pot-drop-zone--hover/);
   await page.mouse.up();
+  await expect(trayAmount).toContainText('$0');
 }
 
 async function assertSeatCardsDoNotOverlapBoardAndPot(
@@ -6690,7 +6732,11 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       await expect(
         alicePage.locator('[data-testid="desktop-right-rail"]'),
       ).toBeVisible();
+      await expect(alicePage.locator('[data-testid="live-audio-panel"]')).toBeVisible();
       await expect(alicePage.locator('[data-testid="chat-panel"]')).toBeVisible();
+      await expect(
+        alicePage.locator('[data-testid="desktop-side-status"]'),
+      ).toHaveCount(0);
       await expect(
         alicePage.locator('[data-testid="chat-preview-strip"]'),
       ).toHaveCount(0);
@@ -6706,8 +6752,14 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         const flyout = document.querySelector<HTMLElement>(
           '[data-testid="your-cards-flyout"]',
         );
+        const liveAudio = document.querySelector<HTMLElement>(
+          '[data-testid="live-audio-panel"]',
+        );
+        const chatPanel = document.querySelector<HTMLElement>(
+          '[data-testid="chat-panel"]',
+        );
 
-        if (!gameColumn || !rightRail || !felt || !flyout) {
+        if (!gameColumn || !rightRail || !felt || !flyout || !liveAudio || !chatPanel) {
           return null;
         }
 
@@ -6715,18 +6767,20 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         const railRect = rightRail.getBoundingClientRect();
         const feltRect = felt.getBoundingClientRect();
         const flyoutRect = flyout.getBoundingClientRect();
+        const liveAudioRect = liveAudio.getBoundingClientRect();
+        const chatRect = chatPanel.getBoundingClientRect();
 
         return {
           railStartsAfterGameColumn: railRect.left >= gameRect.right - 1,
-          cardsPinnedOnFeltRightHalf:
-            flyoutRect.left + flyoutRect.width / 2 >
-            feltRect.left + feltRect.width / 2,
+          liveAudioSitsAboveChat: liveAudioRect.bottom <= chatRect.top + 1,
+          cardsStayOutOfRightRail: flyoutRect.right <= railRect.left + 1,
         };
       });
 
       expect(layout).not.toBeNull();
       expect(layout?.railStartsAfterGameColumn).toBe(true);
-      expect(layout?.cardsPinnedOnFeltRightHalf).toBe(true);
+      expect(layout?.liveAudioSitsAboveChat).toBe(true);
+      expect(layout?.cardsStayOutOfRightRail).toBe(true);
     } finally {
       await teardownTwoPlayerSession(session);
     }
@@ -7617,6 +7671,60 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
 
       const submitTrayButton = bobPage.locator('[data-testid="action-submit-tray"]');
       await expect(submitTrayButton).toBeVisible();
+
+      const desktopActionLayout = await bobPage.evaluate(() => {
+        const submitButton = document.querySelector<HTMLElement>(
+          '[data-testid="action-submit-tray"]',
+        );
+        const trayButton = document.querySelector<HTMLElement>(
+          '[data-testid="chip-stack-draggable"]',
+        );
+        const foldButton = document.querySelector<HTMLElement>(
+          '[data-testid="action-fold"]',
+        );
+        const dock = document.querySelector<HTMLElement>(
+          '[data-testid="action-dock"]',
+        );
+        const cardsPanel = document.querySelector<HTMLElement>(
+          '[data-testid="your-cards-section"]',
+        );
+
+        if (!submitButton || !trayButton || !foldButton || !dock || !cardsPanel) {
+          return null;
+        }
+
+        const submitRect = submitButton.getBoundingClientRect();
+        const trayRect = trayButton.getBoundingClientRect();
+        const foldRect = foldButton.getBoundingClientRect();
+        const dockRect = dock.getBoundingClientRect();
+        const cardsRect = cardsPanel.getBoundingClientRect();
+        const submitCenterX = submitRect.left + submitRect.width / 2;
+        const submitCenterY = submitRect.top + submitRect.height / 2;
+        const trayCenterX = trayRect.left + trayRect.width / 2;
+        const trayCenterY = trayRect.top + trayRect.height / 2;
+        const foldCenterX = foldRect.left + foldRect.width / 2;
+        const foldCenterY = foldRect.top + foldRect.height / 2;
+
+        const distanceToTray = Math.hypot(
+          submitCenterX - trayCenterX,
+          submitCenterY - trayCenterY,
+        );
+        const distanceToFold = Math.hypot(
+          submitCenterX - foldCenterX,
+          submitCenterY - foldCenterY,
+        );
+
+        return {
+          submitNearTrayColumn: distanceToTray < distanceToFold,
+          cardsLeftOfDock: cardsRect.right <= dockRect.left + 1,
+        };
+      });
+
+      expect(desktopActionLayout).not.toBeNull();
+      expect(desktopActionLayout?.submitNearTrayColumn).toBe(true);
+      expect(desktopActionLayout?.cardsLeftOfDock).toBe(true);
+      await expectYourCardsFlyoutLeftOfActionArea(bobPage, 'action-dock');
+
       await submitTrayButton.click();
 
       await expect(
@@ -7635,7 +7743,7 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       const continuePreset = alicePage.locator('[data-testid="chip-load-continue"]');
       await expect(continuePreset).toBeVisible();
       await continuePreset.click();
-      await dragTrayToPot(alicePage);
+      await dragTrayToPot(alicePage, { x: -0.16, y: 0.18 });
       await waitForRound(bobPage, 'FLOP', 3);
     } finally {
       await teardownTwoPlayerSession(session);

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -1822,6 +1822,29 @@ async function assertSeatCardsWithinTableBounds(
   ).toEqual([]);
 }
 
+async function dragTrayToPot(page: Page) {
+  const tray = page.locator('[data-testid="chip-stack-draggable"]');
+  const pot = page.locator('[data-testid="pot-drop-zone"]');
+  const trayBox = await tray.boundingBox();
+  const potBox = await pot.boundingBox();
+
+  if (!trayBox || !potBox) {
+    throw new Error('Unable to drag tray to pot without bounding boxes');
+  }
+
+  await page.mouse.move(
+    trayBox.x + trayBox.width / 2,
+    trayBox.y + trayBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    potBox.x + potBox.width / 2,
+    potBox.y + potBox.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+}
+
 async function assertSeatCardsDoNotOverlapBoardAndPot(
   page: Page,
   label: string,
@@ -6644,6 +6667,71 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('@critical 8.8f: Desktop room uses a fixed game column and right rail', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      forceNonAutomationMode: true,
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 1440, height: 900 }),
+        bobPage.setViewportSize({ width: 1440, height: 900 }),
+      ]);
+
+      await startGameFromLobby(alicePage, bobPage);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      await expect(
+        alicePage.locator('[data-testid="desktop-game-column"]'),
+      ).toBeVisible();
+      await expect(
+        alicePage.locator('[data-testid="desktop-right-rail"]'),
+      ).toBeVisible();
+      await expect(alicePage.locator('[data-testid="chat-panel"]')).toBeVisible();
+      await expect(
+        alicePage.locator('[data-testid="chat-preview-strip"]'),
+      ).toHaveCount(0);
+
+      const layout = await alicePage.evaluate(() => {
+        const gameColumn = document.querySelector<HTMLElement>(
+          '[data-testid="desktop-game-column"]',
+        );
+        const rightRail = document.querySelector<HTMLElement>(
+          '[data-testid="desktop-right-rail"]',
+        );
+        const felt = document.querySelector<HTMLElement>('.felt-oval');
+        const flyout = document.querySelector<HTMLElement>(
+          '[data-testid="your-cards-flyout"]',
+        );
+
+        if (!gameColumn || !rightRail || !felt || !flyout) {
+          return null;
+        }
+
+        const gameRect = gameColumn.getBoundingClientRect();
+        const railRect = rightRail.getBoundingClientRect();
+        const feltRect = felt.getBoundingClientRect();
+        const flyoutRect = flyout.getBoundingClientRect();
+
+        return {
+          railStartsAfterGameColumn: railRect.left >= gameRect.right - 1,
+          cardsPinnedOnFeltRightHalf:
+            flyoutRect.left + flyoutRect.width / 2 >
+            feltRect.left + feltRect.width / 2,
+        };
+      });
+
+      expect(layout).not.toBeNull();
+      expect(layout?.railStartsAfterGameColumn).toBe(true);
+      expect(layout?.cardsPinnedOnFeltRightHalf).toBe(true);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('8.9: Rankings Modal and Card Toggle Reset on New Hand', async ({
     browser,
   }) => {
@@ -7496,6 +7584,58 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         alicePage.locator('[data-testid="action-quick-confirm-modal"]'),
       ).toHaveCount(0);
       await alicePage.click('[data-testid="action-quick-confirm-accept"]');
+      await waitForRound(bobPage, 'FLOP', 3);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
+  test('8.13d: Desktop bet confirmation is click-first while drag remains available', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      forceNonAutomationMode: true,
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 1440, height: 900 }),
+        bobPage.setViewportSize({ width: 1440, height: 900 }),
+      ]);
+
+      await startGameFromLobby(alicePage, bobPage);
+      await bobPage.waitForFunction(() => window.navigator.webdriver === false);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      const raisePreset = bobPage.locator('[data-testid="chip-load-raise"]');
+      await expect(raisePreset).toBeVisible();
+      await raisePreset.click();
+      await expect(
+        bobPage.locator('[data-testid="tray-amount-value"]'),
+      ).not.toContainText('$0');
+
+      const submitTrayButton = bobPage.locator('[data-testid="action-submit-tray"]');
+      await expect(submitTrayButton).toBeVisible();
+      await submitTrayButton.click();
+
+      await expect(
+        bobPage.locator('[data-testid="bet-action-confirm-popover"]'),
+      ).toBeVisible();
+      await bobPage.click('[data-testid="bet-action-confirm-cancel"]');
+      await expect(
+        bobPage.locator('[data-testid="bet-action-confirm-popover"]'),
+      ).toHaveCount(0);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      await submitTrayButton.click();
+      await bobPage.click('[data-testid="bet-action-confirm-accept"]');
+      await waitForPlayerTurn(alicePage, 'Alice');
+
+      const continuePreset = alicePage.locator('[data-testid="chip-load-continue"]');
+      await expect(continuePreset).toBeVisible();
+      await continuePreset.click();
+      await dragTrayToPot(alicePage);
       await waitForRound(bobPage, 'FLOP', 3);
     } finally {
       await teardownTwoPlayerSession(session);
@@ -8739,13 +8879,17 @@ test.describe('Poker E2E - Test Suite 10: Chat History & Concurrency', () => {
     }
   });
 
-  test('10.4: Clicking latest voice preview opens chat and starts that playback source', async ({
+  test('10.4: Mobile voice preview opens chat and starts that playback source', async ({
     browser,
   }) => {
     const session = await setupTwoPlayerSession(browser);
 
     try {
       const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 390, height: 844 }),
+        bobPage.setViewportSize({ width: 390, height: 844 }),
+      ]);
 
       await sendChatMessagesViaSocket(
         alicePage,
@@ -8775,13 +8919,17 @@ test.describe('Poker E2E - Test Suite 10: Chat History & Concurrency', () => {
     }
   });
 
-  test('10.5: Self messages do not create preview, dismiss/open both clear unread preview', async ({
+  test('10.5: Mobile hidden-chat preview dismiss/open both clear unread state', async ({
     browser,
   }) => {
     const session = await setupTwoPlayerSession(browser);
 
     try {
       const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 390, height: 844 }),
+        bobPage.setViewportSize({ width: 390, height: 844 }),
+      ]);
 
       await sendChatMessagesViaSocket(
         bobPage,

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -1861,12 +1861,14 @@ async function assertSeatCardsWithinTableBounds(
 async function dragTrayToPot(
   page: Page,
   dropOffset: { x: number; y: number } = { x: 0, y: 0 },
+  options: { steps?: number } = {},
 ) {
   const tray = page.locator('[data-testid="chip-stack-draggable"]');
   const pot = page.locator('[data-testid="pot-drop-zone"]');
   const trayAmount = page.locator('[data-testid="tray-amount-value"]');
   const trayBox = await tray.boundingBox();
   const potBox = await pot.boundingBox();
+  const steps = options.steps ?? 12;
 
   if (!trayBox || !potBox) {
     throw new Error('Unable to drag tray to pot without bounding boxes');
@@ -1880,7 +1882,7 @@ async function dragTrayToPot(
   await page.mouse.move(
     potBox.x + potBox.width / 2 + potBox.width * dropOffset.x,
     potBox.y + potBox.height / 2 + potBox.height * dropOffset.y,
-    { steps: 12 },
+    { steps },
   );
   await expect(pot).toHaveClass(/pot-drop-zone--hover/);
   await page.mouse.up();
@@ -6781,6 +6783,7 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       expect(layout?.railStartsAfterGameColumn).toBe(true);
       expect(layout?.liveAudioSitsAboveChat).toBe(true);
       expect(layout?.cardsStayOutOfRightRail).toBe(true);
+      await expectYourCardsFlyoutLeftOfActionArea(alicePage, 'desktop-dock-anchor');
     } finally {
       await teardownTwoPlayerSession(session);
     }
@@ -7745,6 +7748,58 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       await continuePreset.click();
       await dragTrayToPot(alicePage, { x: -0.16, y: 0.18 });
       await waitForRound(bobPage, 'FLOP', 3);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
+  test('8.13e: Desktop wide repeated drag-to-pot commits with quick releases', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      forceNonAutomationMode: true,
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 1728, height: 1117 }),
+        bobPage.setViewportSize({ width: 1728, height: 1117 }),
+      ]);
+
+      await startGameFromLobby(alicePage, bobPage);
+
+      await waitForPlayerTurn(bobPage, 'Bob');
+      await bobPage.click('[data-testid="chip-load-continue"]');
+      await dragTrayToPot(bobPage, { x: -0.14, y: 0.16 }, { steps: 2 });
+
+      await waitForPlayerTurn(alicePage, 'Alice');
+      await alicePage.click('[data-testid="action-check"]');
+      await expect(
+        alicePage.locator('[data-testid="action-quick-confirm-popover"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="action-quick-confirm-accept"]');
+
+      await waitForRound(alicePage, 'FLOP', 3);
+      await waitForPlayerTurn(bobPage, 'Bob');
+      const bobContinuePreset = bobPage.locator(
+        '[data-testid="chip-load-continue"]',
+      );
+      await expect(bobContinuePreset).toBeVisible();
+      await expect(bobContinuePreset).toBeEnabled();
+      await bobContinuePreset.click();
+      await dragTrayToPot(bobPage, { x: 0.12, y: -0.1 }, { steps: 2 });
+
+      await waitForPlayerTurn(alicePage, 'Alice');
+      const aliceContinuePreset = alicePage.locator(
+        '[data-testid="chip-load-continue"]',
+      );
+      await expect(aliceContinuePreset).toBeVisible();
+      await expect(aliceContinuePreset).toBeEnabled();
+      await aliceContinuePreset.click();
+      await dragTrayToPot(alicePage, { x: -0.08, y: 0.12 }, { steps: 2 });
+
+      await waitForPlayerTurn(bobPage, 'Bob');
     } finally {
       await teardownTwoPlayerSession(session);
     }


### PR DESCRIPTION
## Summary
- replace the desktop room overlay stack with an explicit two-column shell and always-visible right rail chat
- pin the player's hole cards to the felt's right edge on desktop and keep mobile/tablet chat preview behavior scoped to hidden-chat layouts
- make desktop bet/raise submission click-first with a compact confirm popover while keeping drag-to-pot available as a secondary shortcut

## Testing
- `pnpm --dir poker-client test`
- `pnpm --dir poker-client build`
- `PW_FRONTEND_PORT=5190 PW_BACKEND_PORT=3017 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep "8\.8f|8\.13b: Check/Fold Uses Popover Confirmation|8\.13c: Mobile Reveal Uses Operation Bar And Keeps Cards Above Actions|8\.13d: Desktop bet confirmation is click-first while drag remains available|10\.4: Mobile voice preview opens chat|10\.5: Mobile hidden-chat preview dismiss/open both clear unread state" --reporter=line`

Closes #115
