### PR TITLE
fix: align Zeabur runtime entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ USER node
 
 EXPOSE 3000
 
-CMD ["node", "dist/src/main.js"]
+CMD ["node", "dist/main.js"]

--- a/scripts/pregame-readiness.sh
+++ b/scripts/pregame-readiness.sh
@@ -109,7 +109,7 @@ restart_or_start_pm2 \
   "$ROOT_DIR/poker-client"
 restart_or_start_pm2 \
   "poker-server" \
-  "node dist/src/main.js" \
+  "node dist/main.js" \
   "$ROOT_DIR/poker-server"
 
 sleep 2


### PR DESCRIPTION
## Summary
- update the Docker runtime command to start the built Nest server from `dist/main.js`
- update the local pregame readiness PM2 server command to use the same entrypoint
- fix the Zeabur crash caused by `dist/src/main.js` no longer existing after the prod build layout change

## Validation
- `pnpm --filter poker-server build`
- local health check after starting `node dist/main.js`
- confirmed Zeabur runtime logs were failing on `/app/poker-server/dist/src/main.js`

## Notes
- skipping CI waiting by request