### PR TITLE
fix: stabilize remaining desktop interaction regressions after action-bar refinement

### DIFF
--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -131,6 +131,11 @@ type ThreePlayerSession = {
   roomCode: string;
 };
 
+type SessionViewport = {
+  width: number;
+  height: number;
+};
+
 type SetupTwoPlayerOptions = {
   roomConfig?: Record<string, unknown>;
   forceNonAutomationMode?: boolean;
@@ -471,10 +476,14 @@ async function teardownTwoPlayerSession(session: TwoPlayerSession) {
 
 async function setupThreePlayerSession(
   browser: any,
+  options?: { viewport?: SessionViewport },
 ): Promise<ThreePlayerSession> {
-  const aliceContext = await browser.newContext();
-  const bobContext = await browser.newContext();
-  const charlieContext = await browser.newContext();
+  const contextOptions = options?.viewport
+    ? { viewport: options.viewport }
+    : undefined;
+  const aliceContext = await browser.newContext(contextOptions);
+  const bobContext = await browser.newContext(contextOptions);
+  const charlieContext = await browser.newContext(contextOptions);
   const alicePage = await aliceContext.newPage();
   const bobPage = await bobContext.newPage();
   const charliePage = await charlieContext.newPage();
@@ -8793,12 +8802,13 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
 
       await waitForRound(alicePage, 'FLOP', 3);
       await waitForPlayerTurn(bobPage, 'Bob');
-      const bobContinuePreset = bobPage.locator(
-        '[data-testid="chip-load-continue"]',
-      );
-      await expect(bobContinuePreset).toBeVisible();
-      await expect(bobContinuePreset).toBeEnabled();
-      await bobContinuePreset.click();
+      await expect(
+        bobPage.locator('[data-testid="chip-load-continue"]'),
+      ).toHaveCount(0);
+      const bobRaisePreset = bobPage.locator('[data-testid="chip-load-raise"]');
+      await expect(bobRaisePreset).toBeVisible();
+      await expect(bobRaisePreset).toBeEnabled();
+      await bobRaisePreset.click();
       await dragTrayToPot(bobPage, { x: 0.12, y: -0.1 }, { steps: 2 });
 
       await waitForPlayerTurn(alicePage, 'Alice');
@@ -8819,15 +8829,12 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
   test('8.13b1: Compact seat shows the Check action label after that seat checks', async ({
     browser,
   }) => {
-    const session = await setupThreePlayerSession(browser);
+    const session = await setupThreePlayerSession(browser, {
+      viewport: { width: 520, height: 900 },
+    });
 
     try {
       const { alicePage, bobPage, charliePage } = session;
-      await Promise.all([
-        alicePage.setViewportSize({ width: 520, height: 900 }),
-        bobPage.setViewportSize({ width: 520, height: 900 }),
-        charliePage.setViewportSize({ width: 520, height: 900 }),
-      ]);
 
       await alicePage.click('[data-testid="start-game-button"]');
       await Promise.all([
@@ -8887,15 +8894,12 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
   test('8.13b2: Earlier checked seat keeps the Check label after a later seat also checks', async ({
     browser,
   }) => {
-    const session = await setupThreePlayerSession(browser);
+    const session = await setupThreePlayerSession(browser, {
+      viewport: { width: 520, height: 900 },
+    });
 
     try {
       const { alicePage, bobPage, charliePage } = session;
-      await Promise.all([
-        alicePage.setViewportSize({ width: 520, height: 900 }),
-        bobPage.setViewportSize({ width: 520, height: 900 }),
-        charliePage.setViewportSize({ width: 520, height: 900 }),
-      ]);
 
       await alicePage.click('[data-testid="start-game-button"]');
       await Promise.all([


### PR DESCRIPTION
## Summary

- Align focused 8.13 Playwright expectations with the shipped desktop action model
- Start compact-seat three-player coverage at a mobile viewport from first paint

## Linked Issue

Closes #163

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/163#issuecomment-4230693195

## Validation

- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 TEST_MODE=true pnpm exec playwright test --project comprehensive-e2e --workers=1 --grep "8\.13e: Desktop wide repeated drag-to-pot commits with quick releases|8\.13b1: Compact seat shows the Check action label after that seat checks|8\.13b2: Earlier checked seat keeps the Check label after a later seat also checks" --reporter=line
- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 TEST_MODE=true pnpm exec playwright test --project comprehensive-e2e --workers=1 --grep "8\.13b: Check/Fold Uses Popover Confirmation Instead Of Fullscreen Modal|8\.13d: Desktop bet confirmation is click-first while drag remains available" --reporter=line
