### PR TITLE
fix: expose actionable passkey login blockers on desktop Chrome

### DIFF
--- a/poker-client/src/contexts/AuthContext.tsx
+++ b/poker-client/src/contexts/AuthContext.tsx
@@ -14,6 +14,12 @@ import {
 } from "@simplewebauthn/browser";
 import type { AuthModes, AuthUser } from "poker-types";
 import { authService } from "@/services/auth.service";
+import { getPasskeySupportState, type PasskeySupportIssue } from "@/utils/browser-detection";
+import {
+  createPasskeySupportError,
+  extractPasskeyRpId,
+  normalizePasskeyBrowserError,
+} from "@/utils/passkey-errors";
 import { clearPendingInviteRoom } from "@/utils/pending-invite-room";
 
 type AuthContextType = {
@@ -22,6 +28,7 @@ type AuthContextType = {
   isInitializing: boolean;
   isAuthenticated: boolean;
   passkeySupported: boolean;
+  passkeySupportIssue: PasskeySupportIssue | null;
   refreshSession: () => Promise<void>;
   registerWithPasskey: (
     displayName: string,
@@ -58,9 +65,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   const [authModes, setAuthModes] = useState<AuthModes>(defaultModes);
   const [isInitializing, setIsInitializing] = useState(true);
 
-  const passkeySupported =
-    typeof window !== "undefined" &&
-    typeof window.PublicKeyCredential !== "undefined";
+  const passkeySupportState = getPasskeySupportState();
+  const passkeySupported = passkeySupportState.supported;
+  const passkeySupportIssue = passkeySupportState.supported
+    ? null
+    : passkeySupportState.issue;
 
   const persistSession = useCallback((nextUser: AuthUser) => {
     setUser(nextUser);
@@ -103,18 +112,34 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   const registerWithPasskey = useCallback(
     async (displayName: string, avatarEmoji: string) => {
       if (!passkeySupported) {
-        throw new Error("Passkey is not supported on this browser");
+        throw createPasskeySupportError(passkeySupportIssue);
       }
 
       const start = await authService.startPasskeyRegister(
         displayName,
         avatarEmoji,
       );
-      const passkeyResponse = await startRegistration({
-        optionsJSON: start.options as Parameters<
-          typeof startRegistration
-        >[0]["optionsJSON"],
-      });
+      let passkeyResponse: Awaited<ReturnType<typeof startRegistration>>;
+      try {
+        passkeyResponse = await startRegistration({
+          optionsJSON: start.options as Parameters<
+            typeof startRegistration
+          >[0]["optionsJSON"],
+        });
+      } catch (error) {
+        const normalizedError = normalizePasskeyBrowserError(error, {
+          rpId: extractPasskeyRpId(start.options),
+        });
+        if (normalizedError) {
+          console.warn("Passkey registration failed before server verification", {
+            code: normalizedError.code,
+            details: normalizedError.details,
+            error,
+          });
+          throw normalizedError;
+        }
+        throw error;
+      }
       const finish = await authService.finishPasskeyRegister(
         start.flowId,
         passkeyResponse,
@@ -122,27 +147,43 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       persistSession(finish.user);
       setAuthModes(finish.authModes);
     },
-    [passkeySupported, persistSession],
+    [passkeySupportIssue, passkeySupported, persistSession],
   );
 
   const loginWithPasskey = useCallback(async () => {
     if (!passkeySupported) {
-      throw new Error("Passkey is not supported on this browser");
+      throw createPasskeySupportError(passkeySupportIssue);
     }
 
     const start = await authService.startPasskeyLogin();
-    const passkeyResponse = await startAuthentication({
-      optionsJSON: start.options as Parameters<
-        typeof startAuthentication
-      >[0]["optionsJSON"],
-    });
+    let passkeyResponse: Awaited<ReturnType<typeof startAuthentication>>;
+    try {
+      passkeyResponse = await startAuthentication({
+        optionsJSON: start.options as Parameters<
+          typeof startAuthentication
+        >[0]["optionsJSON"],
+      });
+    } catch (error) {
+      const normalizedError = normalizePasskeyBrowserError(error, {
+        rpId: extractPasskeyRpId(start.options),
+      });
+      if (normalizedError) {
+        console.warn("Passkey login failed before server verification", {
+          code: normalizedError.code,
+          details: normalizedError.details,
+          error,
+        });
+        throw normalizedError;
+      }
+      throw error;
+    }
     const finish = await authService.finishPasskeyLogin(
       start.flowId,
       passkeyResponse,
     );
     persistSession(finish.user);
     setAuthModes(finish.authModes);
-  }, [passkeySupported, persistSession]);
+  }, [passkeySupportIssue, passkeySupported, persistSession]);
 
   const loginWithPassword = useCallback(
     async (accountId: string, password: string) => {
@@ -188,6 +229,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       isInitializing,
       isAuthenticated: Boolean(user),
       passkeySupported,
+      passkeySupportIssue,
       refreshSession,
       registerWithPasskey,
       loginWithPasskey,
@@ -200,6 +242,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       authModes,
       isInitializing,
       passkeySupported,
+      passkeySupportIssue,
       refreshSession,
       registerWithPasskey,
       loginWithPasskey,

--- a/poker-client/src/i18n/messages.ts
+++ b/poker-client/src/i18n/messages.ts
@@ -45,6 +45,16 @@ export const EN_MESSAGES = {
   "auth.error.displayNameRequired": "Please enter a display name first",
   "auth.error.registerFailed": "Registration failed",
   "auth.error.passkeyLoginFailed": "Passkey login failed",
+  "auth.error.passkeyInsecureContext":
+    "Passkey requires a secure browser context. Open Poker from HTTPS or localhost, not from an insecure page.",
+  "auth.error.passkeyEmbeddedContext":
+    "Passkey must run in a top-level browser tab or window. Open Poker directly in Chrome, Safari, or another system browser.",
+  "auth.error.passkeyRpIdMismatch":
+    "This page is using a different host than the passkey's site. Open Poker on the same host you used when registering the passkey.",
+  "auth.error.passkeyNotAllowed":
+    "Chrome did not complete the passkey request. Approve the system prompt if it appears; otherwise make sure this browser profile or device already has a passkey for this host, or register again here.",
+  "auth.error.passkeyUnknownBrowserFailure":
+    "Passkey failed before the server could verify it. Try again, or use password login for a test account.",
   "auth.passkeyNeedProfileInfo":
     "No passkey registration found. Please set display name and avatar, then tap register above.",
   "auth.error.accountRequired": "Please enter a test account",
@@ -540,6 +550,16 @@ const ZH_HANS_MESSAGES: Record<MessageKey, string> = {
   "auth.error.displayNameRequired": "请先输入显示用户名",
   "auth.error.registerFailed": "注册失败",
   "auth.error.passkeyLoginFailed": "Passkey 登录失败",
+  "auth.error.passkeyInsecureContext":
+    "Passkey 需要安全上下文。请通过 HTTPS 或 localhost 打开 Poker，不要在不安全页面中使用。",
+  "auth.error.passkeyEmbeddedContext":
+    "Passkey 必须在顶层浏览器标签页或窗口中运行。请直接在 Chrome、Safari 或其他系统浏览器中打开 Poker。",
+  "auth.error.passkeyRpIdMismatch":
+    "当前页面使用的主机与注册 Passkey 时的站点不一致。请回到注册该 Passkey 时使用的同一主机打开 Poker。",
+  "auth.error.passkeyNotAllowed":
+    "Chrome 没有完成这次 Passkey 请求。请先确认系统弹窗；如果没有可用 Passkey，请确认当前浏览器配置或设备上已为这个主机保存 Passkey，或者在这里重新注册。",
+  "auth.error.passkeyUnknownBrowserFailure":
+    "Passkey 在服务器校验前就失败了。请重试；如果这是测试账号，也可以先使用密码登录。",
   "auth.passkeyNeedProfileInfo": "未找到已注册的 Passkey。请先填写显示用户名和头像，再点击上方注册按钮。",
   "auth.error.accountRequired": "请输入测试账号",
   "auth.error.passwordTooShort": "密码至少 8 位",

--- a/poker-client/src/pages/Auth.tsx
+++ b/poker-client/src/pages/Auth.tsx
@@ -2,11 +2,14 @@ import React, { useMemo, useState } from "react";
 import { PLAYER_EMOJI_OPTIONS, getRandomPlayerEmoji } from "@/constants/player-emojis";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLocalization } from "@/contexts/LocalizationContext";
+import type { MessageKey } from "@/i18n/messages";
+import { getPasskeyErrorTranslationKey } from "@/utils/passkey-errors";
 
 export const AuthPage: React.FC = () => {
   const {
     authModes,
     passkeySupported,
+    passkeySupportIssue,
     registerWithPasskey,
     loginWithPasskey,
     loginWithPassword,
@@ -24,6 +27,26 @@ export const AuthPage: React.FC = () => {
     () => isSubmitting || !passkeySupported,
     [isSubmitting, passkeySupported],
   );
+
+  const unsupportedPasskeyMessage = useMemo(() => {
+    switch (passkeySupportIssue) {
+      case "insecure-context":
+        return t("auth.error.passkeyInsecureContext");
+      case "embedded-context":
+        return t("auth.error.passkeyEmbeddedContext");
+      default:
+        return t("auth.passkeyUnsupported");
+    }
+  }, [passkeySupportIssue, t]);
+
+  const resolvePasskeyFeedback = (error: unknown, fallbackKey: MessageKey) => {
+    const translationKey = getPasskeyErrorTranslationKey(error);
+    if (translationKey) {
+      return t(translationKey);
+    }
+
+    return error instanceof Error ? error.message : t(fallbackKey);
+  };
 
   const shouldFallbackToRegister = (error: unknown): boolean => {
     if (!(error instanceof Error)) {
@@ -51,7 +74,7 @@ export const AuthPage: React.FC = () => {
     try {
       await registerWithPasskey(name, avatarEmoji);
     } catch (error) {
-      setFeedback(error instanceof Error ? error.message : t("auth.error.registerFailed"));
+      setFeedback(resolvePasskeyFeedback(error, "auth.error.registerFailed"));
     } finally {
       setIsSubmitting(false);
     }
@@ -65,7 +88,7 @@ export const AuthPage: React.FC = () => {
       await loginWithPasskey();
     } catch (error) {
       if (!shouldFallbackToRegister(error)) {
-        setFeedback(error instanceof Error ? error.message : t("auth.error.passkeyLoginFailed"));
+        setFeedback(resolvePasskeyFeedback(error, "auth.error.passkeyLoginFailed"));
         return;
       }
 
@@ -166,7 +189,7 @@ export const AuthPage: React.FC = () => {
 
             {!passkeySupported && (
               <p className="rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-                {t("auth.passkeyUnsupported")}
+                {unsupportedPasskeyMessage}
               </p>
             )}
           </div>

--- a/poker-client/src/utils/browser-detection.spec.ts
+++ b/poker-client/src/utils/browser-detection.spec.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getCurrentBrowserUrl,
+  getPasskeySupportState,
+  isHostnameCompatibleWithRpId,
   isIosDevice,
   isSafariOnIos,
   isWeChatInAppBrowser,
@@ -64,5 +66,79 @@ describe("browser-detection", () => {
     });
 
     expect(getCurrentBrowserUrl()).toBe("https://poker.example.com/room/ABCD?seat=2");
+  });
+
+  it("treats insecure contexts as passkey-unsupported even when WebAuthn exists", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        isSecureContext: false,
+        self: {},
+        top: {},
+      },
+    });
+    Object.defineProperty(globalThis, "PublicKeyCredential", {
+      configurable: true,
+      value: class PublicKeyCredential {},
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        credentials: {
+          create() {
+            return Promise.resolve(null);
+          },
+          get() {
+            return Promise.resolve(null);
+          },
+        },
+      },
+    });
+
+    expect(getPasskeySupportState()).toEqual({
+      supported: false,
+      issue: "insecure-context",
+    });
+  });
+
+  it("treats embedded contexts as passkey-unsupported", () => {
+    const topWindow = {};
+    const selfWindow = {};
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        isSecureContext: true,
+        self: selfWindow,
+        top: topWindow,
+      },
+    });
+    Object.defineProperty(globalThis, "PublicKeyCredential", {
+      configurable: true,
+      value: class PublicKeyCredential {},
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        credentials: {
+          create() {
+            return Promise.resolve(null);
+          },
+          get() {
+            return Promise.resolve(null);
+          },
+        },
+      },
+    });
+
+    expect(getPasskeySupportState()).toEqual({
+      supported: false,
+      issue: "embedded-context",
+    });
+  });
+
+  it("accepts exact rp ids and parent-domain rp ids for the current hostname", () => {
+    expect(isHostnameCompatibleWithRpId("localhost", "localhost")).toBe(true);
+    expect(isHostnameCompatibleWithRpId("app.poker.example.com", "poker.example.com")).toBe(true);
+    expect(isHostnameCompatibleWithRpId("127.0.0.1", "localhost")).toBe(false);
   });
 });

--- a/poker-client/src/utils/browser-detection.ts
+++ b/poker-client/src/utils/browser-detection.ts
@@ -24,6 +24,77 @@ export const isWeChatInAppBrowser = () => {
   return /MicroMessenger/i.test(userAgent);
 };
 
+export type PasskeySupportIssue =
+  | "missing-public-key-credential"
+  | "missing-credentials-api"
+  | "insecure-context"
+  | "embedded-context";
+
+export type PasskeySupportState =
+  | { supported: true; issue: null }
+  | { supported: false; issue: PasskeySupportIssue };
+
+export const getPasskeySupportState = (): PasskeySupportState => {
+  if (typeof PublicKeyCredential === "undefined") {
+    return {
+      supported: false,
+      issue: "missing-public-key-credential",
+    };
+  }
+
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.credentials?.create ||
+    !navigator.credentials?.get
+  ) {
+    return {
+      supported: false,
+      issue: "missing-credentials-api",
+    };
+  }
+
+  if (typeof window !== "undefined" && window.isSecureContext === false) {
+    return {
+      supported: false,
+      issue: "insecure-context",
+    };
+  }
+
+  if (
+    typeof window !== "undefined" &&
+    window.top &&
+    window.self &&
+    window.top !== window.self
+  ) {
+    return {
+      supported: false,
+      issue: "embedded-context",
+    };
+  }
+
+  return {
+    supported: true,
+    issue: null,
+  };
+};
+
+export const isHostnameCompatibleWithRpId = (
+  hostname: string,
+  rpId: string,
+) => {
+  const normalizedHostname = hostname.trim().toLowerCase();
+  const normalizedRpId = rpId.trim().toLowerCase();
+
+  if (!normalizedHostname || !normalizedRpId) {
+    return false;
+  }
+
+  return (
+    normalizedHostname === normalizedRpId ||
+    normalizedHostname.endsWith(`.${normalizedRpId}`)
+  );
+};
+
 export const getCurrentBrowserUrl = () => {
   if (typeof window === "undefined") {
     return "";

--- a/poker-client/src/utils/passkey-errors.spec.ts
+++ b/poker-client/src/utils/passkey-errors.spec.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  PasskeyClientError,
+  createPasskeySupportError,
+  getPasskeyErrorTranslationKey,
+  normalizePasskeyBrowserError,
+} from "./passkey-errors";
+
+describe("passkey-errors", () => {
+  const originalNavigator = globalThis.navigator;
+  const originalPublicKeyCredential = globalThis.PublicKeyCredential;
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: originalNavigator,
+    });
+    Object.defineProperty(globalThis, "PublicKeyCredential", {
+      configurable: true,
+      value: originalPublicKeyCredential,
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  it("maps preflight support failures to stable passkey client errors", () => {
+    const error = createPasskeySupportError("embedded-context");
+
+    expect(error).toBeInstanceOf(PasskeyClientError);
+    expect(error.code).toBe("embedded-context");
+    expect(getPasskeyErrorTranslationKey(error)).toBe(
+      "auth.error.passkeyEmbeddedContext",
+    );
+  });
+
+  it("maps browser-side not-allowed errors to an rp-id mismatch when the host differs", () => {
+    const browserWindow = {};
+    Object.defineProperty(globalThis, "PublicKeyCredential", {
+      configurable: true,
+      value: class PublicKeyCredential {},
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        credentials: {
+          create() {
+            return Promise.resolve(null);
+          },
+          get() {
+            return Promise.resolve(null);
+          },
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        isSecureContext: true,
+        location: {
+          hostname: "127.0.0.1",
+          origin: "http://127.0.0.1:5174",
+        },
+        self: browserWindow,
+        top: browserWindow,
+      },
+    });
+
+    const error = normalizePasskeyBrowserError(
+      Object.assign(new Error("The operation either timed out or was not allowed."), {
+        name: "NotAllowedError",
+      }),
+      { rpId: "localhost" },
+    );
+
+    expect(error).toBeInstanceOf(PasskeyClientError);
+    expect(error?.code).toBe("rp-id-mismatch");
+    expect(getPasskeyErrorTranslationKey(error)).toBe(
+      "auth.error.passkeyRpIdMismatch",
+    );
+  });
+
+  it("maps browser-side not-allowed errors to a recoverable no-credential guidance fallback", () => {
+    const browserWindow = {};
+    Object.defineProperty(globalThis, "PublicKeyCredential", {
+      configurable: true,
+      value: class PublicKeyCredential {},
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        credentials: {
+          create() {
+            return Promise.resolve(null);
+          },
+          get() {
+            return Promise.resolve(null);
+          },
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        isSecureContext: true,
+        location: {
+          hostname: "poker.example.com",
+          origin: "https://poker.example.com",
+        },
+        self: browserWindow,
+        top: browserWindow,
+      },
+    });
+
+    const error = normalizePasskeyBrowserError(
+      Object.assign(new Error("The operation either timed out or was not allowed."), {
+        name: "NotAllowedError",
+      }),
+      { rpId: "poker.example.com" },
+    );
+
+    expect(error).toBeInstanceOf(PasskeyClientError);
+    expect(error?.code).toBe("not-allowed");
+    expect(getPasskeyErrorTranslationKey(error)).toBe(
+      "auth.error.passkeyNotAllowed",
+    );
+  });
+});

--- a/poker-client/src/utils/passkey-errors.ts
+++ b/poker-client/src/utils/passkey-errors.ts
@@ -1,0 +1,141 @@
+import {
+  getPasskeySupportState,
+  isHostnameCompatibleWithRpId,
+  type PasskeySupportIssue,
+} from "./browser-detection";
+
+export type PasskeyClientErrorCode =
+  | PasskeySupportIssue
+  | "rp-id-mismatch"
+  | "not-allowed"
+  | "unknown-browser-error";
+
+export class PasskeyClientError extends Error {
+  readonly code: PasskeyClientErrorCode;
+  readonly details: Record<string, string>;
+
+  constructor(code: PasskeyClientErrorCode, details: Record<string, string> = {}) {
+    super(code);
+    this.code = code;
+    this.details = details;
+    this.name = "PasskeyClientError";
+  }
+}
+
+const isNotAllowedLikeError = (error: unknown) => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const normalizedName = error.name.toLowerCase();
+  const normalizedMessage = error.message.toLowerCase();
+
+  return (
+    normalizedName.includes("notallowed") ||
+    normalizedMessage.includes("timed out or was not allowed") ||
+    normalizedMessage.includes("not allowed")
+  );
+};
+
+export const createPasskeySupportError = (
+  issue: PasskeySupportIssue | null,
+) => {
+  switch (issue) {
+    case "insecure-context":
+    case "embedded-context":
+    case "missing-public-key-credential":
+    case "missing-credentials-api":
+      return new PasskeyClientError(issue);
+    default:
+      return new PasskeyClientError("unknown-browser-error");
+  }
+};
+
+export const extractPasskeyRpId = (options: unknown): string | null => {
+  if (!options || typeof options !== "object") {
+    return null;
+  }
+
+  const candidate = options as {
+    rpId?: unknown;
+    rp?: {
+      id?: unknown;
+    };
+  };
+
+  if (typeof candidate.rpId === "string" && candidate.rpId.trim()) {
+    return candidate.rpId.trim();
+  }
+
+  if (typeof candidate.rp?.id === "string" && candidate.rp.id.trim()) {
+    return candidate.rp.id.trim();
+  }
+
+  return null;
+};
+
+export const normalizePasskeyBrowserError = (
+  error: unknown,
+  context: {
+    rpId?: string | null;
+  } = {},
+): PasskeyClientError | null => {
+  const supportState = getPasskeySupportState();
+  if (!supportState.supported) {
+    return createPasskeySupportError(supportState.issue);
+  }
+
+  const currentHostname =
+    typeof window !== "undefined" ? window.location.hostname : "";
+  const rpId = context.rpId?.trim();
+
+  if (
+    rpId &&
+    currentHostname &&
+    !isHostnameCompatibleWithRpId(currentHostname, rpId)
+  ) {
+    return new PasskeyClientError("rp-id-mismatch", {
+      currentHostname,
+      rpId,
+    });
+  }
+
+  if (isNotAllowedLikeError(error)) {
+    return new PasskeyClientError("not-allowed", {
+      rpId: rpId || "",
+      currentOrigin:
+        typeof window !== "undefined" ? window.location.origin : "",
+    });
+  }
+
+  if (error instanceof Error) {
+    return new PasskeyClientError("unknown-browser-error", {
+      name: error.name,
+    });
+  }
+
+  return null;
+};
+
+export const getPasskeyErrorTranslationKey = (error: unknown) => {
+  if (!(error instanceof PasskeyClientError)) {
+    return null;
+  }
+
+  switch (error.code) {
+    case "insecure-context":
+      return "auth.error.passkeyInsecureContext";
+    case "embedded-context":
+      return "auth.error.passkeyEmbeddedContext";
+    case "missing-public-key-credential":
+    case "missing-credentials-api":
+      return "auth.passkeyUnsupported";
+    case "rp-id-mismatch":
+      return "auth.error.passkeyRpIdMismatch";
+    case "not-allowed":
+      return "auth.error.passkeyNotAllowed";
+    case "unknown-browser-error":
+    default:
+      return "auth.error.passkeyUnknownBrowserFailure";
+  }
+};


### PR DESCRIPTION
## Summary
- replace raw browser-side WebAuthn error text on the auth page with localized passkey diagnostics
- preflight passkey runtime support for insecure and embedded browser contexts before invoking WebAuthn
- detect and surface likely RP/host mismatches from WebAuthn options so `localhost` vs `127.0.0.1` style drift is exposed directly
- add focused client coverage for passkey support detection and browser-side error normalization

## Linked Issue
Closes #176

## Closeout Checklist
- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit
- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/176#issuecomment-4272529029

## Validation
- `pnpm --dir poker-client test`
- `pnpm --dir poker-client build`
- No compatible real passkey environment was available in this workspace, so a live browser passkey smoke was not run
