### PR TITLE
fix: support same-user device handoff during active games

### DIFF
--- a/poker-client/src/contexts/GameContext.tsx
+++ b/poker-client/src/contexts/GameContext.tsx
@@ -26,6 +26,7 @@ import type {
   ClientToServerEvents,
   ChatHistorySyncData,
   ChatMessage,
+  SessionDisplacedData,
   SendChatMessageData,
   VoiceMessagePayload,
 } from "poker-types";
@@ -466,6 +467,45 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
     writeLastPlayerEmoji(player.emoji);
   }, [player?.emoji]);
 
+  const clearActiveRoomState = useCallback(
+    ({
+      markJustLeft = false,
+      errorMessage = null,
+    }: {
+      markJustLeft?: boolean;
+      errorMessage?: string | null;
+    } = {}) => {
+      const currentRoomId = roomRef.current?.id;
+      if (currentRoomId) {
+        clearStoredFinalResult(currentRoomId);
+      }
+      if (typeof window !== "undefined" && markJustLeft) {
+        window.sessionStorage.setItem(JUST_LEFT_ROOM_STORAGE_KEY, "1");
+      }
+      clearStoredSession();
+      setRoom(null);
+      setPlayer(null);
+      setYourCards(null);
+      setLastHandResult(null);
+      setFinalGameResult(null);
+      setLastPlayerActionEvent(null);
+      setRevealedHandPlayerIds([]);
+      setShowdownDecisionState(null);
+      setRunCountDecisionState(null);
+      setRevealedShowdownHandsByPlayerId({});
+      setNextStreetRevealState(null);
+      setIsRecoveringSession(false);
+      setLastError(errorMessage);
+      setChatMessages([]);
+      setChatHasMore(false);
+      setChatNextBeforeSeq(null);
+      setChatLoadingHistory(false);
+      setChatUnreadCount(0);
+      setIsChatPanelOpenState(false);
+    },
+    [],
+  );
+
   const registerSocketStateListeners = useCallback(
     (socketInstance: NonNullable<typeof socket>) => {
       const socket = socketInstance;
@@ -583,10 +623,8 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
         setRunCountDecisionState(null);
         setRevealedShowdownHandsByPlayerId({});
         if (isInvalidReconnectReason(reason)) {
-          clearStoredSession();
-          setRoom(null);
-          setPlayer(null);
-          setYourCards(null);
+          clearActiveRoomState({ errorMessage: reason });
+          return;
         }
         setLastError(reason);
       });
@@ -676,6 +714,23 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
               }
             : prev,
         );
+      });
+
+      socket.on("SESSION_DISPLACED", (data: SessionDisplacedData) => {
+        const activeRoomId = roomRef.current?.id;
+        const activePlayerId = playerRef.current?.id;
+        if (
+          (activeRoomId && data.roomId !== activeRoomId) ||
+          (activePlayerId && data.playerId !== activePlayerId)
+        ) {
+          return;
+        }
+
+        reconnectInFlightRef.current = false;
+        clearActiveRoomState({
+          markJustLeft: true,
+          errorMessage: data.message || "This table was moved to another device.",
+        });
       });
 
       socket.on("PLAYER_PROFILE_UPDATED", (data) => {
@@ -1268,6 +1323,7 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
         socket.off("PLAYER_LEFT");
         socket.off("PLAYER_DISCONNECTED");
         socket.off("PLAYER_RECONNECTED");
+        socket.off("SESSION_DISPLACED");
         socket.off("PLAYER_PROFILE_UPDATED");
         socket.off("PLAYER_AUTO_FOLDED");
         socket.off("HOST_CHANGED");
@@ -1292,7 +1348,7 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
         socket.off("ERROR");
       };
     },
-    [],
+    [clearActiveRoomState],
   );
 
   useEffect(() => {
@@ -1333,14 +1389,8 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
             const reason = response.error || "Reconnect failed";
             setIsRecoveringSession(false);
             if (isInvalidReconnectReason(reason)) {
-              clearStoredSession();
-              setRoom(null);
-              setPlayer(null);
-              setYourCards(null);
-              setRunCountDecisionState(null);
-              setShowdownDecisionState(null);
-              setRevealedShowdownHandsByPlayerId({});
-              setNextStreetRevealState(null);
+              clearActiveRoomState({ errorMessage: reason });
+              return;
             }
             setLastError(reason);
           }
@@ -1371,7 +1421,7 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
         socket.off("disconnect", handleDisconnect);
       };
     },
-    [],
+    [clearActiveRoomState],
   );
 
   useEffect(() => {
@@ -1592,32 +1642,10 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
     if (currentRoomId) {
       clearStoredFinalResult(currentRoomId);
     }
-    if (typeof window !== "undefined") {
-      window.sessionStorage.setItem(JUST_LEFT_ROOM_STORAGE_KEY, "1");
-    }
-    clearStoredSession();
-    setRoom(null);
-    setPlayer(null);
-    setYourCards(null);
-    setLastHandResult(null);
-    setFinalGameResult(null);
-    setLastPlayerActionEvent(null);
-    setRevealedHandPlayerIds([]);
-    setShowdownDecisionState(null);
-    setRunCountDecisionState(null);
-    setRevealedShowdownHandsByPlayerId({});
-    setNextStreetRevealState(null);
-    setIsRecoveringSession(false);
-    setLastError(null);
-    setChatMessages([]);
-    setChatHasMore(false);
-    setChatNextBeforeSeq(null);
-    setChatLoadingHistory(false);
-    setChatUnreadCount(0);
-    setIsChatPanelOpenState(false);
+    clearActiveRoomState({ markJustLeft: true });
 
     return true;
-  }, [socket]);
+  }, [clearActiveRoomState, socket]);
 
   const requestRebuy = useCallback(
     (amount: number) => {

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -3824,12 +3824,21 @@ export class EventsGateway
       const displacedSocket =
         this.server.sockets.sockets.get(trackedSocketId) || null;
       if (displacedSocket) {
+        if (tracked.roomId !== roomId) {
+          this.logger.warn(
+            `Displacing socket ${trackedSocketId} for player ${playerId} with mismatched room ids: requested=${roomId}, tracked=${tracked.roomId}`,
+          );
+        }
+
         displacedSocket.emit('SESSION_DISPLACED', {
-          roomId,
+          roomId: tracked.roomId,
           playerId,
           message: 'This table was moved to another device.',
         });
         displacedSocket.leave(tracked.roomId);
+        if (tracked.roomId !== roomId) {
+          displacedSocket.leave(roomId);
+        }
       }
 
       this.socketToPlayer.delete(trackedSocketId);

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -711,6 +711,7 @@ export class EventsGateway
             authenticatedUser.id,
           );
 
+        this.displacePlayerSocket(room.id, player.id, client.id);
         client.join(room.id);
 
         this.trackPlayerSocket(client.id, room.id, player.id);
@@ -740,6 +741,11 @@ export class EventsGateway
           player: this.sanitizePlayer(player),
           room: this.sanitizeRoom(room),
         });
+        if (Array.isArray(player.cards) && player.cards.length > 0) {
+          client.emit('YOUR_CARDS', {
+            cards: player.cards,
+          } as YourCardsData);
+        }
         await this.emitInitialChatHistory(client, room.id);
 
         this.logger.log(
@@ -800,6 +806,7 @@ export class EventsGateway
           this.disconnectTimers.delete(player.id);
         }
 
+        this.displacePlayerSocket(data.roomId, player.id, client.id);
         client.join(data.roomId);
 
         this.trackPlayerSocket(client.id, data.roomId, player.id);
@@ -3802,6 +3809,31 @@ export class EventsGateway
 
   private async getRoom(roomId: string): Promise<any> {
     return await this.storageService.getRoom(roomId);
+  }
+
+  private displacePlayerSocket(
+    roomId: string,
+    playerId: string,
+    nextSocketId: string,
+  ): void {
+    for (const [trackedSocketId, tracked] of this.socketToPlayer.entries()) {
+      if (tracked.playerId !== playerId || trackedSocketId === nextSocketId) {
+        continue;
+      }
+
+      const displacedSocket =
+        this.server.sockets.sockets.get(trackedSocketId) || null;
+      if (displacedSocket) {
+        displacedSocket.emit('SESSION_DISPLACED', {
+          roomId,
+          playerId,
+          message: 'This table was moved to another device.',
+        });
+        displacedSocket.leave(tracked.roomId);
+      }
+
+      this.socketToPlayer.delete(trackedSocketId);
+    }
   }
 
   private trackPlayerSocket(

--- a/poker-server/src/game/game.service.ts
+++ b/poker-server/src/game/game.service.ts
@@ -171,11 +171,12 @@ export class GameService {
     }
     const existingPlayer = existingPlayerByUserId ?? existingPlayerByName;
     if (existingPlayer) {
+      const sameAuthenticatedUser =
+        Boolean(userId) && existingPlayerByUserId?.id === existingPlayer.id;
       if (!isDisconnected(existingPlayer) && existingPlayer.status !== 'left') {
-        if (existingPlayerByUserId?.id === existingPlayer.id) {
-          throw new Error('You are already in this room');
+        if (!sameAuthenticatedUser) {
+          throw new Error('Name already taken');
         }
-        throw new Error('Name already taken');
       }
 
       const priorStatus = existingPlayer.status;
@@ -568,6 +569,9 @@ export class GameService {
       return null;
     }
     if (player.status === 'left') {
+      return null;
+    }
+    if (userId && player.userId && player.userId !== userId) {
       return null;
     }
 

--- a/poker-server/src/game/game.service.ts
+++ b/poker-server/src/game/game.service.ts
@@ -571,8 +571,13 @@ export class GameService {
     if (player.status === 'left') {
       return null;
     }
-    if (userId && player.userId && player.userId !== userId) {
+    if (player.isRobot) {
       return null;
+    }
+    if (userId) {
+      if (!player.userId || player.userId !== userId) {
+        return null;
+      }
     }
 
     player.socketId = newSocketId;

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -7584,6 +7584,108 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.12g: Same User Can Move An Active Seat To Another Device', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser);
+    const takeoverContext = await browser.newContext();
+    const takeoverPage = await takeoverContext.newPage();
+
+    try {
+      const { alicePage, bobPage, roomCode } = session;
+      await startGameFromLobby(alicePage, bobPage);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      const bobBefore = await bobPage.evaluate(() => {
+        const room = (window as any).pokerDebug?.getRoom?.();
+        const player = (window as any).pokerDebug?.getPlayer?.();
+        const cards = (window as any).pokerDebug?.getCards?.();
+        return {
+          roomId: room?.id ?? null,
+          playerId: player?.id ?? null,
+          playerName: player?.name ?? null,
+          handNumber: room?.currentHand?.handNumber ?? null,
+          currentPlayerTurn: room?.currentHand?.currentPlayerTurn ?? null,
+          hasCards: Array.isArray(cards) && cards.length === 2,
+        };
+      });
+
+      expect(bobBefore.roomId).toBe(roomCode);
+      expect(bobBefore.playerName).toBe('Bob');
+      expect(bobBefore.playerId).toBeTruthy();
+      expect(bobBefore.currentPlayerTurn).toBe(bobBefore.playerId);
+      expect(bobBefore.hasCards).toBe(true);
+
+      const displacedPromise = captureNextSocketEvent(
+        bobPage,
+        'SESSION_DISPLACED',
+        10000,
+      );
+      const reconnectedPromise = captureNextSocketEvent(
+        alicePage,
+        'PLAYER_RECONNECTED',
+        10000,
+      );
+
+      await authenticateTestUser(takeoverPage, 'test2', {
+        displayName: 'Bob',
+        avatarEmoji: '🐻',
+      });
+      await takeoverPage.click('[data-testid="join-toggle-button"]');
+      await takeoverPage.fill('[data-testid="room-id-input"]', roomCode);
+      await takeoverPage.click('[data-testid="join-room-button"]');
+
+      const displacedEvent = await displacedPromise;
+      expect(displacedEvent.playerId).toBe(bobBefore.playerId);
+      expect(displacedEvent.roomId).toBe(roomCode);
+
+      const reconnectedEvent = await reconnectedPromise;
+      expect(reconnectedEvent.playerId).toBe(bobBefore.playerId);
+
+      await takeoverPage.waitForSelector('[data-testid="room-title"]');
+      await waitForHoleCards(takeoverPage);
+
+      const takeoverState = await takeoverPage.evaluate(() => {
+        const room = (window as any).pokerDebug?.getRoom?.();
+        const player = (window as any).pokerDebug?.getPlayer?.();
+        const cards = (window as any).pokerDebug?.getCards?.();
+        return {
+          roomId: room?.id ?? null,
+          playerId: player?.id ?? null,
+          playerName: player?.name ?? null,
+          handNumber: room?.currentHand?.handNumber ?? null,
+          currentPlayerTurn: room?.currentHand?.currentPlayerTurn ?? null,
+          hasCards: Array.isArray(cards) && cards.length === 2,
+        };
+      });
+
+      expect(takeoverState.roomId).toBe(bobBefore.roomId);
+      expect(takeoverState.playerId).toBe(bobBefore.playerId);
+      expect(takeoverState.playerName).toBe('Bob');
+      expect(takeoverState.handNumber).toBe(bobBefore.handNumber);
+      expect(takeoverState.currentPlayerTurn).toBe(bobBefore.playerId);
+      expect(takeoverState.hasCards).toBe(true);
+
+      await bobPage.waitForSelector('[data-testid="connection-status"]', {
+        timeout: 10000,
+      });
+      await expect(bobPage.locator('[data-testid="room-title"]')).toHaveCount(0);
+      await expect(
+        bobPage.locator('[data-testid="form-feedback"]'),
+      ).toContainText('moved to another device');
+
+      await takeoverPage.click('[data-testid="action-call"]');
+      await waitForPlayerTurn(alicePage, 'Alice');
+
+      await expect(bobPage.locator('[data-testid="room-title"]')).toHaveCount(0);
+    } finally {
+      await Promise.allSettled([
+        teardownTwoPlayerSession(session),
+        takeoverContext.close(),
+      ]);
+    }
+  });
+
   test('8.13: Street Reveal Hides Turn Dock And One Click Advances', async ({
     browser,
   }) => {

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -394,6 +394,29 @@ describe('EventsGateway membership mutation serialization', () => {
     expect((gateway as any).socketToPlayer.has('socket-bob-old')).toBe(false);
   });
 
+  it('uses tracked room metadata when displacing a stale socket mapping', () => {
+    const displacedClient = createClient('socket-bob-old', {
+      cookieToken: 'token-bob',
+    });
+    (gateway as any).socketToPlayer.set('socket-bob-old', {
+      roomId: 'ROOM2',
+      playerId: 'p-bob',
+    });
+    (gateway.server as any).sockets.sockets.set('socket-bob-old', displacedClient);
+
+    (gateway as any).displacePlayerSocket('ROOM1', 'p-bob', 'socket-bob-new');
+
+    expect(displacedClient.emit).toHaveBeenCalledWith(
+      'SESSION_DISPLACED',
+      expect.objectContaining({
+        roomId: 'ROOM2',
+        playerId: 'p-bob',
+      }),
+    );
+    expect(displacedClient.leave).toHaveBeenCalledWith('ROOM2');
+    expect((gateway as any).socketToPlayer.has('socket-bob-old')).toBe(false);
+  });
+
   it('allows leave between hands before the player readies the next hand', async () => {
     roomState.players[1].status = 'waiting';
     roomState.readyPhase = 'NEXT_HAND';

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -14,6 +14,7 @@ describe('EventsGateway membership mutation serialization', () => {
   let chatStorageService: any;
   let chatMediaStorageService: any;
   let authService: any;
+  let persistViaStaleSnapshot: (mutate: (draft: any) => void) => Promise<any>;
 
   const createPlayer = (params: {
     id: string;
@@ -92,7 +93,7 @@ describe('EventsGateway membership mutation serialization', () => {
       lastActivityAt: Date.now(),
     };
 
-    const persistViaStaleSnapshot = async (mutate: (draft: any) => void) => {
+    persistViaStaleSnapshot = async (mutate: (draft: any) => void) => {
       const snapshot = deepClone(roomState);
       await wait(25);
       mutate(snapshot);
@@ -329,6 +330,68 @@ describe('EventsGateway membership mutation serialization', () => {
     expect(reconnectClient.join).toHaveBeenCalledWith('ROOM1');
     expect(gameService.addPlayerToRoom).toHaveBeenCalledTimes(1);
     expect(gameService.updatePlayerSocket).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the old socket when the same authenticated user joins from another device', async () => {
+    roomState.players[1].status = 'connected';
+    roomState.players[1].connectionStatus = 'connected';
+
+    gameService.addPlayerToRoom.mockImplementationOnce(
+      async (roomId: string, socketId: string) => {
+        if (roomId !== 'ROOM1') {
+          throw new Error('Room not found');
+        }
+
+        let updatedPlayer: any = null;
+        const room = await persistViaStaleSnapshot((draft) => {
+          const player = draft.players.find((entry: any) => entry.id === 'p-bob');
+          if (!player) {
+            throw new Error('Player not found');
+          }
+
+          player.socketId = socketId;
+          player.connectionStatus = 'connected';
+          player.lastConnectedAt = Date.now();
+          draft.lastActivityAt = Date.now();
+          updatedPlayer = deepClone(player);
+        });
+
+        return { room, player: updatedPlayer, rejoined: true };
+      },
+    );
+
+    const displacedClient = createClient('socket-bob-old', {
+      cookieToken: 'token-bob',
+    });
+    const takeoverClient = createClient('socket-bob-new', {
+      cookieToken: 'token-bob',
+    });
+    (gateway as any).socketToPlayer.set('socket-bob-old', {
+      roomId: 'ROOM1',
+      playerId: 'p-bob',
+    });
+    (gateway.server as any).sockets.sockets.set('socket-bob-old', displacedClient);
+
+    const result = await gateway.handleJoinRoom(takeoverClient as any, {
+      roomId: 'ROOM1',
+      playerName: 'Bob',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(displacedClient.emit).toHaveBeenCalledWith(
+      'SESSION_DISPLACED',
+      expect.objectContaining({
+        roomId: 'ROOM1',
+        playerId: 'p-bob',
+      }),
+    );
+    expect(displacedClient.leave).toHaveBeenCalledWith('ROOM1');
+    expect(takeoverClient.join).toHaveBeenCalledWith('ROOM1');
+    expect((gateway as any).socketToPlayer.get('socket-bob-new')).toEqual({
+      roomId: 'ROOM1',
+      playerId: 'p-bob',
+    });
+    expect((gateway as any).socketToPlayer.has('socket-bob-old')).toBe(false);
   });
 
   it('allows leave between hands before the player readies the next hand', async () => {

--- a/poker-server/test/unit/game.service.spec.ts
+++ b/poker-server/test/unit/game.service.spec.ts
@@ -525,7 +525,7 @@ describe('GameService addPlayerToRoom', () => {
     expect(player.chips).toBe(425);
   });
 
-  it('reports that the same authenticated user is already in the room instead of a name collision', async () => {
+  it('allows the same authenticated user to take over an active seat from another device', async () => {
     const room = createRoom({
       gameState: 'IN_PROGRESS',
       players: [
@@ -557,15 +557,69 @@ describe('GameService addPlayerToRoom', () => {
     });
     storageService.getRoom.mockResolvedValue(room);
 
-    await expect(
-      gameService.addPlayerToRoom(
-        'ROOM01',
-        's-bob-new',
-        'Bob',
-        '🤠',
-        'user-bob',
-      ),
-    ).rejects.toThrow('You are already in this room');
+    const { player, rejoined } = await gameService.addPlayerToRoom(
+      'ROOM01',
+      's-bob-new',
+      'Bob',
+      '🤠',
+      'user-bob',
+    );
+
+    expect(rejoined).toBe(true);
+    expect(player.id).toBe('p-bob');
+    expect(player.socketId).toBe('s-bob-new');
+    expect(player.status).toBe('connected');
+    expect((player as any).connectionStatus).toBe('connected');
+    expect(player.chips).toBe(900);
+    expect((player as any).emoji).toBe('🤠');
+    expect(storageService.persistRoom).toHaveBeenCalledWith(
+      room,
+      expect.anything(),
+    );
+  });
+
+  it('rejects reconnecting a player seat owned by another authenticated user', async () => {
+    const room = createRoom({
+      gameState: 'IN_PROGRESS',
+      players: [
+        {
+          ...createPlayer({
+            id: 'p-alice',
+            socketId: 's-alice',
+            name: 'Alice',
+            position: 0,
+            chips: 1000,
+            totalBuyIn: 1000,
+            status: 'connected',
+          }),
+          userId: 'user-alice',
+        } as Player & { userId: string },
+        {
+          ...createPlayer({
+            id: 'p-bob',
+            socketId: 's-bob',
+            name: 'Bob',
+            position: 1,
+            chips: 900,
+            totalBuyIn: 1000,
+            status: 'connected',
+          }),
+          userId: 'user-bob',
+        } as Player & { userId: string },
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    const player = await gameService.updatePlayerSocket(
+      'ROOM01',
+      'Mallory',
+      's-mallory',
+      'p-bob',
+      'user-mallory',
+    );
+
+    expect(player).toBeNull();
+    expect(storageService.persistRoom).not.toHaveBeenCalled();
   });
 
   it('rejects reclaiming a left player seat by name when it belongs to another authenticated user', async () => {

--- a/poker-server/test/unit/game.service.spec.ts
+++ b/poker-server/test/unit/game.service.spec.ts
@@ -622,6 +622,50 @@ describe('GameService addPlayerToRoom', () => {
     expect(storageService.persistRoom).not.toHaveBeenCalled();
   });
 
+  it('rejects reconnecting a robot or legacy seat without a matching authenticated user id', async () => {
+    const room = createRoom({
+      gameState: 'IN_PROGRESS',
+      players: [
+        {
+          ...createPlayer({
+            id: 'p-alice',
+            socketId: 's-alice',
+            name: 'Alice',
+            position: 0,
+            chips: 1000,
+            totalBuyIn: 1000,
+            status: 'connected',
+          }),
+          userId: 'user-alice',
+        } as Player & { userId: string },
+        {
+          ...createPlayer({
+            id: 'p-robot',
+            socketId: 's-robot',
+            name: 'Robot',
+            position: 1,
+            chips: 900,
+            totalBuyIn: 1000,
+            status: 'connected',
+          }),
+          isRobot: true,
+        } as Player,
+      ],
+    });
+    storageService.getRoom.mockResolvedValue(room);
+
+    const player = await gameService.updatePlayerSocket(
+      'ROOM01',
+      'Mallory',
+      's-mallory',
+      'p-robot',
+      'user-mallory',
+    );
+
+    expect(player).toBeNull();
+    expect(storageService.persistRoom).not.toHaveBeenCalled();
+  });
+
   it('rejects reclaiming a left player seat by name when it belongs to another authenticated user', async () => {
     const room = createRoom({
       gameState: 'IN_PROGRESS',

--- a/poker-types/src/events.types.ts
+++ b/poker-types/src/events.types.ts
@@ -287,6 +287,12 @@ export interface PlayerReconnectedData {
   connectionStatus?: PlayerConnectionStatus;
 }
 
+export interface SessionDisplacedData {
+  roomId: string;
+  playerId: string;
+  message: string;
+}
+
 export interface PlayerProfileUpdatedData {
   playerId: string;
   playerName: string;
@@ -391,6 +397,7 @@ export interface ServerToClientEvents {
   NEW_HAND_STARTING: () => void;
   PLAYER_DISCONNECTED: (data: PlayerDisconnectedData) => void;
   PLAYER_RECONNECTED: (data: PlayerReconnectedData) => void;
+  SESSION_DISPLACED: (data: SessionDisplacedData) => void;
   PLAYER_PROFILE_UPDATED: (data: PlayerProfileUpdatedData) => void;
   PLAYER_AUTO_FOLDED: (data: PlayerAutoFoldedData) => void;
   HOST_CHANGED: (data: HostChangedData) => void;


### PR DESCRIPTION
Closes #125

## Summary
- allow the same authenticated user to reclaim their active seat from another device through the normal room join flow
- explicitly displace the superseded socket from the room and notify the old client so it clears in-room state while staying signed in
- keep auth multi-session behavior and scope the takeover contract to the targeted room only, without introducing a global one-active-room restriction across rooms
- harden reconnect ownership checks and extend unit plus Playwright coverage for device handoff and reconnect regressions

## Verification
- `pnpm --filter poker-types build`
- `pnpm --filter poker-client build`
- `pnpm --filter poker-server build`
- `pnpm --filter poker-server test:unit --runInBand --runTestsByPath test/unit/game.service.spec.ts test/unit/events.gateway.membership-race.spec.ts`
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --filter poker-server test:e2e:playwright --project comprehensive-e2e --workers=1 --grep "8\.12(:|a|b|c|d|e|f|g)" --reporter=line`

## Notes
- `JOIN_ROOM` is now the practical same-user device-switch entry point because a second device does not carry the original per-device `playerId` session needed for raw `RECONNECT`.
- This PR does not restrict the same authenticated account from joining a different room on another device; deferred tracking for that policy lives in #127.
- I did not wait on CI per repo instruction.
