### PR TITLE
fix: normalize saved-history participants for legacy archives and add buy-in standings

### DIFF
--- a/poker-client/src/pages/SavedGameDetail.spec.ts
+++ b/poker-client/src/pages/SavedGameDetail.spec.ts
@@ -306,8 +306,20 @@ describe("SavedGameDetailView", () => {
 
   it("renders the desktop standings buy-in column from archived participant totals", () => {
     const html = renderView();
+    const standingsSectionStart = html.indexOf(
+      'data-testid="saved-history-desktop-standings"',
+    );
+    const desktopHandListStart = html.indexOf(
+      'data-testid="saved-history-desktop-hand-list"',
+    );
+    const standingsSection = html.slice(
+      standingsSectionStart,
+      desktopHandListStart,
+    );
 
-    expect(html).toContain("game.rankings.buyIn");
-    expect(html).toContain("$1000");
+    expect(standingsSectionStart).toBeGreaterThanOrEqual(0);
+    expect(desktopHandListStart).toBeGreaterThan(standingsSectionStart);
+    expect(standingsSection).toContain("game.rankings.buyIn");
+    expect(standingsSection).toContain("$1000");
   });
 });

--- a/poker-client/src/pages/SavedGameDetail.spec.ts
+++ b/poker-client/src/pages/SavedGameDetail.spec.ts
@@ -303,4 +303,11 @@ describe("SavedGameDetailView", () => {
     expect(html).toContain('data-testid="saved-history-desktop-hand-list"');
     expect(html).toContain('data-testid="saved-history-mobile-overview-panel"');
   });
+
+  it("renders the desktop standings buy-in column from archived participant totals", () => {
+    const html = renderView();
+
+    expect(html).toContain("game.rankings.buyIn");
+    expect(html).toContain("$1000");
+  });
 });

--- a/poker-client/src/pages/SavedGameDetail.tsx
+++ b/poker-client/src/pages/SavedGameDetail.tsx
@@ -211,6 +211,7 @@ const ParticipantStandingsTable: React.FC<{
         <tr>
           <th className="px-3 py-2 text-left font-semibold">{t("game.rankings.player")}</th>
           <th className="px-3 py-2 text-right font-semibold">{t("game.final.finalChips")}</th>
+          <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.buyIn")}</th>
           <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.handsWon")}</th>
           <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.vpipHands")}</th>
           <th className="px-3 py-2 text-right font-semibold">{t("game.rankings.net")}</th>
@@ -230,6 +231,7 @@ const ParticipantStandingsTable: React.FC<{
                 : ""}
             </td>
             <td className="px-3 py-2 text-right">${participant.finalChips}</td>
+            <td className="px-3 py-2 text-right">${participant.totalBuyIn}</td>
             <td className="px-3 py-2 text-right">{participant.handsWonCount}</td>
             <td className="px-3 py-2 text-right">
               {participant.vpipHandsCount} ({Math.round(participant.vpipRate * 100)}%)

--- a/poker-server/src/storage/json-storage.service.ts
+++ b/poker-server/src/storage/json-storage.service.ts
@@ -615,9 +615,15 @@ export class JsonStorageService
 
   async listSavedGamesForUser(userId: string): Promise<SavedGameSummary[]> {
     await this.ensureDirectories();
-    return (await readJsonFile<SavedGameSummary[]>(
-      this.getSavedGameUserIndexPath(userId),
-    )) ?? [];
+    const savedGames =
+      (await readJsonFile<SavedGameSummary[]>(
+        this.getSavedGameUserIndexPath(userId),
+      )) ?? [];
+
+    return savedGames.map((summary) => ({
+      ...summary,
+      participants: this.normalizeSavedGameParticipants(summary.participants),
+    }));
   }
 
   async getSavedGameDetailForUser(
@@ -635,6 +641,10 @@ export class JsonStorageService
       return null;
     }
 
+    const participants = this.normalizeSavedGameParticipants(
+      archive.participants,
+    );
+
     return {
       archiveId: archive.archiveId,
       roomId: archive.roomId,
@@ -645,7 +655,7 @@ export class JsonStorageService
       concludedAt: archive.concludedAt,
       handCount: archive.handCount,
       blinds: archive.blinds,
-      participants: archive.participants,
+      participants,
       hands: playerView.hands.map((hand) => ({
         ...hand,
         analysis: this.normalizeSavedGameHandAnalysis(hand.analysis),
@@ -1163,6 +1173,14 @@ export class JsonStorageService
           ? Number((vpipHandsCount / handsPlayedCount).toFixed(4))
           : 0,
     };
+  }
+
+  private normalizeSavedGameParticipants(
+    participants: SavedGameParticipant[],
+  ): SavedGameParticipant[] {
+    return participants.filter((participant) =>
+      shouldIncludeArchivedRankingParticipant(participant),
+    );
   }
 
   private async readSavedGameArchive(

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -9320,6 +9320,11 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
         bobPage.locator('[data-testid="saved-history-mobile-session-panel"]'),
       ).toBeVisible();
       await expect(bobPage.getByText('Session Statistics')).toBeVisible();
+      await expect(bobPage.getByText(/^Robot\b/)).toHaveCount(0);
+      await bobPage.setViewportSize({ width: 1440, height: 900 });
+      await expect(
+        bobPage.getByRole('columnheader', { name: 'Buy-in' }),
+      ).toBeVisible();
       const savedHandDetail = bobPage
         .locator('section')
         .filter({ has: bobPage.getByRole('heading', { name: 'Hand #1' }) });

--- a/poker-server/test/unit/json-storage.service.spec.ts
+++ b/poker-server/test/unit/json-storage.service.spec.ts
@@ -1500,6 +1500,136 @@ describe('JsonStorageService', () => {
       );
     });
 
+    it('normalizes legacy zero-activity robots out of saved-game summary and detail reads', async () => {
+      const roomId = 'ROOMARCHIVE-LEGACY-ROBOTS';
+      await seedCompletedHands(roomId);
+
+      const endedRoom = await service.getRoom(roomId);
+      if (!endedRoom) {
+        throw new Error('Expected ended room to exist');
+      }
+
+      endedRoom.players = endedRoom.players.map((player) => {
+        if (player.id === 'alice') {
+          return { ...player, userId: 'user-alice' };
+        }
+        if (player.id === 'bob') {
+          return { ...player, userId: 'user-bob' };
+        }
+        return player;
+      });
+      endedRoom.lastActivityAt = 2800;
+      await service.persistRoom(endedRoom);
+
+      const archiveEndedRoom = (
+        service as JsonStorageService & {
+          archiveEndedRoom?: (roomId: string) => Promise<{ archiveId: string } | null>;
+        }
+      ).archiveEndedRoom;
+      const listSavedGamesForUser = (
+        service as JsonStorageService & {
+          listSavedGamesForUser?: (userId: string) => Promise<any[]>;
+        }
+      ).listSavedGamesForUser;
+      const getSavedGameDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameDetailForUser?: (
+            archiveId: string,
+            userId: string,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameDetailForUser;
+
+      expect(typeof archiveEndedRoom).toBe('function');
+      expect(typeof listSavedGamesForUser).toBe('function');
+      expect(typeof getSavedGameDetailForUser).toBe('function');
+      if (
+        typeof archiveEndedRoom !== 'function' ||
+        typeof listSavedGamesForUser !== 'function' ||
+        typeof getSavedGameDetailForUser !== 'function'
+      ) {
+        return;
+      }
+
+      const archived = await archiveEndedRoom.call(service, roomId);
+      const archiveId = archived?.archiveId;
+      if (!archiveId) {
+        throw new Error('Expected archive id');
+      }
+
+      const legacyRobotParticipant = {
+        playerId: 'robot-idle',
+        userId: null,
+        playerName: 'Robot 1',
+        avatarEmoji: '🤖',
+        isRobot: true,
+        finalChips: 0,
+        totalBuyIn: 0,
+        profit: 0,
+        handsPlayedCount: 0,
+        handsWonCount: 0,
+        vpipHandsCount: 0,
+        vpipRate: 0,
+      };
+      const userIndexPath = path.join(
+        testDataDir,
+        'saved-games',
+        'users',
+        'user-alice.json',
+      );
+      const archivePath = path.join(
+        testDataDir,
+        'saved-games',
+        'archives',
+        `${archiveId}.json`,
+      );
+      const savedGames = JSON.parse(
+        await fs.readFile(userIndexPath, 'utf8'),
+      ) as Array<{ participants: unknown[] }>;
+      savedGames[0].participants.push(legacyRobotParticipant);
+      await fs.writeFile(userIndexPath, JSON.stringify(savedGames, null, 2));
+
+      const archiveRecord = JSON.parse(
+        await fs.readFile(archivePath, 'utf8'),
+      ) as { participants: unknown[] };
+      archiveRecord.participants.push(legacyRobotParticipant);
+      await fs.writeFile(archivePath, JSON.stringify(archiveRecord, null, 2));
+
+      const aliceGames = await listSavedGamesForUser.call(service, 'user-alice');
+      expect(aliceGames[0]?.participants).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            playerId: 'robot-idle',
+          }),
+        ]),
+      );
+      expect(aliceGames[0]?.participants).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ playerId: 'alice' }),
+          expect.objectContaining({ playerId: 'bob' }),
+        ]),
+      );
+
+      const aliceDetail = await getSavedGameDetailForUser.call(
+        service,
+        archiveId,
+        'user-alice',
+      );
+      expect(aliceDetail?.participants).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            playerId: 'robot-idle',
+          }),
+        ]),
+      );
+      expect(aliceDetail?.participants).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ playerId: 'alice' }),
+          expect.objectContaining({ playerId: 'bob' }),
+        ]),
+      );
+    });
+
     it('merges a localized locale entry without dropping other locales or changing canonical updatedAt', async () => {
       const roomId = 'ROOMARCHIVE2';
       await seedCompletedHands(roomId);


### PR DESCRIPTION
## Summary

- normalize legacy saved-game summary/detail participants on read so stale zero-activity robot rows no longer surface
- add the missing buy-in column to the desktop saved-history standings table and cover it with focused client and browser assertions

## Linked Issue

Closes #151

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/151#issuecomment-4227687842

## Validation

- pnpm --dir poker-client test -- SavedGameDetail.spec.ts
- pnpm --filter poker-types build
- pnpm --filter poker-server test:unit --runInBand --runTestsByPath test/unit/json-storage.service.spec.ts
- pnpm --dir poker-client build
- pnpm --filter poker-server build
- PW_FRONTEND_URL=http://localhost:5188 PW_BACKEND_URL=http://localhost:3015 E2E_FRONTEND_URL=http://localhost:5188 E2E_BACKEND_URL=http://localhost:3015 E2E_FRONTEND_BIND_HOST=localhost PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server run test:e2e:playwright --project comprehensive-e2e --workers=1 --grep "8\.15:" --reporter=line
