### PR TITLE
fix: auto-archive abandoned games after disconnect timeout

### DIFF
--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -302,6 +302,7 @@ export class EventsGateway
       clearTimeout(timer);
     }
     this.runCountDecisionTimers.clear();
+    this.abandonedRoomSince.clear();
   }
 
   private extractSocketToken(client: Socket): string {
@@ -401,6 +402,16 @@ export class EventsGateway
 
     if (!this.abandonedRoomSince.has(room.id)) {
       this.abandonedRoomSince.set(room.id, Date.now());
+    }
+  }
+
+  private cancelPendingDisconnectTimersForRoom(room: any): void {
+    for (const player of room?.players ?? []) {
+      const timer = this.disconnectTimers.get(player.id);
+      if (timer) {
+        clearTimeout(timer);
+        this.disconnectTimers.delete(player.id);
+      }
     }
   }
 
@@ -525,6 +536,7 @@ export class EventsGateway
     };
 
     this.abandonedRoomSince.delete(room.id);
+    this.cancelPendingDisconnectTimersForRoom(room);
     this.server.to(room.id).emit('GAME_ENDED', gameEndedData);
   }
 
@@ -3732,8 +3744,17 @@ export class EventsGateway
   private async handleDisconnectTimeout(roomId: string, playerId: string) {
     try {
       await this.runRoomActionSequentially(roomId, async () => {
+        const timer = this.disconnectTimers.get(playerId);
+        if (timer) {
+          clearTimeout(timer);
+          this.disconnectTimers.delete(playerId);
+        }
+
         const room = await this.getRoom(roomId);
         if (!room) {
+          return;
+        }
+        if (room.gameState === 'ENDED') {
           return;
         }
 

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -140,6 +140,7 @@ export class EventsGateway
 
   private readonly logger = new Logger(EventsGateway.name);
   private disconnectTimers: Map<string, NodeJS.Timeout> = new Map();
+  private abandonedRoomSince: Map<string, number> = new Map();
   private runCountDecisionTimers: Map<string, NodeJS.Timeout> = new Map();
   private socketToPlayer: Map<string, { roomId: string; playerId: string }> =
     new Map();
@@ -368,6 +369,188 @@ export class EventsGateway
       .filter((player: any) => player.status !== 'left')
       .filter((player: any) => !this.isPlayerDisconnected(player))
       .map((player: any) => player.id);
+  }
+
+  private hasConnectedHumanPlayers(room: any): boolean {
+    return (room?.players ?? []).some(
+      (player: any) =>
+        !player?.isRobot &&
+        player?.status !== 'left' &&
+        !this.isPlayerDisconnected(player),
+    );
+  }
+
+  private isSafeToFinalizeRoom(room: any): boolean {
+    return Boolean(
+      room?.gameState === 'IN_PROGRESS' &&
+        room?.currentHand &&
+        room.currentHand.currentPlayerTurn === null &&
+        room.currentHand.lastResult,
+    );
+  }
+
+  private updateAbandonedRoomTracking(room: any): void {
+    if (!room?.id) {
+      return;
+    }
+
+    if (room.gameState !== 'IN_PROGRESS' || this.hasConnectedHumanPlayers(room)) {
+      this.abandonedRoomSince.delete(room.id);
+      return;
+    }
+
+    if (!this.abandonedRoomSince.has(room.id)) {
+      this.abandonedRoomSince.set(room.id, Date.now());
+    }
+  }
+
+  private async finalizeRoomAndArchive(
+    room: Room,
+    actorPlayerId?: string,
+  ): Promise<void> {
+    const standings = [...room.players]
+      .filter((seatPlayer) => shouldIncludeLiveRankingPlayer(seatPlayer))
+      .map((seatPlayer) => {
+        const finalChips = seatPlayer.chips + (seatPlayer.currentBet || 0);
+        const totalBuyIn = seatPlayer.totalBuyIn || 0;
+        return {
+          playerId: seatPlayer.id,
+          playerName: seatPlayer.name,
+          finalChips,
+          totalBuyIn,
+          profit: finalChips - totalBuyIn,
+          handsPlayedCount: seatPlayer.handsPlayedCount ?? 0,
+          handsWonCount: seatPlayer.handsWonCount ?? 0,
+          vpipHandsCount: seatPlayer.vpipHandsCount ?? 0,
+        };
+      })
+      .sort((a, b) => {
+        if (b.finalChips !== a.finalChips) return b.finalChips - a.finalChips;
+        if (b.profit !== a.profit) return b.profit - a.profit;
+        return a.playerName.localeCompare(b.playerName);
+      });
+
+    const totalPlayers = standings.length;
+    const totalBuyIn = standings.reduce(
+      (sum, entry) => sum + entry.totalBuyIn,
+      0,
+    );
+    const totalChipsInPlay = standings.reduce(
+      (sum, entry) => sum + entry.finalChips,
+      0,
+    );
+    const profitablePlayers = standings.filter(
+      (entry) => entry.profit > 0,
+    ).length;
+    const averageFinalStack =
+      totalPlayers > 0 ? Math.round(totalChipsInPlay / totalPlayers) : 0;
+    const handsPlayed = room.currentHand?.handNumber ?? 0;
+    const chipLeader = standings[0]
+      ? {
+          playerId: standings[0].playerId,
+          playerName: standings[0].playerName,
+          amount: standings[0].finalChips,
+        }
+      : null;
+
+    const biggestWinner = standings
+      .filter((entry) => entry.profit > 0)
+      .sort((a, b) => b.profit - a.profit)[0];
+    const biggestLoss = standings
+      .filter((entry) => entry.profit < 0)
+      .sort((a, b) => a.profit - b.profit)[0];
+
+    room.gameState = 'ENDED';
+    room.currentHand = null;
+    room.readyPhase = null;
+    room.readyPlayerIds = [];
+    room.lastActivityAt = Date.now();
+    room.players = room.players.map((seatPlayer) => ({
+      ...seatPlayer,
+      cards: null,
+      currentBet: 0,
+      lastAction: null,
+      status: seatPlayer.status === 'left' ? 'left' : 'waiting',
+    }));
+
+    await this.storageService.persistRoom(
+      room,
+      roomWrite(
+        roomEvent({
+          roomId: room.id,
+          type: 'ROOM_CONFIG_UPDATED',
+          actor: actorPlayerId
+            ? { source: 'EVENTS_GATEWAY', playerId: actorPlayerId }
+            : { source: 'EVENTS_GATEWAY' },
+          payload: {
+            config: room.config,
+          },
+        }),
+      ),
+    );
+    const archived = await this.savedGameArchiveStorageService.archiveEndedRoom(
+      room.id,
+    );
+    if (archived?.archiveId) {
+      await this.savedGameReviewService.scheduleArchiveReview(
+        archived.archiveId,
+      );
+    }
+
+    const gameEndedData: GameEndedData = {
+      standings,
+      summary: {
+        totalPlayers,
+        handsPlayed,
+        totalBuyIn,
+        totalChipsInPlay,
+        profitablePlayers,
+        averageFinalStack,
+        chipLeader,
+        biggestWinner: biggestWinner
+          ? {
+              playerId: biggestWinner.playerId,
+              playerName: biggestWinner.playerName,
+              amount: biggestWinner.profit,
+            }
+          : null,
+        biggestLoss: biggestLoss
+          ? {
+              playerId: biggestLoss.playerId,
+              playerName: biggestLoss.playerName,
+              amount: Math.abs(biggestLoss.profit),
+            }
+          : null,
+      },
+    };
+
+    this.abandonedRoomSince.delete(room.id);
+    this.server.to(room.id).emit('GAME_ENDED', gameEndedData);
+  }
+
+  private async maybeFinalizeAbandonedRoom(room: any): Promise<boolean> {
+    if (!room?.id || room.gameState !== 'IN_PROGRESS') {
+      return false;
+    }
+
+    if (this.hasConnectedHumanPlayers(room)) {
+      this.abandonedRoomSince.delete(room.id);
+      return false;
+    }
+
+    const abandonedSince = this.abandonedRoomSince.get(room.id);
+    const gracePeriod = room.config?.reconnectGracePeriod ?? 120000;
+    if (!abandonedSince || Date.now() - abandonedSince < gracePeriod) {
+      return false;
+    }
+
+    if (!this.isSafeToFinalizeRoom(room)) {
+      return false;
+    }
+
+    await this.finalizeRoomAndArchive(room);
+    this.logger.log(`Game auto-finalized in abandoned room ${room.id}`);
+    return true;
   }
 
   private syncRoomReadyState(room: any): void {
@@ -606,6 +789,7 @@ export class EventsGateway
           playerId,
         );
         if (updatedRoom) {
+          this.updateAbandonedRoomTracking(updatedRoom);
           this.syncRoomReadyState(updatedRoom);
           await this.storageService.persistRoom(
             updatedRoom,
@@ -752,6 +936,7 @@ export class EventsGateway
         this.logger.log(
           `Player ${player.name} ${rejoined ? 'rejoined' : 'joined'} room ${room.id}`,
         );
+        this.updateAbandonedRoomTracking(room);
         this.syncRoomReadyState(room);
         await this.storageService.persistRoom(
           room,
@@ -817,6 +1002,7 @@ export class EventsGateway
         if (!room) {
           throw new Error('Room not found');
         }
+        this.updateAbandonedRoomTracking(room);
         this.syncRoomReadyState(room);
         await this.storageService.persistRoom(
           room,
@@ -1255,123 +1441,7 @@ export class EventsGateway
       if (room.currentHand.currentPlayerTurn) {
         throw new Error('Can only end game between hands');
       }
-
-      const standings = [...room.players]
-        .filter((seatPlayer) => shouldIncludeLiveRankingPlayer(seatPlayer))
-        .map((seatPlayer) => {
-          const finalChips = seatPlayer.chips + (seatPlayer.currentBet || 0);
-          const totalBuyIn = seatPlayer.totalBuyIn || 0;
-          return {
-            playerId: seatPlayer.id,
-            playerName: seatPlayer.name,
-            finalChips,
-            totalBuyIn,
-            profit: finalChips - totalBuyIn,
-            handsPlayedCount: seatPlayer.handsPlayedCount ?? 0,
-            handsWonCount: seatPlayer.handsWonCount ?? 0,
-            vpipHandsCount: seatPlayer.vpipHandsCount ?? 0,
-          };
-        })
-        .sort((a, b) => {
-          if (b.finalChips !== a.finalChips) return b.finalChips - a.finalChips;
-          if (b.profit !== a.profit) return b.profit - a.profit;
-          return a.playerName.localeCompare(b.playerName);
-        });
-
-      const totalPlayers = standings.length;
-      const totalBuyIn = standings.reduce(
-        (sum, entry) => sum + entry.totalBuyIn,
-        0,
-      );
-      const totalChipsInPlay = standings.reduce(
-        (sum, entry) => sum + entry.finalChips,
-        0,
-      );
-      const profitablePlayers = standings.filter(
-        (entry) => entry.profit > 0,
-      ).length;
-      const averageFinalStack =
-        totalPlayers > 0 ? Math.round(totalChipsInPlay / totalPlayers) : 0;
-      const handsPlayed = room.currentHand.handNumber ?? 0;
-      const chipLeader = standings[0]
-        ? {
-            playerId: standings[0].playerId,
-            playerName: standings[0].playerName,
-            amount: standings[0].finalChips,
-          }
-        : null;
-
-      const biggestWinner = standings
-        .filter((entry) => entry.profit > 0)
-        .sort((a, b) => b.profit - a.profit)[0];
-      const biggestLoss = standings
-        .filter((entry) => entry.profit < 0)
-        .sort((a, b) => a.profit - b.profit)[0];
-
-      room.gameState = 'ENDED';
-      room.currentHand = null;
-      room.readyPhase = null;
-      room.readyPlayerIds = [];
-      room.lastActivityAt = Date.now();
-      room.players = room.players.map((seatPlayer) => {
-        return {
-          ...seatPlayer,
-          cards: null,
-          currentBet: 0,
-          lastAction: null,
-          status: seatPlayer.status === 'left' ? 'left' : 'waiting',
-        };
-      });
-      await this.storageService.persistRoom(
-        room,
-        roomWrite(
-          roomEvent({
-            roomId: room.id,
-            type: 'ROOM_CONFIG_UPDATED',
-            actor: { source: 'EVENTS_GATEWAY', playerId: playerInfo.playerId },
-            payload: {
-              config: room.config,
-            },
-          }),
-        ),
-      );
-      const archived = await this.savedGameArchiveStorageService.archiveEndedRoom(
-        room.id,
-      );
-      if (archived?.archiveId) {
-        await this.savedGameReviewService.scheduleArchiveReview(
-          archived.archiveId,
-        );
-      }
-
-      const gameEndedData: GameEndedData = {
-        standings,
-        summary: {
-          totalPlayers,
-          handsPlayed,
-          totalBuyIn,
-          totalChipsInPlay,
-          profitablePlayers,
-          averageFinalStack,
-          chipLeader,
-          biggestWinner: biggestWinner
-            ? {
-                playerId: biggestWinner.playerId,
-                playerName: biggestWinner.playerName,
-                amount: biggestWinner.profit,
-              }
-            : null,
-          biggestLoss: biggestLoss
-            ? {
-                playerId: biggestLoss.playerId,
-                playerName: biggestLoss.playerName,
-                amount: Math.abs(biggestLoss.profit),
-              }
-            : null,
-        },
-      };
-
-      this.server.to(room.id).emit('GAME_ENDED', gameEndedData);
+      await this.finalizeRoomAndArchive(room, playerInfo.playerId);
       this.logger.log(
         `Game ended in room ${room.id} by host ${playerInfo.playerId}`,
       );
@@ -3700,6 +3770,11 @@ export class EventsGateway
           !twiceAgreedPlayerIds.has(playerId)
         ) {
           await this.resolveRunCountDecision(room, 1);
+          const resolvedRoom = await this.getRoom(roomId);
+          if (resolvedRoom) {
+            this.updateAbandonedRoomTracking(resolvedRoom);
+            await this.maybeFinalizeAbandonedRoom(resolvedRoom);
+          }
           return;
         }
 
@@ -3718,6 +3793,7 @@ export class EventsGateway
             const disconnectedRoom =
               await this.gameService.markPlayerDisconnected(roomId, playerId);
             if (disconnectedRoom) {
+              this.updateAbandonedRoomTracking(disconnectedRoom);
               this.syncRoomReadyState(disconnectedRoom);
               await this.storageService.persistRoom(disconnectedRoom);
               const started = await this.maybeStartReadyPhaseIfAllReady(
@@ -3727,6 +3803,7 @@ export class EventsGateway
               if (!started) {
                 this.emitReadyStateUpdated(roomId, disconnectedRoom);
               }
+              await this.maybeFinalizeAbandonedRoom(disconnectedRoom);
             }
             return;
           }
@@ -3748,6 +3825,7 @@ export class EventsGateway
           playerId,
         );
         if (disconnectedRoom) {
+          this.updateAbandonedRoomTracking(disconnectedRoom);
           this.syncRoomReadyState(disconnectedRoom);
           await this.storageService.persistRoom(disconnectedRoom);
           const started = await this.maybeStartReadyPhaseIfAllReady(
@@ -3757,6 +3835,7 @@ export class EventsGateway
           if (!started) {
             this.emitReadyStateUpdated(roomId, disconnectedRoom);
           }
+          await this.maybeFinalizeAbandonedRoom(disconnectedRoom);
         }
       });
     } catch (error) {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -9085,6 +9085,77 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.15c: Abandoned Room Auto-Archives Saved History After Last Disconnect Timeout', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      roomConfig: { reconnectGracePeriod: 1200 },
+    });
+    let bobReturnContext: BrowserContext | null = null;
+
+    try {
+      const { alicePage, bobPage, roomCode, aliceContext, bobContext } = session;
+      await setTestDeckForCurrentRoom(alicePage, [
+        { suit: 'hearts', rank: 'A' }, // Alice
+        { suit: 'hearts', rank: 'K' }, // Alice
+        { suit: 'spades', rank: 'Q' }, // Bob
+        { suit: 'spades', rank: 'J' }, // Bob
+        { suit: 'clubs', rank: '2' }, // Flop 1
+        { suit: 'diamonds', rank: '5' }, // Flop 2
+        { suit: 'spades', rank: '8' }, // Flop 3
+        { suit: 'hearts', rank: '9' }, // Turn
+        { suit: 'diamonds', rank: 'K' }, // River
+      ]);
+
+      const handCompletePromise = captureNextHandComplete(alicePage, 20000, [
+        alicePage,
+        bobPage,
+      ]);
+      await startGameFromLobby(alicePage, bobPage);
+      await playCheckCheckToShowdown(alicePage, bobPage);
+      await handCompletePromise;
+
+      await Promise.allSettled([aliceContext.close(), bobContext.close()]);
+
+      bobReturnContext = await browser.newContext();
+      const bobReturnPage = await bobReturnContext.newPage();
+      await authenticateTestUser(bobReturnPage, 'test2', {
+        displayName: 'Bob',
+        avatarEmoji: '🐻',
+      });
+
+      await expect
+        .poll(
+          async () => {
+            const response = await bobReturnPage.context().request.get(
+              `${BACKEND_URL}/api/history/games`,
+            );
+            if (!response.ok()) {
+              return false;
+            }
+
+            const games = (await response.json()) as Array<{ roomId?: string }>;
+            return games.some((game) => game.roomId === roomCode);
+          },
+          { timeout: 10000, intervals: [500, 1000, 1500] },
+        )
+        .toBe(true);
+
+      await bobReturnPage.getByRole('button', { name: 'History' }).click();
+      await expect(
+        bobReturnPage.locator('[data-testid="saved-games-page"]'),
+      ).toBeVisible();
+      await expect(
+        bobReturnPage.locator(`[data-testid="saved-game-card-${roomCode}"]`),
+      ).toBeVisible();
+    } finally {
+      await Promise.allSettled([
+        teardownTwoPlayerSession(session),
+        bobReturnContext?.close(),
+      ]);
+    }
+  });
+
   test('8.16: Non-Showdown Result Keeps Hole Cards Hidden', async ({
     browser,
   }) => {

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -1138,4 +1138,96 @@ describe('EventsGateway membership mutation serialization', () => {
       (gateway as any).savedGameReviewService.scheduleArchiveReview,
     ).toHaveBeenCalledWith('ROOM1');
   });
+
+  it('clears abandoned-room tracking during module teardown', () => {
+    (gateway as any).abandonedRoomSince.set('ROOM1', Date.now());
+
+    gateway.onModuleDestroy();
+
+    expect((gateway as any).abandonedRoomSince.size).toBe(0);
+  });
+
+  it('treats stale disconnect timers as a no-op after the room has already ended', async () => {
+    roomState.gameState = 'ENDED';
+    roomState.currentHand = null;
+    roomState.players[0].connectionStatus = 'disconnected';
+
+    await (gateway as any).handleDisconnectTimeout('ROOM1', 'p-host');
+
+    expect(gameService.markPlayerDisconnected).not.toHaveBeenCalled();
+    expect(storageService.persistRoom).not.toHaveBeenCalled();
+    expect(storageService.archiveEndedRoom).not.toHaveBeenCalled();
+  });
+
+  it('clears pending room disconnect timers when abandoned-room finalization succeeds', async () => {
+    roomState.hostId = 'p-host';
+    roomState.gameState = 'IN_PROGRESS';
+    roomState.players = [
+      {
+        ...createPlayer({
+          id: 'p-host',
+          socketId: 'socket-host',
+          name: 'Host',
+          status: 'waiting',
+          position: 0,
+          userId: 'user-alice',
+        }),
+        connectionStatus: 'disconnected',
+      },
+      {
+        ...createPlayer({
+          id: 'p-bob',
+          socketId: 'socket-bob-old',
+          name: 'Bob',
+          status: 'waiting',
+          position: 1,
+          userId: 'user-bob',
+        }),
+        connectionStatus: 'disconnected',
+      },
+    ];
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 0,
+      bigBlindPosition: 1,
+      pot: 0,
+      sidePots: [],
+      communityCards: [],
+      activePlayers: [],
+      bettingRound: 'SHOWDOWN',
+      currentBet: 0,
+      currentPlayerTurn: null,
+      roundActions: {},
+      lastRaiseSize: 10,
+      deck: [],
+      blindStructure: { smallBlind: 5, bigBlind: 10 },
+      allInPlayers: [],
+      winners: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      firstPlayerToAct: 'p-host',
+      lastAggressor: null,
+      pendingStreetRevealRound: null,
+      nextStreetReadyPlayerIds: [],
+      nextStreetRequiredPlayerIds: [],
+      revealedPlayerIds: [],
+      lastResult: {
+        winners: [],
+        winningHand: null,
+        potAmount: 0,
+        playerHands: [],
+      },
+    };
+    (gateway as any).abandonedRoomSince.set(
+      'ROOM1',
+      Date.now() - roomState.config.reconnectGracePeriod - 1,
+    );
+    (gateway as any).disconnectTimers.set('p-host', setTimeout(() => {}, 1000));
+    (gateway as any).disconnectTimers.set('p-bob', setTimeout(() => {}, 1000));
+
+    await (gateway as any).handleDisconnectTimeout('ROOM1', 'p-host');
+
+    expect((gateway as any).disconnectTimers.size).toBe(0);
+  });
 });

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -197,6 +197,25 @@ describe('EventsGateway membership mutation serialization', () => {
           return updatedRoom;
         },
       ),
+      markPlayerDisconnected: jest.fn(async (roomId: string, playerId: string) => {
+        if (roomId !== 'ROOM1') {
+          return null;
+        }
+
+        let updatedRoom: any = null;
+        await persistViaStaleSnapshot((draft) => {
+          const player = draft.players.find((entry: any) => entry.id === playerId);
+          if (!player) {
+            return;
+          }
+
+          player.connectionStatus = 'disconnected';
+          draft.lastActivityAt = Date.now();
+          updatedRoom = deepClone(draft);
+        });
+
+        return updatedRoom;
+      }),
     };
 
     handService = {
@@ -791,5 +810,332 @@ describe('EventsGateway membership mutation serialization', () => {
         }),
       ]),
     );
+  });
+
+  it('auto-finalizes and archives an abandoned room between hands after disconnect timeout', async () => {
+    roomState.hostId = 'p-host';
+    roomState.gameState = 'IN_PROGRESS';
+    roomState.players = [
+      {
+        ...createPlayer({
+          id: 'p-host',
+          socketId: 'socket-host',
+          name: 'Host',
+          status: 'waiting',
+          position: 0,
+          userId: 'user-alice',
+        }),
+        connectionStatus: 'disconnected',
+      },
+      {
+        ...createPlayer({
+          id: 'p-bob',
+          socketId: 'socket-bob-old',
+          name: 'Bob',
+          status: 'waiting',
+          position: 1,
+          userId: 'user-bob',
+        }),
+        connectionStatus: 'disconnected',
+      },
+    ];
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 0,
+      bigBlindPosition: 1,
+      pot: 0,
+      sidePots: [],
+      communityCards: [],
+      activePlayers: [],
+      bettingRound: 'SHOWDOWN',
+      currentBet: 0,
+      currentPlayerTurn: null,
+      roundActions: {},
+      lastRaiseSize: 10,
+      deck: [],
+      blindStructure: { smallBlind: 5, bigBlind: 10 },
+      allInPlayers: [],
+      winners: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      firstPlayerToAct: 'p-host',
+      lastAggressor: null,
+      pendingStreetRevealRound: null,
+      nextStreetReadyPlayerIds: [],
+      nextStreetRequiredPlayerIds: [],
+      revealedPlayerIds: [],
+      lastResult: {
+        winners: [],
+        winningHand: null,
+        potAmount: 0,
+        playerHands: [],
+      },
+    };
+    (gateway as any).abandonedRoomSince.set(
+      'ROOM1',
+      Date.now() - roomState.config.reconnectGracePeriod - 1,
+    );
+
+    await (gateway as any).handleDisconnectTimeout('ROOM1', 'p-host');
+
+    expect(storageService.archiveEndedRoom).toHaveBeenCalledWith('ROOM1');
+    expect(
+      (gateway as any).savedGameReviewService.scheduleArchiveReview,
+    ).toHaveBeenCalledWith('ROOM1');
+    const savedRoom = storageService.persistRoom.mock.calls.at(-1)?.[0];
+    expect(savedRoom?.gameState).toBe('ENDED');
+  });
+
+  it('does not auto-finalize after disconnect timeout while another human is still connected', async () => {
+    roomState.hostId = 'p-host';
+    roomState.gameState = 'IN_PROGRESS';
+    roomState.players = [
+      {
+        ...createPlayer({
+          id: 'p-host',
+          socketId: 'socket-host',
+          name: 'Host',
+          status: 'waiting',
+          position: 0,
+          userId: 'user-alice',
+        }),
+        connectionStatus: 'disconnected',
+      },
+      {
+        ...createPlayer({
+          id: 'p-bob',
+          socketId: 'socket-bob-old',
+          name: 'Bob',
+          status: 'waiting',
+          position: 1,
+          userId: 'user-bob',
+        }),
+        connectionStatus: 'connected',
+      },
+    ];
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 0,
+      bigBlindPosition: 1,
+      pot: 0,
+      sidePots: [],
+      communityCards: [],
+      activePlayers: [],
+      bettingRound: 'SHOWDOWN',
+      currentBet: 0,
+      currentPlayerTurn: null,
+      roundActions: {},
+      lastRaiseSize: 10,
+      deck: [],
+      blindStructure: { smallBlind: 5, bigBlind: 10 },
+      allInPlayers: [],
+      winners: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      firstPlayerToAct: 'p-host',
+      lastAggressor: null,
+      pendingStreetRevealRound: null,
+      nextStreetReadyPlayerIds: [],
+      nextStreetRequiredPlayerIds: [],
+      revealedPlayerIds: [],
+      lastResult: {
+        winners: [],
+        winningHand: null,
+        potAmount: 0,
+        playerHands: [],
+      },
+    };
+    (gateway as any).abandonedRoomSince.set(
+      'ROOM1',
+      Date.now() - roomState.config.reconnectGracePeriod - 1,
+    );
+
+    await (gateway as any).handleDisconnectTimeout('ROOM1', 'p-host');
+
+    expect(storageService.archiveEndedRoom).not.toHaveBeenCalled();
+    expect(
+      (gateway as any).savedGameReviewService.scheduleArchiveReview,
+    ).not.toHaveBeenCalled();
+    expect((gateway as any).abandonedRoomSince.has('ROOM1')).toBe(false);
+  });
+
+  it('does not auto-finalize an abandoned room while a hand is still in progress', async () => {
+    roomState.hostId = 'p-host';
+    roomState.gameState = 'IN_PROGRESS';
+    roomState.players = [
+      {
+        ...createPlayer({
+          id: 'p-host',
+          socketId: 'socket-host',
+          name: 'Host',
+          status: 'connected',
+          position: 0,
+          userId: 'user-alice',
+        }),
+        connectionStatus: 'disconnected',
+      },
+      {
+        ...createPlayer({
+          id: 'p-bob',
+          socketId: 'socket-bob-old',
+          name: 'Bob',
+          status: 'connected',
+          position: 1,
+          userId: 'user-bob',
+        }),
+        connectionStatus: 'disconnected',
+      },
+    ];
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 0,
+      bigBlindPosition: 1,
+      pot: 15,
+      sidePots: [],
+      communityCards: [],
+      activePlayers: ['p-host', 'p-bob'],
+      bettingRound: 'PRE_FLOP',
+      currentBet: 10,
+      currentPlayerTurn: 'p-bob',
+      roundActions: { 'p-host': true },
+      lastRaiseSize: 10,
+      deck: [],
+      blindStructure: { smallBlind: 5, bigBlind: 10 },
+      allInPlayers: [],
+      winners: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      firstPlayerToAct: 'p-host',
+      lastAggressor: null,
+      pendingStreetRevealRound: null,
+      nextStreetReadyPlayerIds: [],
+      nextStreetRequiredPlayerIds: [],
+      revealedPlayerIds: [],
+      lastResult: null,
+    };
+    (gateway as any).abandonedRoomSince.set(
+      'ROOM1',
+      Date.now() - roomState.config.reconnectGracePeriod - 1,
+    );
+
+    await (gateway as any).handleDisconnectTimeout('ROOM1', 'p-host');
+
+    expect(storageService.archiveEndedRoom).not.toHaveBeenCalled();
+    const savedRoom = storageService.persistRoom.mock.calls.at(-1)?.[0];
+    expect(savedRoom?.gameState).toBe('IN_PROGRESS');
+  });
+
+  it('clears abandoned-room tracking when a player reconnects before finalization', async () => {
+    (gateway as any).abandonedRoomSince.set(
+      'ROOM1',
+      Date.now() - roomState.config.reconnectGracePeriod - 1,
+    );
+    const reconnectClient = createClient('socket-reconnect', {
+      cookieToken: 'token-bob',
+    });
+
+    const reconnectResult = await gateway.handleReconnect(reconnectClient as any, {
+      roomId: 'ROOM1',
+      playerName: 'Bob',
+      playerId: 'p-bob',
+    });
+
+    expect(reconnectResult).toEqual({ success: true });
+    expect((gateway as any).abandonedRoomSince.has('ROOM1')).toBe(false);
+  });
+
+  it('auto-finalizes after run-count timeout resolution reaches a safe paused phase', async () => {
+    roomState.hostId = 'p-host';
+    roomState.gameState = 'IN_PROGRESS';
+    roomState.players = [
+      {
+        ...createPlayer({
+          id: 'p-host',
+          socketId: 'socket-host',
+          name: 'Host',
+          status: 'connected',
+          position: 0,
+          userId: 'user-alice',
+        }),
+        connectionStatus: 'disconnected',
+      },
+      {
+        ...createPlayer({
+          id: 'p-bob',
+          socketId: 'socket-bob-old',
+          name: 'Bob',
+          status: 'connected',
+          position: 1,
+          userId: 'user-bob',
+        }),
+        connectionStatus: 'disconnected',
+      },
+    ];
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 0,
+      bigBlindPosition: 1,
+      pot: 20,
+      sidePots: [],
+      communityCards: [],
+      activePlayers: ['p-host', 'p-bob'],
+      bettingRound: 'TURN',
+      currentBet: 10,
+      currentPlayerTurn: 'p-bob',
+      roundActions: { 'p-host': true },
+      lastRaiseSize: 10,
+      deck: [],
+      blindStructure: { smallBlind: 5, bigBlind: 10 },
+      allInPlayers: [],
+      winners: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      firstPlayerToAct: 'p-host',
+      lastAggressor: null,
+      pendingStreetRevealRound: null,
+      nextStreetReadyPlayerIds: [],
+      nextStreetRequiredPlayerIds: [],
+      revealedPlayerIds: [],
+      lastResult: null,
+      runCountDecision: {
+        requestedByPlayerId: 'p-bob',
+        eligiblePlayerIds: ['p-host', 'p-bob'],
+        twiceAgreedPlayerIds: ['p-bob'],
+        currentSelectionByPlayerId: {},
+        expiresAt: Date.now() + 5000,
+      },
+    };
+    (gateway as any).abandonedRoomSince.set(
+      'ROOM1',
+      Date.now() - roomState.config.reconnectGracePeriod - 1,
+    );
+
+    jest
+      .spyOn(gateway as any, 'resolveRunCountDecision')
+      .mockImplementation(async () => {
+        roomState.currentHand = {
+          ...roomState.currentHand,
+          bettingRound: 'SHOWDOWN',
+          currentPlayerTurn: null,
+          runCountDecision: null,
+          lastResult: {
+            winners: [],
+            winningHand: null,
+            potAmount: 20,
+            playerHands: [],
+          },
+        };
+      });
+
+    await (gateway as any).handleDisconnectTimeout('ROOM1', 'p-host');
+
+    expect(storageService.archiveEndedRoom).toHaveBeenCalledWith('ROOM1');
+    expect(
+      (gateway as any).savedGameReviewService.scheduleArchiveReview,
+    ).toHaveBeenCalledWith('ROOM1');
   });
 });


### PR DESCRIPTION
## Summary
- share the room end-and-archive flow between manual `END_GAME` and abandoned-room finalization
- auto-finalize and archive in-progress rooms after the last human stays disconnected past the reconnect grace period, but only once the room reaches a safe paused phase
- add regression coverage for between-hands abandonment, reconnect cancellation, run-count resolution, and saved-history visibility after auto-archival

## Testing
- `pnpm --filter poker-server build`
- `pnpm --filter poker-client build`
- `pnpm --filter poker-server test:unit --runInBand --runTestsByPath test/unit/events.gateway.membership-race.spec.ts`
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --filter poker-server test:e2e:playwright --project comprehensive-e2e --workers=1 --grep "8\.15c:" --reporter=line`

Closes #140.
