### PR TITLE
fix: keep the mobile chip keypad above Your Cards and use bet wording for opening action

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -4447,6 +4447,7 @@ const useGameRoomElement = () => {
               <ChipComposerDock ref={bottomBarOverlayRef} className={desktopMainDockClassName}>
                 <TurnActionDock
                   callAmount={callAmount}
+                  isOpeningBetAction={(currentHand?.currentBet ?? 0) <= 0}
                   minRaise={minRaise}
                   maxStack={maxStack}
                   trayAmount={trayAmount}

--- a/poker-client/src/components/poker/turn-action-dock.spec.ts
+++ b/poker-client/src/components/poker/turn-action-dock.spec.ts
@@ -6,6 +6,7 @@ import { storyTranslate } from "./storybook-fixtures";
 
 const baseProps = {
   callAmount: 40,
+  isOpeningBetAction: false,
   minRaise: 80,
   maxStack: 980,
   trayAmount: 120,
@@ -137,8 +138,8 @@ describe("TurnActionDock", () => {
 
     expect(html).not.toContain('data-testid="chip-custom-input"');
     expect(html).toContain('data-testid="chip-mobile-input-trigger"');
-    expect(html).toContain('data-testid="chip-mobile-input-popover"');
-    expect(html).toContain('data-testid="chip-mobile-popover-confirm"');
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).not.toContain('data-testid="chip-mobile-input-popover"');
   });
 
   it("collapses mobile-only extra raise presets into a raise popover trigger while keeping call visible", () => {
@@ -212,6 +213,7 @@ describe("TurnActionDock", () => {
       React.createElement(TurnActionDock, {
         ...baseProps,
         callAmount: 0,
+        isOpeningBetAction: true,
         isDesktopClickBetting: false,
         isCompactMobileLayout: true,
         trayPresetButtons: [
@@ -247,6 +249,47 @@ describe("TurnActionDock", () => {
     expect(html).toContain('data-testid="action-open-raise-menu"');
     expect(html).not.toContain('data-testid="preset-third-pot"');
     expect(html).not.toContain('data-testid="preset-half-pot"');
+  });
+
+  it("uses bet wording for the compact mobile menu opener when no bet is facing the player", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TurnActionDock, {
+        ...baseProps,
+        callAmount: 0,
+        isOpeningBetAction: true,
+        isDesktopClickBetting: false,
+        isCompactMobileLayout: true,
+        trayPresetButtons: [
+          {
+            key: "min-raise",
+            label: "Min Bet",
+            amount: 80,
+            testId: "chip-load-raise",
+            tone: "raise" as const,
+            enabled: true,
+          },
+          {
+            key: "third-pot",
+            label: "1/3 Pot",
+            amount: 120,
+            testId: "preset-third-pot",
+            tone: "raise" as const,
+            enabled: true,
+          },
+          {
+            key: "half-pot",
+            label: "1/2 Pot",
+            amount: 180,
+            testId: "preset-half-pot",
+            tone: "raise" as const,
+            enabled: true,
+          },
+        ],
+      }),
+    );
+
+    expect(html).toContain('data-testid="action-open-raise-menu"');
+    expect(html).toContain(">game.preset.bet<");
   });
 
   it("partitions compact mobile presets so only call or min-bet remain standalone", () => {

--- a/poker-client/src/components/poker/turn-action-dock.stories.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.stories.tsx
@@ -107,6 +107,7 @@ const meta = {
   tags: ["autodocs"],
   args: {
     callAmount: 40,
+    isOpeningBetAction: false,
     minRaise: 80,
     maxStack: 980,
     trayAmount: 120,
@@ -172,6 +173,7 @@ export const CheckAvailable: Story = {
   args: {
     canCheck: true,
     callAmount: 0,
+    isOpeningBetAction: true,
     trayPresetButtons: noBetPresets,
   },
 };

--- a/poker-client/src/components/poker/turn-action-dock.tsx
+++ b/poker-client/src/components/poker/turn-action-dock.tsx
@@ -17,6 +17,7 @@ type MobilePresetPartition = {
 
 type TurnActionDockProps = {
   callAmount: number;
+  isOpeningBetAction: boolean;
   minRaise: number;
   maxStack: number;
   trayAmount: number;
@@ -78,6 +79,7 @@ export const partitionCompactMobilePresets = (
 
 export const TurnActionDock: React.FC<TurnActionDockProps> = ({
   callAmount,
+  isOpeningBetAction,
   minRaise,
   maxStack,
   trayAmount,
@@ -145,6 +147,9 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
       : null;
   const hasCompactMobileRaiseMenu =
     isCompactMobileLayout && menuPresets.length > 0 && !directCompactMobileMenuPreset;
+  const compactRaiseMenuLabelKey: MessageKey =
+    isOpeningBetAction ? "game.preset.bet" : "game.raise";
+  const compactRaiseMenuLabel = t(compactRaiseMenuLabelKey);
   const quickConfirmAnchorRef =
     quickConfirmAction === "check" ? checkActionButtonRef : foldActionButtonRef;
   const quickConfirmStyle = useAnchoredPopover({
@@ -176,6 +181,7 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
     popoverRef: mobileChipPopoverRef,
     preferredPlacement: "top",
     align: "center",
+    strategy: "fixed",
   });
   const isQuickDecisionLocked = isQuickDecisionAvailable && isQuickDecisionTemporarilyLocked;
   const showDesktopSubmitTrayButton =
@@ -305,13 +311,13 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
       <div
         ref={raiseMenuPopoverRef}
         role="dialog"
-        aria-label={t("game.raise")}
+        aria-label={compactRaiseMenuLabel}
         data-testid="raise-action-popover"
         className="action-quick-confirm-popover action-quick-confirm-popover--wide chip-raise-menu-popover"
         style={raiseMenuStyle}
       >
         <div className="chip-raise-menu-popover__header">
-          <span className="chip-raise-menu-popover__title">{t("game.raise")}</span>
+          <span className="chip-raise-menu-popover__title">{compactRaiseMenuLabel}</span>
           <button
             type="button"
             onClick={() => setIsRaiseMenuOpen(false)}
@@ -325,6 +331,73 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
           {menuPresets.map((preset) =>
             renderPresetButton(preset, `chip-quick chip-quick--preset chip-quick--${preset.tone}`),
           )}
+        </div>
+      </div>
+    ) : null;
+  const mobileChipPopover =
+    !isDesktopClickBetting && showMobileChipPopover ? (
+      <div
+        ref={mobileChipPopoverRef}
+        role="dialog"
+        aria-label={t("game.mobileChipInput.title")}
+        data-testid="chip-mobile-input-popover"
+        className="action-quick-confirm-popover chip-mobile-input-popover"
+        style={mobileChipPopoverStyle}
+      >
+        <p className="chip-mobile-input-popover__title">{t("game.mobileChipInput.title")}</p>
+        <div
+          className="chip-mobile-input-popover__display"
+          data-testid="chip-mobile-input-display"
+        >
+          ${mobileChipDisplayValue}
+        </div>
+        <div className="chip-mobile-input-popover__keypad">
+          {["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"].map((digit) => (
+            <button
+              key={digit}
+              type="button"
+              onClick={() => onMobileChipDigit(digit)}
+              data-testid={`chip-mobile-digit-${digit}`}
+              className="chip-mobile-input-popover__key"
+            >
+              {digit}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={onMobileChipBackspace}
+            data-testid="chip-mobile-backspace"
+            aria-label={t("game.mobileChipInput.backspace")}
+            className="chip-mobile-input-popover__key chip-mobile-input-popover__key--wide"
+          >
+            {t("game.mobileChipInput.backspace")}
+          </button>
+        </div>
+        <div className="chip-mobile-input-popover__actions">
+          <button
+            type="button"
+            onClick={onMobileChipClearDraft}
+            data-testid="chip-mobile-popover-clear"
+            className="chip-mobile-input-popover__secondary"
+          >
+            {t("common.clear")}
+          </button>
+          <button
+            type="button"
+            onClick={onCloseMobileChipPopover}
+            data-testid="chip-mobile-popover-cancel"
+            className="chip-mobile-input-popover__secondary"
+          >
+            {t("common.cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={onMobileChipConfirm}
+            data-testid="chip-mobile-popover-confirm"
+            className="chip-mobile-input-popover__confirm"
+          >
+            {t("common.confirm")}
+          </button>
         </div>
       </div>
     ) : null;
@@ -447,7 +520,7 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
                       aria-expanded={isRaiseMenuOpen}
                       aria-haspopup="dialog"
                     >
-                      <span>{t("game.raise")}</span>
+                      <span>{compactRaiseMenuLabel}</span>
                     </button>
                   )}
                 </div>
@@ -544,73 +617,6 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
               </div>
             )}
 
-            {!isDesktopClickBetting && showMobileChipPopover && (
-              <div
-                ref={mobileChipPopoverRef}
-                role="dialog"
-                aria-label={t("game.mobileChipInput.title")}
-                data-testid="chip-mobile-input-popover"
-                className="action-quick-confirm-popover chip-mobile-input-popover"
-                style={mobileChipPopoverStyle}
-              >
-                <p className="chip-mobile-input-popover__title">{t("game.mobileChipInput.title")}</p>
-                <div
-                  className="chip-mobile-input-popover__display"
-                  data-testid="chip-mobile-input-display"
-                >
-                  ${mobileChipDisplayValue}
-                </div>
-                <div className="chip-mobile-input-popover__keypad">
-                  {["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"].map((digit) => (
-                    <button
-                      key={digit}
-                      type="button"
-                      onClick={() => onMobileChipDigit(digit)}
-                      data-testid={`chip-mobile-digit-${digit}`}
-                      className="chip-mobile-input-popover__key"
-                    >
-                      {digit}
-                    </button>
-                  ))}
-                  <button
-                    type="button"
-                    onClick={onMobileChipBackspace}
-                    data-testid="chip-mobile-backspace"
-                    aria-label={t("game.mobileChipInput.backspace")}
-                    className="chip-mobile-input-popover__key chip-mobile-input-popover__key--wide"
-                  >
-                    {t("game.mobileChipInput.backspace")}
-                  </button>
-                </div>
-                <div className="chip-mobile-input-popover__actions">
-                  <button
-                    type="button"
-                    onClick={onMobileChipClearDraft}
-                    data-testid="chip-mobile-popover-clear"
-                    className="chip-mobile-input-popover__secondary"
-                  >
-                    {t("common.clear")}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={onCloseMobileChipPopover}
-                    data-testid="chip-mobile-popover-cancel"
-                    className="chip-mobile-input-popover__secondary"
-                  >
-                    {t("common.cancel")}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={onMobileChipConfirm}
-                    data-testid="chip-mobile-popover-confirm"
-                    className="chip-mobile-input-popover__confirm"
-                  >
-                    {t("common.confirm")}
-                  </button>
-                </div>
-              </div>
-            )}
-
             <div className="chip-composer-dock__footer">
               <button
                 ref={checkActionButtonRef}
@@ -637,6 +643,9 @@ export const TurnActionDock: React.FC<TurnActionDockProps> = ({
 
       {raiseMenuPopover &&
         (typeof document !== "undefined" ? createPortal(raiseMenuPopover, document.body) : null)}
+
+      {mobileChipPopover &&
+        (typeof document !== "undefined" ? createPortal(mobileChipPopover, document.body) : null)}
 
       {isAutomationMode && (
         <div className="chip-composer-dock__legacy" data-testid="legacy-action-controls">

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -5630,8 +5630,10 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         };
       });
       expect(mobileChipOverlayCheck).not.toBeNull();
-      expect(mobileChipOverlayCheck?.hasOverlap).toBe(true);
-      expect(mobileChipOverlayCheck?.popoverOwnsTopElement).toBe(true);
+      expect(
+        (mobileChipOverlayCheck?.hasOverlap ?? false) === false ||
+          mobileChipOverlayCheck?.popoverOwnsTopElement === true,
+      ).toBe(true);
       await bobPage.click('[data-testid="chip-mobile-popover-clear"]');
       for (let index = 0; index < 6; index += 1) {
         await bobPage.click('[data-testid="chip-mobile-digit-9"]');

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -555,6 +555,7 @@ async function startGameFromLobby(
     [alicePage, bobPage],
     desiredStreetReveal,
   );
+  await closeChatPanelIfOpen(alicePage);
   await alicePage.click('[data-testid="start-game-button"]');
   await Promise.all([
     alicePage.waitForSelector('[data-testid="round-value"]', {
@@ -950,6 +951,23 @@ async function openChatPanel(page: Page) {
   await page.click('[data-testid="open-chat-button"]');
   await page.waitForSelector('[data-testid="chat-panel"]', {
     state: 'visible',
+    timeout: 5000,
+  });
+}
+
+async function closeChatPanelIfOpen(page: Page) {
+  const closeButton = page.locator('[data-testid="close-chat-button"]');
+  if ((await closeButton.count()) === 0) {
+    return;
+  }
+
+  if (!(await closeButton.isVisible())) {
+    return;
+  }
+
+  await closeButton.click();
+  await page.waitForSelector('[data-testid="chat-panel"]', {
+    state: 'hidden',
     timeout: 5000,
   });
 }
@@ -5484,7 +5502,15 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         alicePage.setViewportSize({ width: 390, height: 844 }),
         bobPage.setViewportSize({ width: 390, height: 844 }),
       ]);
+      await Promise.all([
+        closeChatPanelIfOpen(alicePage),
+        closeChatPanelIfOpen(bobPage),
+      ]);
       await startGameFromLobby(alicePage, bobPage);
+      await Promise.all([
+        closeChatPanelIfOpen(alicePage),
+        closeChatPanelIfOpen(bobPage),
+      ]);
 
       // Remove pre-flop call pressure so min raise becomes the opening amount.
       await waitForPlayerTurn(bobPage, 'Bob');
@@ -5505,6 +5531,30 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         '[data-testid="chip-load-continue"]',
       );
       await expect(continueButton).toHaveCount(0);
+      const openRaiseMenuButton = bobPage.locator(
+        '[data-testid="action-open-raise-menu"]',
+      );
+      await expect(openRaiseMenuButton).toBeVisible();
+      await expect(openRaiseMenuButton).toContainText('Bet');
+      await openRaiseMenuButton.click();
+      await expect(
+        bobPage.locator('[data-testid="raise-action-popover"]'),
+      ).toBeVisible();
+      await expect(
+        bobPage.locator('[data-testid="raise-action-popover"]'),
+      ).toHaveAttribute('aria-label', 'Bet');
+      await expect(
+        bobPage.locator('.chip-raise-menu-popover__title'),
+      ).toContainText('Bet');
+      await expect(
+        bobPage.locator(
+          '[data-testid="raise-action-popover"] [data-testid="chip-load-all-in"]',
+        ),
+      ).toBeVisible();
+      await openRaiseMenuButton.click();
+      await expect(
+        bobPage.locator('[data-testid="raise-action-popover"]'),
+      ).toHaveCount(0);
 
       const raiseButton = bobPage.locator('[data-testid="chip-load-raise"]');
       await expect(raiseButton).toBeVisible();
@@ -5512,7 +5562,6 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       const raiseButtonText = (await raiseButton.textContent()) ?? '';
       const raiseAmountMatch = raiseButtonText.match(/\$([0-9]+)/);
       expect(raiseAmountMatch).not.toBeNull();
-      await expect(bobPage.locator('[data-testid="chip-load-all-in"]')).toBeVisible();
       expect(
         await bobPage.locator('[data-testid="chip-load-3bet"]').count(),
       ).toBe(0);
@@ -5536,6 +5585,53 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       await expect(
         bobPage.locator('[data-testid="chip-mobile-input-popover"]'),
       ).toBeVisible();
+      await expect(
+        bobPage.locator('[data-testid="your-cards-section"]'),
+      ).toBeVisible();
+      const mobileChipOverlayCheck = await bobPage.evaluate(() => {
+        const popover = document.querySelector<HTMLElement>(
+          '[data-testid="chip-mobile-input-popover"]',
+        );
+        const cards = document.querySelector<HTMLElement>(
+          '[data-testid="your-cards-section"]',
+        );
+        if (!popover || !cards) {
+          return null;
+        }
+
+        const popoverRect = popover.getBoundingClientRect();
+        const cardsRect = cards.getBoundingClientRect();
+        const overlapLeft = Math.max(popoverRect.left, cardsRect.left);
+        const overlapRight = Math.min(popoverRect.right, cardsRect.right);
+        const overlapTop = Math.max(popoverRect.top, cardsRect.top);
+        const overlapBottom = Math.min(popoverRect.bottom, cardsRect.bottom);
+        const hasOverlap =
+          overlapLeft < overlapRight && overlapTop < overlapBottom;
+        const sampleX = hasOverlap
+          ? overlapLeft + (overlapRight - overlapLeft) / 2
+          : popoverRect.left + Math.min(popoverRect.width * 0.2, 40);
+        const sampleY = hasOverlap
+          ? overlapTop + (overlapBottom - overlapTop) / 2
+          : popoverRect.top + Math.min(popoverRect.height * 0.2, 40);
+        const topElement = document.elementFromPoint(sampleX, sampleY);
+
+        return {
+          hasOverlap,
+          topTestId:
+            topElement instanceof HTMLElement
+              ? topElement.dataset.testid ??
+                topElement.closest<HTMLElement>('[data-testid]')?.dataset
+                  .testid ??
+                null
+              : null,
+          popoverOwnsTopElement:
+            topElement instanceof HTMLElement &&
+            (topElement === popover || popover.contains(topElement)),
+        };
+      });
+      expect(mobileChipOverlayCheck).not.toBeNull();
+      expect(mobileChipOverlayCheck?.hasOverlap).toBe(true);
+      expect(mobileChipOverlayCheck?.popoverOwnsTopElement).toBe(true);
       await bobPage.click('[data-testid="chip-mobile-popover-clear"]');
       for (let index = 0; index < 6; index += 1) {
         await bobPage.click('[data-testid="chip-mobile-digit-9"]');


### PR DESCRIPTION
## Summary

- portal the mobile custom chip keypad to `document.body` with fixed anchored positioning so it stays above `Your Cards`
- switch the compact mobile raise-menu opener/title to `Bet` only for true unopened action, using authoritative hand state instead of `callAmount`
- extend targeted dock coverage in client specs, stories, and Playwright `8.2c`, plus harden that scenario against persisted mobile chat-panel state

## Linked Issue

Closes #139

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/139#issuecomment-4224367383

## Validation

- `pnpm --dir poker-client test -- --run src/components/poker/turn-action-dock.spec.ts src/components/poker/turn-action-presets.spec.ts`
- `pnpm --dir poker-client build`
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server run test:e2e:playwright --project comprehensive-e2e --workers=1 --grep "8\.2c:" --reporter=line`
