### PR TITLE
fix: keep rankings usable on mobile and drop zero-activity robot rows

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -91,7 +91,9 @@ const hasMeaningfulRobotRankingActivity = (
   rankedPlayer.vpipHandsCount > 0 ||
   rankedPlayer.chips + (rankedPlayer.currentBet || 0) > 0;
 
-const shouldIncludeLiveRankingPlayer = (rankedPlayer: Player) =>
+// Keep this client-side predicate aligned with poker-types/src/rankings.ts.
+// The Vite client bundle does not cleanly consume that CommonJS runtime helper.
+const shouldDisplayLiveRankingPlayer = (rankedPlayer: Player) =>
   !rankedPlayer.isRobot ||
   rankedPlayer.status !== "left" ||
   hasMeaningfulRobotRankingActivity(rankedPlayer);
@@ -2541,7 +2543,7 @@ const useGameRoomElement = () => {
     () => {
       if (!room) return [];
       return [...room.players]
-        .filter((rankedPlayer) => shouldIncludeLiveRankingPlayer(rankedPlayer))
+        .filter((rankedPlayer) => shouldDisplayLiveRankingPlayer(rankedPlayer))
         .map((rankedPlayer) => {
           const tableStack = rankedPlayer.chips + (rankedPlayer.currentBet || 0);
           const net = tableStack - rankedPlayer.totalBuyIn;

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -74,6 +74,28 @@ const DESKTOP_SIDE_DOCK_QUERY = "(min-width: 1024px)";
 const COMPACT_MOBILE_DOCK_QUERY = "(max-width: 767px)";
 const CHAT_PREVIEW_TEXT_MAX_LENGTH = 80;
 
+const hasMeaningfulRobotRankingActivity = (
+  rankedPlayer: Pick<
+    Player,
+    | "chips"
+    | "currentBet"
+    | "totalBuyIn"
+    | "handsPlayedCount"
+    | "handsWonCount"
+    | "vpipHandsCount"
+  >,
+) =>
+  rankedPlayer.totalBuyIn > 0 ||
+  rankedPlayer.handsPlayedCount > 0 ||
+  rankedPlayer.handsWonCount > 0 ||
+  rankedPlayer.vpipHandsCount > 0 ||
+  rankedPlayer.chips + (rankedPlayer.currentBet || 0) > 0;
+
+const shouldIncludeLiveRankingPlayer = (rankedPlayer: Player) =>
+  !rankedPlayer.isRobot ||
+  rankedPlayer.status !== "left" ||
+  hasMeaningfulRobotRankingActivity(rankedPlayer);
+
 const truncatePreviewText = (text: string, maxLength: number): string => {
   if (text.length <= maxLength) {
     return text;
@@ -2519,6 +2541,7 @@ const useGameRoomElement = () => {
     () => {
       if (!room) return [];
       return [...room.players]
+        .filter((rankedPlayer) => shouldIncludeLiveRankingPlayer(rankedPlayer))
         .map((rankedPlayer) => {
           const tableStack = rankedPlayer.chips + (rankedPlayer.currentBet || 0);
           const net = tableStack - rankedPlayer.totalBuyIn;

--- a/poker-client/src/components/poker/rankings-modal.spec.ts
+++ b/poker-client/src/components/poker/rankings-modal.spec.ts
@@ -36,5 +36,8 @@ describe("RankingsModal", () => {
     expect(html).toContain("max-h-[calc(100vh-2rem)]");
     expect(html).toContain('data-testid="rankings-modal-scroll-region"');
     expect(html).toContain("overflow-y-auto");
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('aria-labelledby="rankings-modal-title"');
   });
 });

--- a/poker-client/src/components/poker/rankings-modal.spec.ts
+++ b/poker-client/src/components/poker/rankings-modal.spec.ts
@@ -1,0 +1,40 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { RankingsModal } from "./rankings-modal";
+import { storyTranslate } from "./storybook-fixtures";
+
+const basePlayerRankings = [
+  {
+    id: "p1",
+    name: "Kai",
+    tableStack: 1240,
+    totalBuyIn: 1000,
+    net: 240,
+  },
+  {
+    id: "p2",
+    name: "Maya",
+    tableStack: 980,
+    totalBuyIn: 1000,
+    net: -20,
+  },
+];
+
+describe("RankingsModal", () => {
+  it("renders a viewport-bounded panel with a dedicated scroll region for standings", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(RankingsModal, {
+        playerRankings: basePlayerRankings,
+        currentPlayerId: "p1",
+        onClose: vi.fn(),
+        t: storyTranslate,
+      }),
+    );
+
+    expect(html).toContain('data-testid="rankings-modal-panel"');
+    expect(html).toContain("max-h-[calc(100vh-2rem)]");
+    expect(html).toContain('data-testid="rankings-modal-scroll-region"');
+    expect(html).toContain("overflow-y-auto");
+  });
+});

--- a/poker-client/src/components/poker/rankings-modal.tsx
+++ b/poker-client/src/components/poker/rankings-modal.tsx
@@ -40,9 +40,14 @@ export const RankingsModal: React.FC<RankingsModalProps> = ({
     <section
       className="surface-panel flex max-h-[calc(100vh-2rem)] w-full max-w-2xl flex-col p-4 md:p-6"
       data-testid="rankings-modal-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="rankings-modal-title"
     >
       <div className="flex items-center justify-between gap-3">
-        <h3 className="text-lg font-black text-white">{t("game.rankings.title")}</h3>
+        <h3 id="rankings-modal-title" className="text-lg font-black text-white">
+          {t("game.rankings.title")}
+        </h3>
         <button
           onClick={onClose}
           data-testid="close-rankings-button"

--- a/poker-client/src/components/poker/rankings-modal.tsx
+++ b/poker-client/src/components/poker/rankings-modal.tsx
@@ -31,8 +31,16 @@ export const RankingsModal: React.FC<RankingsModalProps> = ({
   <div
     className="fixed inset-0 z-[75] flex items-center justify-center bg-emerald-950/85 p-4 backdrop-blur-sm"
     data-testid="rankings-modal"
+    onClick={(event) => {
+      if (event.target === event.currentTarget) {
+        onClose();
+      }
+    }}
   >
-    <div className="surface-panel w-full max-w-2xl p-4 md:p-6">
+    <section
+      className="surface-panel flex max-h-[calc(100vh-2rem)] w-full max-w-2xl flex-col p-4 md:p-6"
+      data-testid="rankings-modal-panel"
+    >
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-lg font-black text-white">{t("game.rankings.title")}</h3>
         <button
@@ -45,44 +53,49 @@ export const RankingsModal: React.FC<RankingsModalProps> = ({
       </div>
       <p className="mt-1 text-sm text-emerald-100/80">{t("game.rankings.sortedBy")}</p>
 
-      <div className="mt-4 overflow-x-auto rounded-xl border border-emerald-700/60">
-        <table className="min-w-full text-sm">
-          <thead className="bg-emerald-950/70 text-emerald-100/70">
-            <tr>
-              <th className="px-3 py-2 text-left font-semibold">{t("game.rankings.rank")}</th>
-              <th className="px-3 py-2 text-left font-semibold">{t("game.rankings.player")}</th>
-              <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.stack")}</th>
-              <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.buyIn")}</th>
-              <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.net")}</th>
-            </tr>
-          </thead>
-          <tbody className="bg-emerald-950/45">
-            {playerRankings.map((rankedPlayer, idx) => (
-              <tr
-                key={rankedPlayer.id}
-                className="border-t border-emerald-800/60 text-emerald-50"
-                data-testid={`ranking-row-${idx + 1}`}
-              >
-                <td className="px-3 py-2">#{idx + 1}</td>
-                <td className="px-3 py-2">
-                  {rankedPlayer.name}
-                  {rankedPlayer.id === currentPlayerId ? ` (${t("common.you")})` : ""}
-                  {rankedPlayer.status === "left" ? ` (${t("game.status.left")})` : ""}
-                </td>
-                <td className="px-3 py-2 text-right">${rankedPlayer.tableStack}</td>
-                <td className="px-3 py-2 text-right">${rankedPlayer.totalBuyIn}</td>
-                <td
-                  className={`px-3 py-2 text-right font-semibold ${
-                    rankedPlayer.net >= 0 ? "text-emerald-300" : "text-red-300"
-                  }`}
-                >
-                  {rankedPlayer.net >= 0 ? "+" : ""}${rankedPlayer.net}
-                </td>
+      <div
+        className="mt-4 min-h-0 flex-1 overflow-y-auto"
+        data-testid="rankings-modal-scroll-region"
+      >
+        <div className="overflow-x-auto rounded-xl border border-emerald-700/60">
+          <table className="min-w-full text-sm">
+            <thead className="bg-emerald-950/70 text-emerald-100/70">
+              <tr>
+                <th className="px-3 py-2 text-left font-semibold">{t("game.rankings.rank")}</th>
+                <th className="px-3 py-2 text-left font-semibold">{t("game.rankings.player")}</th>
+                <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.stack")}</th>
+                <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.buyIn")}</th>
+                <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.net")}</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="bg-emerald-950/45">
+              {playerRankings.map((rankedPlayer, idx) => (
+                <tr
+                  key={rankedPlayer.id}
+                  className="border-t border-emerald-800/60 text-emerald-50"
+                  data-testid={`ranking-row-${idx + 1}`}
+                >
+                  <td className="px-3 py-2">#{idx + 1}</td>
+                  <td className="px-3 py-2">
+                    {rankedPlayer.name}
+                    {rankedPlayer.id === currentPlayerId ? ` (${t("common.you")})` : ""}
+                    {rankedPlayer.status === "left" ? ` (${t("game.status.left")})` : ""}
+                  </td>
+                  <td className="px-3 py-2 text-right">${rankedPlayer.tableStack}</td>
+                  <td className="px-3 py-2 text-right">${rankedPlayer.totalBuyIn}</td>
+                  <td
+                    className={`px-3 py-2 text-right font-semibold ${
+                      rankedPlayer.net >= 0 ? "text-emerald-300" : "text-red-300"
+                    }`}
+                  >
+                    {rankedPlayer.net >= 0 ? "+" : ""}${rankedPlayer.net}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    </section>
   </div>
 );

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -80,6 +80,7 @@ import {
   HandResult,
   Room,
   RunCount,
+  shouldIncludeLiveRankingPlayer,
 } from 'poker-types';
 import { roomEvent, roomWrite } from '../storage/room-write.factory';
 
@@ -1256,6 +1257,7 @@ export class EventsGateway
       }
 
       const standings = [...room.players]
+        .filter((seatPlayer) => shouldIncludeLiveRankingPlayer(seatPlayer))
         .map((seatPlayer) => {
           const finalChips = seatPlayer.chips + (seatPlayer.currentBet || 0);
           const totalBuyIn = seatPlayer.totalBuyIn || 0;

--- a/poker-server/src/storage/json-storage.service.ts
+++ b/poker-server/src/storage/json-storage.service.ts
@@ -19,6 +19,7 @@ import {
   SavedGameParticipant,
   SavedGameReviewTargets,
   SavedGameSummary,
+  shouldIncludeArchivedRankingParticipant,
 } from 'poker-types';
 import { randomUUID } from 'crypto';
 import { IStorageService } from '../common/interfaces/storage.interface';
@@ -557,6 +558,9 @@ export class JsonStorageService
       const concludedAt = Number(room.lastActivityAt || Date.now());
       const participants = archivedPlayers
         .map((player) => this.toSavedGameParticipant(player))
+        .filter((participant) =>
+          shouldIncludeArchivedRankingParticipant(participant),
+        )
         .sort((left, right) => {
           if (right.finalChips !== left.finalChips) {
             return right.finalChips - left.finalChips;

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -6965,6 +6965,37 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
 
     try {
       const { alicePage, bobPage } = session;
+      await alicePage.click('[data-testid="add-robot-button"]');
+      await alicePage.waitForFunction(
+        () =>
+          ((window as any).pokerDebug?.getRoom?.()?.players ?? []).some(
+            (player: any) => player.isRobot && player.status !== 'left',
+          ),
+        { timeout: 10000 },
+      );
+      const robot = await alicePage.evaluate(() => {
+        const players = (window as any).pokerDebug?.getRoom?.()?.players ?? [];
+        const seat = players.find(
+          (player: any) => player.isRobot && player.status !== 'left',
+        );
+        return seat ? { id: seat.id, name: seat.name } : null;
+      });
+
+      expect(robot).not.toBeNull();
+      if (!robot) {
+        throw new Error('Robot was not added before rankings coverage');
+      }
+
+      await alicePage.click(`[data-testid="remove-robot-${robot.id}"]`);
+      await alicePage.waitForFunction(
+        (robotId) =>
+          !((window as any).pokerDebug?.getRoom?.()?.players ?? []).some(
+            (player: any) => player.id === robotId && player.status !== 'left',
+          ),
+        robot.id,
+        { timeout: 10000 },
+      );
+
       await startGameFromLobby(alicePage, bobPage);
 
       await alicePage.click('[data-testid="open-rankings-button"]');
@@ -6977,6 +7008,9 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       await expect(
         alicePage.locator('[data-testid="rankings-modal"]'),
       ).toContainText('Player Rankings');
+      await expect(
+        alicePage.locator('[data-testid="rankings-modal"]'),
+      ).not.toContainText(robot.name);
       await alicePage.click('[data-testid="close-rankings-button"]');
       await expect(
         alicePage.locator('[data-testid="rankings-modal"]'),

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -685,4 +685,111 @@ describe('EventsGateway membership mutation serialization', () => {
       (gateway as any).savedGameReviewService.scheduleArchiveReview,
     ).toHaveBeenCalledWith('ROOM1');
   });
+
+  it('excludes zero-activity left robots from end-game standings', async () => {
+    roomState.players = [
+      createPlayer({
+        id: 'p-host',
+        socketId: 'socket-host',
+        name: 'Host',
+        status: 'connected',
+        position: 0,
+        userId: 'user-alice',
+      }),
+      {
+        ...createPlayer({
+          id: 'p-bob',
+          socketId: '',
+          name: 'Bob',
+          status: 'left',
+          position: 1,
+          userId: 'user-bob',
+        }),
+        chips: 425,
+        totalBuyIn: 1000,
+      },
+      {
+        ...createPlayer({
+          id: 'p-robot-idle',
+          socketId: '',
+          name: 'Robot 1',
+          status: 'left',
+          position: 2,
+        }),
+        isRobot: true,
+        chips: 0,
+        totalBuyIn: 0,
+        handsPlayedCount: 0,
+        handsWonCount: 0,
+        vpipHandsCount: 0,
+      },
+    ];
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 0,
+      bigBlindPosition: 1,
+      pot: 0,
+      sidePots: [],
+      communityCards: [],
+      activePlayers: [],
+      bettingRound: 'SHOWDOWN',
+      currentBet: 0,
+      currentPlayerTurn: null,
+      roundActions: {},
+      lastRaiseSize: 10,
+      deck: [],
+      blindStructure: { smallBlind: 5, bigBlind: 10 },
+      allInPlayers: [],
+      winners: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      firstPlayerToAct: 'p-host',
+      lastAggressor: null,
+      pendingStreetRevealRound: null,
+      nextStreetReadyPlayerIds: [],
+      nextStreetRequiredPlayerIds: [],
+      revealedPlayerIds: [],
+      lastResult: {
+        winners: [],
+        winningHand: null,
+        potAmount: 0,
+        playerHands: [],
+      },
+    };
+
+    (gateway as any).socketToPlayer.set('socket-host', {
+      roomId: 'ROOM1',
+      playerId: 'p-host',
+    });
+    const hostClient = createClient('socket-host', {
+      cookieToken: 'token-alice',
+    });
+
+    const result = await gateway.handleEndGame(hostClient as any);
+
+    expect(result).toEqual({ success: true });
+    const gameEndedPayload = (gateway.server.to as jest.Mock).mock.results
+      .map((result) => result.value.emit.mock.calls)
+      .flat()
+      .find(([eventName]) => eventName === 'GAME_ENDED')?.[1];
+
+    expect(gameEndedPayload?.standings).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({
+          playerId: 'p-robot-idle',
+        }),
+      ]),
+    );
+    expect(gameEndedPayload?.standings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          playerId: 'p-host',
+        }),
+        expect.objectContaining({
+          playerId: 'p-bob',
+        }),
+      ]),
+    );
+  });
 });

--- a/poker-server/test/unit/json-storage.service.spec.ts
+++ b/poker-server/test/unit/json-storage.service.spec.ts
@@ -1419,6 +1419,87 @@ describe('JsonStorageService', () => {
       expect(unauthorizedDetail).toBeNull();
     });
 
+    it('omits zero-activity left robots from archived saved-game participants', async () => {
+      const roomId = 'ROOMARCHIVE-ROBOTS';
+      await seedCompletedHands(roomId);
+
+      const endedRoom = await service.getRoom(roomId);
+      if (!endedRoom) {
+        throw new Error('Expected ended room to exist');
+      }
+
+      endedRoom.players = endedRoom.players
+        .map((player) => {
+          if (player.id === 'alice') {
+            return { ...player, userId: 'user-alice' };
+          }
+          if (player.id === 'bob') {
+            return { ...player, userId: 'user-bob' };
+          }
+          return player;
+        })
+        .concat([
+          {
+            id: 'robot-idle',
+            socketId: '',
+            name: 'Robot 1',
+            emoji: '🤖',
+            isRobot: true,
+            chips: 0,
+            totalBuyIn: 0,
+            handsPlayedCount: 0,
+            handsWonCount: 0,
+            vpipHandsCount: 0,
+            position: 2,
+            status: 'left' as const,
+            cards: null,
+            currentBet: 0,
+            lastAction: null,
+            lastConnectedAt: Date.now(),
+          },
+        ]);
+      endedRoom.lastActivityAt = 2700;
+      await service.persistRoom(endedRoom);
+
+      const archiveEndedRoom = (
+        service as JsonStorageService & {
+          archiveEndedRoom?: (roomId: string) => Promise<{ archiveId: string } | null>;
+        }
+      ).archiveEndedRoom;
+      const getSavedGameDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameDetailForUser?: (
+            archiveId: string,
+            userId: string,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameDetailForUser;
+
+      expect(typeof archiveEndedRoom).toBe('function');
+      expect(typeof getSavedGameDetailForUser).toBe('function');
+      if (
+        typeof archiveEndedRoom !== 'function' ||
+        typeof getSavedGameDetailForUser !== 'function'
+      ) {
+        return;
+      }
+
+      const archived = await archiveEndedRoom.call(service, roomId);
+      const aliceDetail = await getSavedGameDetailForUser.call(
+        service,
+        archived!.archiveId,
+        'user-alice',
+      );
+
+      expect(aliceDetail?.participants).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            playerId: 'robot-idle',
+          }),
+        ]),
+      );
+    });
+
     it('merges a localized locale entry without dropping other locales or changing canonical updatedAt', async () => {
       const roomId = 'ROOMARCHIVE2';
       await seedCompletedHands(roomId);

--- a/poker-server/test/unit/rankings-participants.spec.ts
+++ b/poker-server/test/unit/rankings-participants.spec.ts
@@ -1,0 +1,49 @@
+import {
+  shouldIncludeArchivedRankingParticipant,
+  shouldIncludeLiveRankingPlayer,
+} from 'poker-types';
+
+describe('ranking participant filters', () => {
+  it('excludes robots that never bought in or played from live rankings', () => {
+    expect(
+      shouldIncludeLiveRankingPlayer({
+        isRobot: true,
+        status: 'left',
+        chips: 0,
+        currentBet: 0,
+        totalBuyIn: 0,
+        handsPlayedCount: 0,
+        handsWonCount: 0,
+        vpipHandsCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps robots that actually participated in the game', () => {
+    expect(
+      shouldIncludeLiveRankingPlayer({
+        isRobot: true,
+        status: 'left',
+        chips: 0,
+        currentBet: 0,
+        totalBuyIn: 1000,
+        handsPlayedCount: 1,
+        handsWonCount: 0,
+        vpipHandsCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('excludes zero-activity robots from archived standings as well', () => {
+    expect(
+      shouldIncludeArchivedRankingParticipant({
+        isRobot: true,
+        finalChips: 0,
+        totalBuyIn: 0,
+        handsPlayedCount: 0,
+        handsWonCount: 0,
+        vpipHandsCount: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/poker-types/src/index.ts
+++ b/poker-types/src/index.ts
@@ -8,3 +8,4 @@ export * from "./chat.types";
 export * from "./auth.types";
 export * from "./storage.types";
 export * from "./history.types";
+export * from "./rankings";

--- a/poker-types/src/rankings.ts
+++ b/poker-types/src/rankings.ts
@@ -1,0 +1,65 @@
+type NumericValue = number | null | undefined;
+
+type LiveRankingPlayerLike = {
+  isRobot?: boolean;
+  status?: string | null;
+  chips?: NumericValue;
+  currentBet?: NumericValue;
+  totalBuyIn?: NumericValue;
+  handsPlayedCount?: NumericValue;
+  handsWonCount?: NumericValue;
+  vpipHandsCount?: NumericValue;
+};
+
+type ArchivedRankingParticipantLike = {
+  isRobot?: boolean;
+  finalChips?: NumericValue;
+  totalBuyIn?: NumericValue;
+  handsPlayedCount?: NumericValue;
+  handsWonCount?: NumericValue;
+  vpipHandsCount?: NumericValue;
+};
+
+const toAmount = (value: NumericValue): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return value;
+};
+
+const hasTrackedActivity = (snapshot: {
+  totalBuyIn?: NumericValue;
+  handsPlayedCount?: NumericValue;
+  handsWonCount?: NumericValue;
+  vpipHandsCount?: NumericValue;
+}): boolean =>
+  toAmount(snapshot.totalBuyIn) > 0 ||
+  toAmount(snapshot.handsPlayedCount) > 0 ||
+  toAmount(snapshot.handsWonCount) > 0 ||
+  toAmount(snapshot.vpipHandsCount) > 0;
+
+export const shouldIncludeLiveRankingPlayer = (
+  player: LiveRankingPlayerLike,
+): boolean => {
+  if (!player.isRobot) {
+    return true;
+  }
+
+  const tableStack = toAmount(player.chips) + toAmount(player.currentBet);
+  if (player.status !== "left") {
+    return true;
+  }
+
+  return hasTrackedActivity(player) || tableStack > 0;
+};
+
+export const shouldIncludeArchivedRankingParticipant = (
+  participant: ArchivedRankingParticipantLike,
+): boolean => {
+  if (!participant.isRobot) {
+    return true;
+  }
+
+  return hasTrackedActivity(participant) || toAmount(participant.finalChips) > 0;
+};


### PR DESCRIPTION
## Summary

- rework the rankings modal into a viewport-bounded sheet with a dedicated scroll region and backdrop dismiss
- filter zero-activity removed robots out of live rankings, GAME_ENDED standings, and archived saved-game participants
- add component, unit, archive, and Playwright regression coverage for the rankings contract

## Linked Issue

Closes #136

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/136#issuecomment-4224002932

## Validation

- pnpm --dir poker-client test
- pnpm --filter poker-server test:unit --runInBand --runTestsByPath test/unit/rankings-participants.spec.ts test/unit/events.gateway.membership-race.spec.ts test/unit/json-storage.service.spec.ts
- pnpm --dir poker-client build
- pnpm --filter poker-server build
- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server run test:e2e:playwright --project comprehensive-e2e --workers=1 --grep '8\.9:' --reporter=line
