### PR TITLE
fix: allow informational modals after a hand ends

### DIFF
--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -2218,8 +2218,9 @@ const useGameRoomElement = () => {
     readyActionPhase === "START_GAME" ? canReadyPreGame : canReadyNextHand;
   const showOperationBar =
     isRunCountDecisionStep || showShowdownDecisionArea || showNextStreetActionArea;
-  const shouldPreemptInformationalModals =
-    showOperationBar || showNextHandActionArea || showHandResultsModal || showFinalSummaryModal;
+  // Hand/final result dialogs already replace the current primary modal when they open.
+  // Keep blanket preemption only for active in-hand action states that need table focus.
+  const shouldPreemptInformationalModals = showOperationBar;
   const operationBarMode = isRunCountDecisionStep
     ? "runCount"
     : showShowdownDecisionArea

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -6606,6 +6606,67 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.4g: Final Summary Preempts Rankings When The Host Ends The Game', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser);
+
+    try {
+      const { alicePage, bobPage } = session;
+      await startGameFromLobby(alicePage, bobPage);
+
+      await waitForPlayerTurn(bobPage, 'Bob');
+      await bobPage.click('[data-testid="action-fold"]');
+      await expect(
+        alicePage.locator('[data-testid="reveal-next-street-action-area"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="reveal-next-street-button"]');
+
+      await expect(
+        alicePage.locator('[data-testid="next-hand-action-area"]'),
+      ).toBeVisible();
+
+      await expect(
+        alicePage.locator('[data-testid="hand-results-modal"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="close-hand-results-button"]');
+      await expect(
+        alicePage.locator('[data-testid="hand-results-modal"]'),
+      ).toHaveCount(0);
+      await expect(
+        alicePage.locator('[data-testid="end-game-button"]'),
+      ).toBeVisible();
+
+      await expect(
+        bobPage.locator('[data-testid="hand-results-modal"]'),
+      ).toBeVisible();
+      await bobPage.click('[data-testid="close-hand-results-button"]');
+      await expect(
+        bobPage.locator('[data-testid="hand-results-modal"]'),
+      ).toHaveCount(0);
+
+      await bobPage.click('[data-testid="open-rankings-button"]');
+      await expect(
+        bobPage.locator('[data-testid="rankings-modal"]'),
+      ).toBeVisible();
+
+      await alicePage.click('[data-testid="end-game-button"]');
+      await expect(
+        alicePage.locator('[data-testid="end-game-confirm-modal"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="end-game-confirm-accept"]');
+
+      await expect(
+        bobPage.locator('[data-testid="final-summary-modal"]'),
+      ).toBeVisible();
+      await expect(
+        bobPage.locator('[data-testid="rankings-modal"]'),
+      ).toHaveCount(0);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('@critical 8.5: Players Can Ready Next Hand After Break', async ({
     browser,
   }) => {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -7701,6 +7701,79 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.9e: Reopened Rankings Are Preempted Again When Action-Bar State Returns', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser);
+
+    try {
+      const { alicePage, bobPage } = session;
+      await startGameFromLobby(alicePage, bobPage);
+
+      await waitForPlayerTurn(bobPage, 'Bob');
+      const firstHandCompletePromise = captureNextHandComplete(alicePage, 20000, [
+        alicePage,
+        bobPage,
+      ]);
+      await bobPage.click('[data-testid="action-fold"]');
+      await expect(
+        alicePage.locator('[data-testid="reveal-next-street-action-area"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="reveal-next-street-button"]');
+      await firstHandCompletePromise;
+
+      await expect(
+        alicePage.locator('[data-testid="hand-results-modal"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="close-hand-results-button"]');
+      await expect(
+        alicePage.locator('[data-testid="hand-results-modal"]'),
+      ).toHaveCount(0);
+
+      await expect(
+        bobPage.locator('[data-testid="hand-results-modal"]'),
+      ).toBeVisible();
+      await bobPage.click('[data-testid="close-hand-results-button"]');
+      await expect(
+        bobPage.locator('[data-testid="hand-results-modal"]'),
+      ).toHaveCount(0);
+
+      await bobPage.click('[data-testid="open-rankings-button"]');
+      await expect(
+        bobPage.locator('[data-testid="rankings-modal"]'),
+      ).toBeVisible();
+
+      await expect(
+        alicePage.locator('[data-testid="start-next-hand-button"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="start-next-hand-button"]');
+      await waitForHandStart(alicePage, 2);
+
+      await expect(
+        bobPage.locator('[data-testid="rankings-modal"]'),
+      ).toBeVisible();
+
+      await waitForPlayerTurn(alicePage, 'Alice');
+      const secondHandCompletePromise = captureNextHandComplete(bobPage, 20000, [
+        alicePage,
+        bobPage,
+      ]);
+      await alicePage.click('[data-testid="action-fold"]');
+
+      await expect(
+        bobPage.locator('[data-testid="reveal-next-street-action-area"]'),
+      ).toBeVisible();
+      await expect(
+        bobPage.locator('[data-testid="rankings-modal"]'),
+      ).toHaveCount(0);
+
+      await bobPage.click('[data-testid="reveal-next-street-button"]');
+      await secondHandCompletePromise;
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('8.10: Rejected Action Shows Detailed Error Modal', async ({
     browser,
   }) => {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -7567,6 +7567,79 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.9d: Rankings Can Open After Hand Results Are Dismissed At Hand End', async ({ browser }) => {
+    const session = await setupTwoPlayerSession(browser);
+
+    try {
+      const { alicePage, bobPage } = session;
+      await startGameFromLobby(alicePage, bobPage);
+
+      await waitForPlayerTurn(bobPage, 'Bob');
+      const handCompletePromise = captureNextHandComplete(alicePage, 20000, [
+        alicePage,
+        bobPage,
+      ]);
+      await bobPage.click('[data-testid="action-fold"]');
+      await expect(
+        alicePage.locator('[data-testid="reveal-next-street-action-area"]'),
+      ).toBeVisible();
+      await alicePage.click('[data-testid="reveal-next-street-button"]');
+      await handCompletePromise;
+
+      await expect(
+        alicePage.locator('[data-testid="hand-results-modal"]'),
+      ).toBeVisible();
+
+      await alicePage.click('[data-testid="close-hand-results-button"]');
+      await expect(
+        alicePage.locator('[data-testid="hand-results-modal"]'),
+      ).toHaveCount(0);
+      await expect(
+        alicePage.locator('[data-testid="start-next-hand-button"]'),
+      ).toBeVisible();
+
+      await alicePage.click('[data-testid="open-rankings-button"]');
+
+      await expect(
+        alicePage.locator('[data-testid="rankings-modal"]'),
+      ).toBeVisible();
+      await alicePage.waitForTimeout(300);
+      await expect(
+        alicePage.locator('[data-testid="rankings-modal"]'),
+      ).toBeVisible();
+
+      await alicePage.click('[data-testid="close-rankings-button"]');
+      await expect(
+        alicePage.locator('[data-testid="rankings-modal"]'),
+      ).toHaveCount(0);
+
+      await alicePage.click('[data-testid="open-rules-button"]');
+      await expect(
+        alicePage.locator('[data-testid="rules-modal"]'),
+      ).toBeVisible();
+      await alicePage.waitForTimeout(300);
+      await expect(
+        alicePage.locator('[data-testid="rules-modal"]'),
+      ).toBeVisible();
+
+      await alicePage.click('[data-testid="close-rules-button"]');
+      await expect(
+        alicePage.locator('[data-testid="rules-modal"]'),
+      ).toHaveCount(0);
+
+      await alicePage.click('[data-testid="open-settings-button"]');
+      await expect(
+        alicePage.locator('[data-testid="settings-modal"]'),
+      ).toBeVisible();
+      await alicePage.waitForTimeout(300);
+      await expect(
+        alicePage.locator('[data-testid="settings-modal"]'),
+      ).toBeVisible();
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('8.10: Rejected Action Shows Detailed Error Modal', async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary

- narrow `GameRoom` informational-modal preemption so only active in-hand action states force-close rankings, rules, or settings
- keep the existing hand-results takeover regression in place while restoring post-hand reopening for rankings, rules, and settings after hand-results dismissal
- add comprehensive Playwright coverage for end-of-hand reopening, game-end final-summary takeover, and re-preemption when the table returns to an active action-bar state

## Linked Issue

Closes #174

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/174#issuecomment-4272508093

## Validation

- `pnpm --dir poker-client build`
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep '8\.9[c-d]:' --reporter=line`
- `PW_FRONTEND_PORT=5191 PW_BACKEND_PORT=3018 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep '8\.4[f-g]:' --reporter=line`
- `PW_FRONTEND_PORT=5193 PW_BACKEND_PORT=3020 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep '8\.4[f-g]:|8\.9[c-e]:' --reporter=line`
