### PR TITLE
fix: support OpenAI responses models through compatible gateways

### DIFF
--- a/poker-server/README.md
+++ b/poker-server/README.md
@@ -76,8 +76,18 @@ AI_ROBOT_TEMPERATURE=0.3
 Use the provider API root for `AI_ROBOT_BASE_URL`. Do not point it directly at
 `/chat/completions` or `/responses`, because the SDK appends the required path.
 Set `AI_ROBOT_API_MODE=responses` for providers such as Volcengine/Doubao that
-require the Responses API. `AI_ROBOT_TEMPERATURE` is used in `chat` mode and is
-ignored when `AI_ROBOT_API_MODE=responses`.
+require the Responses API, including OpenAI-compatible gateways that proxy GPT-5
+models. Example:
+
+```bash
+AI_ROBOT_API_KEY=...
+AI_ROBOT_BASE_URL=https://api.hanbbq.top/v1
+AI_ROBOT_MODEL_ID=gpt-5.4
+AI_ROBOT_API_MODE=responses
+```
+
+`AI_ROBOT_TEMPERATURE` is used in `chat` mode and is ignored when
+`AI_ROBOT_API_MODE=responses`.
 
 ## Deployment
 

--- a/poker-server/src/game/openai-responses-compat.ts
+++ b/poker-server/src/game/openai-responses-compat.ts
@@ -114,7 +114,7 @@ export function isVolcengineResponsesBaseUrl(baseURL: string): boolean {
   }
 }
 
-export function createVolcengineResponsesCompatFetch(
+export function createResponsesCompatFetch(
   fetchImpl: CompatibleFetch = globalThis.fetch,
 ): CompatibleFetch {
   return async (input, init) => {
@@ -156,3 +156,5 @@ export function createVolcengineResponsesCompatFetch(
     });
   };
 }
+
+export const createVolcengineResponsesCompatFetch = createResponsesCompatFetch;

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -6,8 +6,7 @@ import {
 } from 'poker-types';
 import { z } from 'zod';
 import {
-  createVolcengineResponsesCompatFetch,
-  isVolcengineResponsesBaseUrl,
+  createResponsesCompatFetch,
 } from './openai-responses-compat';
 
 export type RobotActionCandidate = {
@@ -354,9 +353,7 @@ export class RobotAgentService {
         name: `${providerNamePrefix}-openai-responses`,
         baseURL,
         apiKey,
-        ...(isVolcengineResponsesBaseUrl(baseURL)
-          ? { fetch: createVolcengineResponsesCompatFetch() }
-          : {}),
+        fetch: createResponsesCompatFetch(),
       });
       return provider.responses(modelId);
     }

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -197,6 +197,26 @@ describe('RobotAgentService', () => {
     expect(capturedConfig).not.toHaveProperty('temperature');
   });
 
+  it('applies responses compatibility fetch for non-Volcengine OpenAI-compatible gateways', () => {
+    process.env.AI_ROBOT_BASE_URL = 'https://api.hanbbq.top/v1';
+
+    const responses = jest.fn().mockReturnValue('responses-model');
+    mockCreateOpenAI.mockReturnValue({ responses });
+
+    const service = new RobotAgentService();
+    const model = service.createConfiguredModel('robot');
+
+    expect(model).toBe('responses-model');
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'robot-openai-responses',
+        baseURL: 'https://api.hanbbq.top/v1',
+        apiKey: 'test-key',
+        fetch: expect.any(Function),
+      }),
+    );
+  });
+
   it('falls back to the latest validated tool candidate when structured output is invalid', async () => {
     mockToolLoopAgent.mockImplementation((config) => ({
       generate: jest.fn().mockImplementation(async () => {


### PR DESCRIPTION
## Summary
- make the server-side `responses` robot provider always use the existing responses compatibility fetch instead of gating it on a Volcengine hostname
- add focused coverage for a non-Volcengine OpenAI-compatible gateway path using `https://api.hanbbq.top/v1` with `gpt-5.4`
- document the supported `AI_ROBOT_*` configuration for OpenAI models proxied through an OpenAI-compatible gateway

## Validation
- `pnpm --dir poker-server exec jest test/unit/robot-agent.service.spec.ts --runInBand`
- `pnpm --dir poker-server exec jest test/unit/openai-responses-compat.spec.ts --runInBand`
- `pnpm --dir poker-server build`

Closes #179
