### PR TITLE
fix: restore chat, voice, and persistence e2e coverage in the comprehensive suite

### DIFF
--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -134,14 +134,26 @@ type ThreePlayerSession = {
 type SetupTwoPlayerOptions = {
   roomConfig?: Record<string, unknown>;
   forceNonAutomationMode?: boolean;
+  viewport?: {
+    width: number;
+    height: number;
+  };
 };
 
 async function createBrowserContext(
   browser: any,
-  forceNonAutomationMode = false,
+  options?: {
+    forceNonAutomationMode?: boolean;
+    viewport?: {
+      width: number;
+      height: number;
+    };
+  },
 ) {
-  const context = await browser.newContext();
-  if (!forceNonAutomationMode) {
+  const context = await browser.newContext(
+    options?.viewport ? { viewport: options.viewport } : undefined,
+  );
+  if (!options?.forceNonAutomationMode) {
     return context;
   }
 
@@ -420,11 +432,17 @@ async function setupTwoPlayerSession(
 ): Promise<TwoPlayerSession> {
   const aliceContext = await createBrowserContext(
     browser,
-    options?.forceNonAutomationMode ?? false,
+    {
+      forceNonAutomationMode: options?.forceNonAutomationMode ?? false,
+      viewport: options?.viewport,
+    },
   );
   const bobContext = await createBrowserContext(
     browser,
-    options?.forceNonAutomationMode ?? false,
+    {
+      forceNonAutomationMode: options?.forceNonAutomationMode ?? false,
+      viewport: options?.viewport,
+    },
   );
   const alicePage = await aliceContext.newPage();
   const bobPage = await bobContext.newPage();
@@ -948,6 +966,11 @@ async function requestRebuy(page: Page, amount: number) {
 }
 
 async function openChatPanel(page: Page) {
+  const chatPanel = page.locator('[data-testid="chat-panel"]');
+  if ((await chatPanel.count()) > 0 && (await chatPanel.first().isVisible())) {
+    return;
+  }
+
   await page.click('[data-testid="open-chat-button"]');
   await page.waitForSelector('[data-testid="chat-panel"]', {
     state: 'visible',
@@ -10210,14 +10233,12 @@ test.describe('Poker E2E - Test Suite 10: Chat History & Concurrency', () => {
   test('10.4: Mobile voice preview opens chat and starts that playback source', async ({
     browser,
   }) => {
-    const session = await setupTwoPlayerSession(browser);
+    const session = await setupTwoPlayerSession(browser, {
+      viewport: { width: 390, height: 844 },
+    });
 
     try {
       const { alicePage, bobPage } = session;
-      await Promise.all([
-        alicePage.setViewportSize({ width: 390, height: 844 }),
-        bobPage.setViewportSize({ width: 390, height: 844 }),
-      ]);
 
       await sendChatMessagesViaSocket(
         alicePage,
@@ -10250,14 +10271,12 @@ test.describe('Poker E2E - Test Suite 10: Chat History & Concurrency', () => {
   test('10.5: Mobile hidden-chat preview dismiss/open both clear unread state', async ({
     browser,
   }) => {
-    const session = await setupTwoPlayerSession(browser);
+    const session = await setupTwoPlayerSession(browser, {
+      viewport: { width: 390, height: 844 },
+    });
 
     try {
       const { alicePage, bobPage } = session;
-      await Promise.all([
-        alicePage.setViewportSize({ width: 390, height: 844 }),
-        bobPage.setViewportSize({ width: 390, height: 844 }),
-      ]);
 
       await sendChatMessagesViaSocket(
         bobPage,

--- a/poker-server/test/e2e/helpers/persistence-e2e.helpers.ts
+++ b/poker-server/test/e2e/helpers/persistence-e2e.helpers.ts
@@ -48,6 +48,10 @@ export type TwoPlayerSession = {
 type SetupTwoPlayerOptions = {
   roomConfig?: Record<string, unknown>;
   forceNonAutomationMode?: boolean;
+  viewport?: {
+    width: number;
+    height: number;
+  };
 };
 
 export async function waitForPokerDebug(page: Page) {
@@ -58,10 +62,18 @@ export async function waitForPokerDebug(page: Page) {
 
 async function createBrowserContext(
   browser: any,
-  forceNonAutomationMode = false,
+  options?: {
+    forceNonAutomationMode?: boolean;
+    viewport?: {
+      width: number;
+      height: number;
+    };
+  },
 ) {
-  const context = await browser.newContext();
-  if (!forceNonAutomationMode) {
+  const context = await browser.newContext(
+    options?.viewport ? { viewport: options.viewport } : undefined,
+  );
+  if (!options?.forceNonAutomationMode) {
     return context;
   }
 
@@ -324,11 +336,17 @@ export async function setupTwoPlayerSession(
 ): Promise<TwoPlayerSession> {
   const aliceContext = await createBrowserContext(
     browser,
-    options?.forceNonAutomationMode ?? false,
+    {
+      forceNonAutomationMode: options?.forceNonAutomationMode ?? false,
+      viewport: options?.viewport,
+    },
   );
   const bobContext = await createBrowserContext(
     browser,
-    options?.forceNonAutomationMode ?? false,
+    {
+      forceNonAutomationMode: options?.forceNonAutomationMode ?? false,
+      viewport: options?.viewport,
+    },
   );
   const alicePage = await aliceContext.newPage();
   const bobPage = await bobContext.newPage();
@@ -603,6 +621,11 @@ export function buildChipRanking(room: Room) {
 }
 
 export async function openChatPanel(page: Page) {
+  const chatPanel = page.locator('[data-testid="chat-panel"]');
+  if ((await chatPanel.count()) > 0 && (await chatPanel.first().isVisible())) {
+    return;
+  }
+
   await page.click('[data-testid="open-chat-button"]');
   await page.waitForSelector('[data-testid="chat-panel"]', {
     state: 'visible',


### PR DESCRIPTION
## Summary

- Start mobile preview coverage in a mobile viewport from first render
- Teach shared chat helpers to reuse the already-mounted desktop rail

## Linked Issue

Closes #166

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/166#issuecomment-4267489421

## Validation

- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 TEST_MODE=true pnpm exec playwright test --project comprehensive-e2e --workers=1 --grep "10\.4: Mobile voice preview opens chat and starts that playback source|10\.5: Mobile hidden-chat preview dismiss/open both clear unread state|10\.6: Incoming messages do not interrupt current voice source unless another voice is clicked|10\.6: Outgoing voice message stays right-aligned without full-width stretch|1\.2: Refresh restores chat and pagination can load full history|1\.6: Voice upload message persists and is playable after sync" --reporter=line
- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server run test:e2e:playwright:comprehensive (current #166 branch leaves only #163 failures; stacked local validation with #163 surfaced follow-up #172)
