### PR TITLE
fix: align desktop table width with top bar and center action HUD on table

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -2894,14 +2894,14 @@ const useGameRoomElement = () => {
     const seatNode = seatNodeRefs.current[actionCenterAlert.playerId];
     const alertNode = actionCenterAlertRef.current;
     const boardStageNode = boardStageRef.current;
-    if (!seatNode || !alertNode || !boardStageNode) {
+    if (!seatNode || !alertNode || (isDesktopSideDock && !boardStageNode)) {
       setActionPointerVector(null);
       return;
     }
 
     const seatRect = seatNode.getBoundingClientRect();
     const alertRect = alertNode.getBoundingClientRect();
-    const boardStageRect = boardStageNode.getBoundingClientRect();
+    const boardStageRect = boardStageNode?.getBoundingClientRect() ?? null;
 
     const centerX = alertRect.left + alertRect.width / 2;
     const centerY = alertRect.top + alertRect.height / 2;
@@ -2927,12 +2927,12 @@ const useGameRoomElement = () => {
     const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI);
 
     setActionPointerVector({
-      x: startX - boardStageRect.left,
-      y: startY - boardStageRect.top,
+      x: isDesktopSideDock && boardStageRect ? startX - boardStageRect.left : startX,
+      y: isDesktopSideDock && boardStageRect ? startY - boardStageRect.top : startY,
       angle,
       length: lineLength,
     });
-  }, [actionCenterAlert]);
+  }, [actionCenterAlert, isDesktopSideDock]);
 
   const triggerTurnAlert = useCallback(() => {
     if (turnAlertTimeoutRef.current) {
@@ -4219,6 +4219,7 @@ const useGameRoomElement = () => {
                 tone={actionCenterAlert.tone}
                 exiting={actionCenterAlert.exiting}
                 cardRef={actionCenterAlertRef}
+                anchorToStage={isDesktopSideDock}
               />
             )}
 

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -1811,6 +1811,7 @@ const useGameRoomElement = () => {
   const chatForcedByDesktopRef = useRef(false);
   const feltOvalRef = useRef<HTMLDivElement | null>(null);
   const boardCenterStackRef = useRef<HTMLDivElement | null>(null);
+  const boardStageRef = useRef<HTMLDivElement | null>(null);
   const communityLaneRef = useRef<HTMLDivElement | null>(null);
   const seatNodeRefs = useRef<Record<string, HTMLElement | null>>({});
   const actionAlertHideTimeoutRef = useRef<number | null>(null);
@@ -2892,13 +2893,15 @@ const useGameRoomElement = () => {
 
     const seatNode = seatNodeRefs.current[actionCenterAlert.playerId];
     const alertNode = actionCenterAlertRef.current;
-    if (!seatNode || !alertNode) {
+    const boardStageNode = boardStageRef.current;
+    if (!seatNode || !alertNode || !boardStageNode) {
       setActionPointerVector(null);
       return;
     }
 
     const seatRect = seatNode.getBoundingClientRect();
     const alertRect = alertNode.getBoundingClientRect();
+    const boardStageRect = boardStageNode.getBoundingClientRect();
 
     const centerX = alertRect.left + alertRect.width / 2;
     const centerY = alertRect.top + alertRect.height / 2;
@@ -2924,8 +2927,8 @@ const useGameRoomElement = () => {
     const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI);
 
     setActionPointerVector({
-      x: startX,
-      y: startY,
+      x: startX - boardStageRect.left,
+      y: startY - boardStageRect.top,
       angle,
       length: lineLength,
     });
@@ -4188,7 +4191,7 @@ const useGameRoomElement = () => {
             </div>
           )}
 
-          <div className="table-shell__board-stage">
+          <div ref={boardStageRef} className="table-shell__board-stage">
             {shouldRenderCardsInBoardStage && (
               <YourCardsFlyout
                 ref={mobileCardsFlyoutRef}

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -4182,16 +4182,17 @@ const useGameRoomElement = () => {
             </section>
           )}
 
-          {turnAlertToken !== null && (
-            <div aria-live="assertive" key={`turn-alert-${turnAlertToken}`}>
-              <TurnCenterAlert
-                eyebrow={t("game.turnAlert.eyebrow")}
-                title={t("game.turnAlert.title")}
-              />
-            </div>
-          )}
-
           <div ref={boardStageRef} className="table-shell__board-stage">
+            {turnAlertToken !== null && (
+              <div aria-live="assertive" key={`turn-alert-${turnAlertToken}`}>
+                <TurnCenterAlert
+                  eyebrow={t("game.turnAlert.eyebrow")}
+                  title={t("game.turnAlert.title")}
+                  anchorToStage={isDesktopSideDock}
+                />
+              </div>
+            )}
+
             {shouldRenderCardsInBoardStage && (
               <YourCardsFlyout
                 ref={mobileCardsFlyoutRef}

--- a/poker-client/src/components/poker/action-center-alert-overlay.tsx
+++ b/poker-client/src/components/poker/action-center-alert-overlay.tsx
@@ -28,10 +28,14 @@ export const ActionCenterAlertOverlay: React.FC<ActionCenterAlertOverlayProps> =
   cardRef,
 }) => {
   return (
-    <div className="action-center-alert-layer" aria-live="polite" data-testid="action-center-alert">
+    <div
+      className="action-center-alert-layer action-center-alert-layer--table-stage"
+      aria-live="polite"
+      data-testid="action-center-alert"
+    >
       {pointerVector && (
         <div
-          className="action-center-alert__arrow"
+          className="action-center-alert__arrow action-center-alert__arrow--table-stage"
           style={{
             left: `${pointerVector.x}px`,
             top: `${pointerVector.y}px`,
@@ -50,6 +54,8 @@ export const ActionCenterAlertOverlay: React.FC<ActionCenterAlertOverlayProps> =
           tone={tone}
           exiting={exiting}
           testId="action-center-alert-card"
+          wrapInLayer={false}
+          cardClassName="action-center-alert--table-stage"
         />
       </div>
     </div>

--- a/poker-client/src/components/poker/action-center-alert-overlay.tsx
+++ b/poker-client/src/components/poker/action-center-alert-overlay.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import { ActionCenterAlert } from "@/components/poker/action-center-alert";
 
 type ActionPointerVector = {
@@ -16,6 +17,7 @@ type ActionCenterAlertOverlayProps = {
   tone: "neutral" | "aggressive" | "fold" | "allin";
   exiting: boolean;
   cardRef: React.RefObject<HTMLDivElement | null>;
+  anchorToStage?: boolean;
 };
 
 export const ActionCenterAlertOverlay: React.FC<ActionCenterAlertOverlayProps> = ({
@@ -26,16 +28,23 @@ export const ActionCenterAlertOverlay: React.FC<ActionCenterAlertOverlayProps> =
   tone,
   exiting,
   cardRef,
+  anchorToStage = false,
 }) => {
   return (
     <div
-      className="action-center-alert-layer action-center-alert-layer--table-stage"
+      className={cn(
+        "action-center-alert-layer",
+        anchorToStage && "action-center-alert-layer--table-stage",
+      )}
       aria-live="polite"
       data-testid="action-center-alert"
     >
       {pointerVector && (
         <div
-          className="action-center-alert__arrow action-center-alert__arrow--table-stage"
+          className={cn(
+            "action-center-alert__arrow",
+            anchorToStage && "action-center-alert__arrow--table-stage",
+          )}
           style={{
             left: `${pointerVector.x}px`,
             top: `${pointerVector.y}px`,
@@ -54,8 +63,8 @@ export const ActionCenterAlertOverlay: React.FC<ActionCenterAlertOverlayProps> =
           tone={tone}
           exiting={exiting}
           testId="action-center-alert-card"
-          wrapInLayer={false}
-          cardClassName="action-center-alert--table-stage"
+          wrapInLayer={!anchorToStage}
+          cardClassName={anchorToStage ? "action-center-alert--table-stage" : undefined}
         />
       </div>
     </div>

--- a/poker-client/src/components/poker/action-center-alert.tsx
+++ b/poker-client/src/components/poker/action-center-alert.tsx
@@ -8,6 +8,8 @@ type ActionCenterAlertProps = {
   tone: "neutral" | "aggressive" | "fold" | "allin";
   exiting: boolean;
   testId?: string;
+  wrapInLayer?: boolean;
+  cardClassName?: string;
 };
 
 export const ActionCenterAlert: React.FC<ActionCenterAlertProps> = ({
@@ -17,21 +19,32 @@ export const ActionCenterAlert: React.FC<ActionCenterAlertProps> = ({
   tone,
   exiting,
   testId = "action-center-alert",
+  wrapInLayer = true,
+  cardClassName,
 }) => {
+  const alertCard = (
+    <div
+      className={cn(
+        "action-center-alert",
+        `action-center-alert--${tone}`,
+        exiting && "action-center-alert--exit",
+        cardClassName,
+      )}
+      data-testid={testId}
+    >
+      <span className="action-center-alert__eyebrow">{eyebrow}</span>
+      <span className="action-center-alert__actor">{actor}</span>
+      <span className="action-center-alert__title">{title}</span>
+    </div>
+  );
+
+  if (!wrapInLayer) {
+    return alertCard;
+  }
+
   return (
     <div className="action-center-alert-layer" data-testid={`${testId}-layer`}>
-      <div
-        className={cn(
-          "action-center-alert",
-          `action-center-alert--${tone}`,
-          exiting && "action-center-alert--exit",
-        )}
-        data-testid={testId}
-      >
-        <span className="action-center-alert__eyebrow">{eyebrow}</span>
-        <span className="action-center-alert__actor">{actor}</span>
-        <span className="action-center-alert__title">{title}</span>
-      </div>
+      {alertCard}
     </div>
   );
 };

--- a/poker-client/src/components/poker/turn-center-alert.tsx
+++ b/poker-client/src/components/poker/turn-center-alert.tsx
@@ -1,19 +1,33 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 
 type TurnCenterAlertProps = {
   eyebrow: string;
   title: string;
   testId?: string;
+  anchorToStage?: boolean;
 };
 
 export const TurnCenterAlert: React.FC<TurnCenterAlertProps> = ({
   eyebrow,
   title,
   testId = "turn-center-alert",
+  anchorToStage = false,
 }) => {
   return (
-    <div className="turn-center-alert-layer">
-      <div className="turn-center-alert" data-testid={testId}>
+    <div
+      className={cn(
+        "turn-center-alert-layer",
+        anchorToStage && "turn-center-alert-layer--table-stage",
+      )}
+    >
+      <div
+        className={cn(
+          "turn-center-alert",
+          anchorToStage && "turn-center-alert--table-stage",
+        )}
+        data-testid={testId}
+      >
         <span className="turn-center-alert__eyebrow">{eyebrow}</span>
         <span className="turn-center-alert__title">{title}</span>
       </div>

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -1377,6 +1377,11 @@ body {
   padding: 1rem;
 }
 
+.turn-center-alert-layer--table-stage {
+  position: absolute;
+  padding: 0;
+}
+
 .turn-center-alert {
   border-radius: 1rem;
   border: 1px solid rgba(252, 211, 77, 0.72);
@@ -1391,6 +1396,10 @@ body {
   text-align: center;
   padding: 0.95rem 1.2rem;
   animation: turnCenterAlert 1.65s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.turn-center-alert--table-stage {
+  min-width: min(100%, 22rem);
 }
 
 .turn-center-alert__eyebrow {

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -1254,6 +1254,10 @@ body {
   pointer-events: none;
 }
 
+.action-center-alert-layer--table-stage {
+  position: absolute;
+}
+
 .action-center-alert {
   position: fixed;
   left: 50%;
@@ -1272,6 +1276,10 @@ body {
   text-align: center;
   padding: 0.75rem 1rem 0.85rem;
   animation: actionCenterAlertIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.action-center-alert--table-stage {
+  position: absolute;
 }
 
 .action-center-alert--neutral {
@@ -1340,6 +1348,10 @@ body {
   background: linear-gradient(90deg, rgba(125, 211, 252, 0.95), rgba(56, 189, 248, 0.36));
   transform-origin: left center;
   box-shadow: 0 0 10px rgba(56, 189, 248, 0.56);
+}
+
+.action-center-alert__arrow--table-stage {
+  position: absolute;
 }
 
 .action-center-alert__arrow-head {
@@ -2731,10 +2743,6 @@ body {
     display: grid;
     gap: 0.8rem;
     align-content: start;
-  }
-
-  .table-shell--desktop-two-column .table-shell__board-stage {
-    padding-right: clamp(10rem, 16vw, 12.5rem);
   }
 
   .table-shell--desktop-two-column .table-micro-hud {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -7054,23 +7054,27 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
           '[data-testid="action-center-alert-card"]',
         );
         const arrow = document.querySelector<HTMLElement>('.action-center-alert__arrow');
+        const arrowHead = document.querySelector<HTMLElement>('.action-center-alert__arrow-head');
         const seatNodes = Array.from(
           document.querySelectorAll<HTMLElement>('[data-testid^="player-seat-"]'),
         );
         const aliceSeat = seatNodes.find((node) => node.textContent?.includes('Alice'));
 
-        if (!boardStage || !alert || !arrow || !aliceSeat) {
+        if (!boardStage || !alert || !arrow || !arrowHead || !aliceSeat) {
           return null;
         }
 
         const stageRect = boardStage.getBoundingClientRect();
         const alertRect = alert.getBoundingClientRect();
         const arrowRect = arrow.getBoundingClientRect();
+        const arrowHeadRect = arrowHead.getBoundingClientRect();
         const seatRect = aliceSeat.getBoundingClientRect();
         const alertCenterX = alertRect.left + alertRect.width / 2;
         const alertCenterY = alertRect.top + alertRect.height / 2;
         const arrowMidX = arrowRect.left + arrowRect.width / 2;
         const arrowMidY = arrowRect.top + arrowRect.height / 2;
+        const arrowHeadCenterX = arrowHeadRect.left + arrowHeadRect.width / 2;
+        const arrowHeadCenterY = arrowHeadRect.top + arrowHeadRect.height / 2;
         const seatCenterX = seatRect.left + seatRect.width / 2;
         const seatCenterY = seatRect.top + seatRect.height / 2;
         const stageCenterX = stageRect.left + stageRect.width / 2;
@@ -7078,6 +7082,14 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         const lineDeltaX = seatCenterX - alertCenterX;
         const lineDeltaY = seatCenterY - alertCenterY;
         const lineLength = Math.hypot(lineDeltaX, lineDeltaY);
+        const alertDistanceToSeat = Math.hypot(
+          seatCenterX - alertCenterX,
+          seatCenterY - alertCenterY,
+        );
+        const arrowHeadDistanceToSeat = Math.hypot(
+          seatCenterX - arrowHeadCenterX,
+          seatCenterY - arrowHeadCenterY,
+        );
         const arrowMidpointDistanceFromSeatLine =
           lineLength <= 1
             ? Number.POSITIVE_INFINITY
@@ -7092,6 +7104,8 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
           alertCenterDeltaFromStage: Math.abs(alertCenterX - stageCenterX),
           alertCenterDeltaFromViewport: Math.abs(alertCenterX - viewportCenterX),
           arrowMidpointDistanceFromSeatLine,
+          arrowHeadDistanceToSeat,
+          alertDistanceToSeat,
         };
       });
 
@@ -7099,6 +7113,9 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       expect(geometry?.alertCenterDeltaFromStage).toBeLessThanOrEqual(4);
       expect(geometry?.alertCenterDeltaFromViewport).toBeGreaterThan(40);
       expect(geometry?.arrowMidpointDistanceFromSeatLine).toBeLessThanOrEqual(8);
+      expect(geometry?.arrowHeadDistanceToSeat).toBeLessThan(
+        (geometry?.alertDistanceToSeat ?? 0) * 0.45,
+      );
     } finally {
       await teardownTwoPlayerSession(session);
     }

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -6958,6 +6958,152 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('@critical 8.8g: Desktop table board stays aligned with the top bar and game column', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      forceNonAutomationMode: true,
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 1440, height: 900 }),
+        bobPage.setViewportSize({ width: 1440, height: 900 }),
+      ]);
+
+      await startGameFromLobby(alicePage, bobPage);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      await expect(
+        alicePage.locator('[data-testid="desktop-game-column"]'),
+      ).toBeVisible();
+      await expect(alicePage.locator('.table-micro-hud')).toBeVisible();
+      await expect(
+        alicePage.locator('[data-testid="table-board-section"]'),
+      ).toBeVisible();
+
+      const alignment = await alicePage.evaluate(() => {
+        const gameColumn = document.querySelector<HTMLElement>(
+          '[data-testid="desktop-game-column"]',
+        );
+        const topBar = document.querySelector<HTMLElement>('.table-micro-hud');
+        const boardSection = document.querySelector<HTMLElement>(
+          '[data-testid="table-board-section"]',
+        );
+
+        if (!gameColumn || !topBar || !boardSection) {
+          return null;
+        }
+
+        const gameRect = gameColumn.getBoundingClientRect();
+        const topBarRect = topBar.getBoundingClientRect();
+        const boardRect = boardSection.getBoundingClientRect();
+
+        return {
+          boardLeftDeltaFromTopBar: Math.abs(boardRect.left - topBarRect.left),
+          boardRightDeltaFromTopBar: Math.abs(boardRect.right - topBarRect.right),
+          boardLeftDeltaFromGameColumn: Math.abs(boardRect.left - gameRect.left),
+          boardRightDeltaFromGameColumn: Math.abs(boardRect.right - gameRect.right),
+        };
+      });
+
+      expect(alignment).not.toBeNull();
+      expect(alignment?.boardLeftDeltaFromTopBar).toBeLessThanOrEqual(2);
+      expect(alignment?.boardRightDeltaFromTopBar).toBeLessThanOrEqual(2);
+      expect(alignment?.boardLeftDeltaFromGameColumn).toBeLessThanOrEqual(2);
+      expect(alignment?.boardRightDeltaFromGameColumn).toBeLessThanOrEqual(2);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
+  test('@critical 8.8h: Desktop action alert centers on the table stage and keeps aiming at the acting seat', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      forceNonAutomationMode: true,
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 1440, height: 900 }),
+        bobPage.setViewportSize({ width: 1440, height: 900 }),
+      ]);
+
+      await startGameFromLobby(alicePage, bobPage);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      await bobPage.evaluate(() => (window as any).pokerDebug.call());
+      await waitForPlayerTurn(alicePage, 'Alice');
+
+      const alertCard = alicePage.locator('[data-testid="action-center-alert-card"]');
+      await alicePage.click('[data-testid="action-check"]');
+      await expect(
+        alicePage.locator('[data-testid="action-quick-confirm-popover"]'),
+      ).toBeVisible();
+      await Promise.all([
+        expect(alertCard).toBeVisible(),
+        alicePage.click('[data-testid="action-quick-confirm-accept"]'),
+      ]);
+
+      const geometry = await alicePage.evaluate(() => {
+        const boardStage = document.querySelector<HTMLElement>('.table-shell__board-stage');
+        const alert = document.querySelector<HTMLElement>(
+          '[data-testid="action-center-alert-card"]',
+        );
+        const arrow = document.querySelector<HTMLElement>('.action-center-alert__arrow');
+        const seatNodes = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid^="player-seat-"]'),
+        );
+        const aliceSeat = seatNodes.find((node) => node.textContent?.includes('Alice'));
+
+        if (!boardStage || !alert || !arrow || !aliceSeat) {
+          return null;
+        }
+
+        const stageRect = boardStage.getBoundingClientRect();
+        const alertRect = alert.getBoundingClientRect();
+        const arrowRect = arrow.getBoundingClientRect();
+        const seatRect = aliceSeat.getBoundingClientRect();
+        const alertCenterX = alertRect.left + alertRect.width / 2;
+        const alertCenterY = alertRect.top + alertRect.height / 2;
+        const arrowMidX = arrowRect.left + arrowRect.width / 2;
+        const arrowMidY = arrowRect.top + arrowRect.height / 2;
+        const seatCenterX = seatRect.left + seatRect.width / 2;
+        const seatCenterY = seatRect.top + seatRect.height / 2;
+        const stageCenterX = stageRect.left + stageRect.width / 2;
+        const viewportCenterX = window.innerWidth / 2;
+        const lineDeltaX = seatCenterX - alertCenterX;
+        const lineDeltaY = seatCenterY - alertCenterY;
+        const lineLength = Math.hypot(lineDeltaX, lineDeltaY);
+        const arrowMidpointDistanceFromSeatLine =
+          lineLength <= 1
+            ? Number.POSITIVE_INFINITY
+            : Math.abs(
+                lineDeltaY * arrowMidX -
+                  lineDeltaX * arrowMidY +
+                  seatCenterX * alertCenterY -
+                  seatCenterY * alertCenterX,
+              ) / lineLength;
+
+        return {
+          alertCenterDeltaFromStage: Math.abs(alertCenterX - stageCenterX),
+          alertCenterDeltaFromViewport: Math.abs(alertCenterX - viewportCenterX),
+          arrowMidpointDistanceFromSeatLine,
+        };
+      });
+
+      expect(geometry).not.toBeNull();
+      expect(geometry?.alertCenterDeltaFromStage).toBeLessThanOrEqual(4);
+      expect(geometry?.alertCenterDeltaFromViewport).toBeGreaterThan(40);
+      expect(geometry?.arrowMidpointDistanceFromSeatLine).toBeLessThanOrEqual(8);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('8.9: Rankings Modal and Card Toggle Reset on New Hand', async ({
     browser,
   }) => {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -7121,6 +7121,57 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('@critical 8.8i: Desktop turn alert centers on the table stage instead of the viewport', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      forceNonAutomationMode: true,
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+      await Promise.all([
+        alicePage.setViewportSize({ width: 1440, height: 900 }),
+        bobPage.setViewportSize({ width: 1440, height: 900 }),
+      ]);
+
+      await startGameFromLobby(alicePage, bobPage);
+      await waitForPlayerTurn(bobPage, 'Bob');
+
+      await bobPage.evaluate(() => (window as any).pokerDebug.call());
+      await waitForPlayerTurn(alicePage, 'Alice');
+
+      const turnAlert = alicePage.locator('[data-testid="turn-center-alert"]');
+      await expect(turnAlert).toBeVisible();
+
+      const geometry = await alicePage.evaluate(() => {
+        const boardStage = document.querySelector<HTMLElement>('.table-shell__board-stage');
+        const alert = document.querySelector<HTMLElement>('[data-testid="turn-center-alert"]');
+
+        if (!boardStage || !alert) {
+          return null;
+        }
+
+        const stageRect = boardStage.getBoundingClientRect();
+        const alertRect = alert.getBoundingClientRect();
+        const alertCenterX = alertRect.left + alertRect.width / 2;
+        const stageCenterX = stageRect.left + stageRect.width / 2;
+        const viewportCenterX = window.innerWidth / 2;
+
+        return {
+          alertCenterDeltaFromStage: Math.abs(alertCenterX - stageCenterX),
+          alertCenterDeltaFromViewport: Math.abs(alertCenterX - viewportCenterX),
+        };
+      });
+
+      expect(geometry).not.toBeNull();
+      expect(geometry?.alertCenterDeltaFromStage).toBeLessThanOrEqual(4);
+      expect(geometry?.alertCenterDeltaFromViewport).toBeGreaterThan(40);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('8.9: Rankings Modal and Card Toggle Reset on New Hand', async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary

- Align the desktop board section with the sticky top bar in two-column mode
- Anchor the desktop action and turn alerts to the board stage and add desktop Playwright geometry coverage

## Linked Issue

Closes #134

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/134#issuecomment-4223632122

## Validation

- pnpm --dir poker-client build
- PW_FRONTEND_PORT=5192 PW_BACKEND_PORT=3019 pnpm --dir poker-server run test:e2e:playwright --project comprehensive-e2e --workers=1 --grep "8\.8f:|8\.8g:|8\.8h:|8\.8i:" --reporter=line
