### PR TITLE
fix: make WeChat gate scroll on small screens

### DIFF
--- a/poker-client/src/components/WeChatBrowserGate.spec.ts
+++ b/poker-client/src/components/WeChatBrowserGate.spec.ts
@@ -21,4 +21,18 @@ describe("WeChatBrowserGate", () => {
     expect(html).toContain("https://poker.example.com/room/ABCD");
     expect(html).toContain("data-testid=\"wechat-browser-copy-link\"");
   });
+
+  it("uses an overflow-safe fullscreen shell for tall mobile content", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(LocalizationProvider, {
+        children: React.createElement(WeChatBrowserGate, {
+          currentUrl: "https://poker.example.com/room/ABCD",
+        }),
+      }),
+    );
+
+    expect(html).toContain("overflow-y-auto");
+    expect(html).toContain("max-h-[calc(100vh-2rem)]");
+    expect(html).toContain("data-testid=\"wechat-browser-gate-panel\"");
+  });
 });

--- a/poker-client/src/components/WeChatBrowserGate.spec.ts
+++ b/poker-client/src/components/WeChatBrowserGate.spec.ts
@@ -31,8 +31,12 @@ describe("WeChatBrowserGate", () => {
       }),
     );
 
-    expect(html).toContain("overflow-y-auto");
-    expect(html).toContain("max-h-[calc(100vh-2rem)]");
-    expect(html).toContain("data-testid=\"wechat-browser-gate-panel\"");
+    const panelTagMatch = html.match(
+      /<[^>]*data-testid="wechat-browser-gate-panel"[^>]*>/,
+    );
+
+    expect(panelTagMatch).not.toBeNull();
+    expect(panelTagMatch?.[0]).toContain("overflow-y-auto");
+    expect(panelTagMatch?.[0]).toContain("max-h-[calc(100vh-2rem)]");
   });
 });

--- a/poker-client/src/components/WeChatBrowserGate.tsx
+++ b/poker-client/src/components/WeChatBrowserGate.tsx
@@ -35,11 +35,11 @@ export const WeChatBrowserGate: React.FC<WeChatBrowserGateProps> = ({
 
   return (
     <div
-      className="fixed inset-0 z-[120] flex items-start justify-center overflow-y-auto bg-emerald-950/92 p-4 backdrop-blur-sm sm:items-center"
+      className="fixed inset-0 z-[120] flex items-start justify-center bg-emerald-950/92 p-4 backdrop-blur-sm sm:items-center"
       data-testid="wechat-browser-gate"
     >
       <div
-        className="surface-panel my-4 max-h-[calc(100vh-2rem)] w-full max-w-xl overflow-y-auto p-5 sm:my-0 sm:p-6"
+        className="surface-panel max-h-[calc(100vh-2rem)] w-full max-w-xl overflow-y-auto p-5 sm:p-6"
         role="dialog"
         aria-modal="true"
         aria-labelledby="wechat-browser-gate-title"

--- a/poker-client/src/components/WeChatBrowserGate.tsx
+++ b/poker-client/src/components/WeChatBrowserGate.tsx
@@ -35,14 +35,15 @@ export const WeChatBrowserGate: React.FC<WeChatBrowserGateProps> = ({
 
   return (
     <div
-      className="fixed inset-0 z-[120] flex items-center justify-center bg-emerald-950/92 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[120] flex items-start justify-center overflow-y-auto bg-emerald-950/92 p-4 backdrop-blur-sm sm:items-center"
       data-testid="wechat-browser-gate"
     >
       <div
-        className="surface-panel w-full max-w-xl p-5 sm:p-6"
+        className="surface-panel my-4 max-h-[calc(100vh-2rem)] w-full max-w-xl overflow-y-auto p-5 sm:my-0 sm:p-6"
         role="dialog"
         aria-modal="true"
         aria-labelledby="wechat-browser-gate-title"
+        data-testid="wechat-browser-gate-panel"
       >
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300/80">
           {t("wechatGate.eyebrow")}


### PR DESCRIPTION
## Summary

- make the WeChat browser handoff modal scrollable on constrained mobile viewports instead of clipping off-screen
- add a focused component assertion for the overflow-safe fullscreen shell contract
- track the broader reusable modal-shell cleanup separately in #161

## Linked Work

- Follow-up to #157
- Follow-up issue for reusable modal structure: #161

## Validation

- `pnpm --dir poker-client test -- src/components/WeChatBrowserGate.spec.ts`
- `pnpm --dir poker-client build`
