### PR TITLE
fix: reconcile saved-history session stats expectation in comprehensive export validation

### DIFF
--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -9535,11 +9535,14 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
           (mobileHistoryLayout?.selectedHandTop ?? Number.NEGATIVE_INFINITY),
       ).toBe(true);
       await bobPage.click('[data-testid="saved-history-mobile-tab-session"]');
+      const mobileSessionPanel = bobPage.locator(
+        '[data-testid="saved-history-mobile-session-panel"]',
+      );
+      await expect(mobileSessionPanel).toBeVisible();
       await expect(
-        bobPage.locator('[data-testid="saved-history-mobile-session-panel"]'),
+        mobileSessionPanel.getByRole('heading', { name: 'Session Statistics' }),
       ).toBeVisible();
-      await expect(bobPage.getByText('Session Statistics')).toBeVisible();
-      await expect(bobPage.getByText(/^Robot\b/)).toHaveCount(0);
+      await expect(mobileSessionPanel.getByText(/^Robot\b/)).toHaveCount(0);
       await bobPage.setViewportSize({ width: 1440, height: 900 });
       await expect(
         bobPage.getByRole('columnheader', { name: 'Buy-in' }),


### PR DESCRIPTION
## Summary

- Scope the saved-history session assertions to the visible mobile session panel instead of page-global text queries.

## Linked Issue

Closes #172

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/172#issuecomment-4272531092

## Validation

- PASS: PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 TEST_MODE=true pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep "8\.15b: Hand Results Export, Review Unavailable State, And Final Full Export" --reporter=line
- INFO: PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server run test:e2e:playwright:comprehensive (executed previously on the rebased branch; remaining failures were outside #172 scope)
