### PR TITLE
fix: keep large saved-game history detail responsive and stop archive-detail crashes

### DIFF
--- a/poker-client/src/pages/SavedGameDetail.spec.ts
+++ b/poker-client/src/pages/SavedGameDetail.spec.ts
@@ -238,6 +238,19 @@ const buildDetail = () => ({
   ],
 });
 
+const buildSummaryOnlyDetail = () => {
+  const detail = buildDetail();
+  return {
+    ...detail,
+    hands: detail.hands.map((hand) => ({
+      handNumber: hand.handNumber,
+      totalPot: hand.history.settlement.totalPot,
+      actionCount: hand.history.actions.length,
+      analysis: hand.analysis,
+    })),
+  };
+};
+
 const t = (key: MessageKey, values?: Record<string, string | number>) => {
   if (!values) {
     return key;
@@ -247,9 +260,29 @@ const t = (key: MessageKey, values?: Record<string, string | number>) => {
 };
 
 const renderView = () =>
-  renderToStaticMarkup(
-    React.createElement(SavedGameDetailView, {
-      detail: buildDetail(),
+  (() => {
+    const detail = buildDetail();
+    return renderToStaticMarkup(
+      React.createElement(SavedGameDetailView, {
+        detail,
+        selectedHand: detail.hands[0],
+        selectedHandNumber: 1,
+        locale: "en" satisfies Locale,
+        localeTag: "en-US",
+        t,
+        onBackToHistory: vi.fn(),
+        onBackToLobby: vi.fn(),
+        onSelectHandNumber: vi.fn(),
+      }),
+    );
+  })();
+
+const renderSummaryOnlyView = () => {
+  const detail = buildDetail();
+  return renderToStaticMarkup(
+    React.createElement(SavedGameDetailView as any, {
+      detail: buildSummaryOnlyDetail(),
+      selectedHand: detail.hands[0],
       selectedHandNumber: 1,
       locale: "en" satisfies Locale,
       localeTag: "en-US",
@@ -259,6 +292,7 @@ const renderView = () =>
       onSelectHandNumber: vi.fn(),
     }),
   );
+};
 
 describe("SavedGameDetailView", () => {
   it("keeps history and lobby navigation visible in shell states like loading or error", () => {
@@ -321,5 +355,13 @@ describe("SavedGameDetailView", () => {
     expect(desktopHandListStart).toBeGreaterThan(standingsSectionStart);
     expect(standingsSection).toContain("game.rankings.buyIn");
     expect(standingsSection).toContain("$1000");
+  });
+
+  it("renders selected-hand detail from a separately loaded hand while the archive hand list stays summary-only", () => {
+    const html = renderSummaryOnlyView();
+
+    expect(html).toContain("history.handLabel:{&quot;handNumber&quot;:1}");
+    expect(html).toContain("history.handPot:{&quot;amount&quot;:80}");
+    expect(html).toContain("history.handPot:{&quot;amount&quot;:15}");
   });
 });

--- a/poker-client/src/pages/SavedGameDetail.spec.ts
+++ b/poker-client/src/pages/SavedGameDetail.spec.ts
@@ -2,7 +2,11 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import type { MessageKey, Locale } from "@/i18n/messages";
-import { SavedGameDetailShell, SavedGameDetailView } from "./SavedGameDetail";
+import {
+  SavedGameDetailShell,
+  SavedGameDetailView,
+  shouldLoadSelectedHandDetail,
+} from "./SavedGameDetail";
 
 const buildDetail = () => ({
   archiveId: "G5V69T",
@@ -266,6 +270,7 @@ const renderView = () =>
       React.createElement(SavedGameDetailView, {
         detail,
         selectedHand: detail.hands[0],
+        selectedHandLoadError: null,
         selectedHandNumber: 1,
         locale: "en" satisfies Locale,
         localeTag: "en-US",
@@ -283,6 +288,7 @@ const renderSummaryOnlyView = () => {
     React.createElement(SavedGameDetailView as any, {
       detail: buildSummaryOnlyDetail(),
       selectedHand: detail.hands[0],
+      selectedHandLoadError: null,
       selectedHandNumber: 1,
       locale: "en" satisfies Locale,
       localeTag: "en-US",
@@ -363,5 +369,67 @@ describe("SavedGameDetailView", () => {
     expect(html).toContain("history.handLabel:{&quot;handNumber&quot;:1}");
     expect(html).toContain("history.handPot:{&quot;amount&quot;:80}");
     expect(html).toContain("history.handPot:{&quot;amount&quot;:15}");
+  });
+
+  it("keeps the archive shell visible when the selected hand fails to load", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SavedGameDetailView as any, {
+        detail: buildSummaryOnlyDetail(),
+        selectedHand: null,
+        selectedHandLoadError: "Saved hand unavailable",
+        selectedHandNumber: 2,
+        locale: "en" satisfies Locale,
+        localeTag: "en-US",
+        t,
+        onBackToHistory: vi.fn(),
+        onBackToLobby: vi.fn(),
+        onSelectHandNumber: vi.fn(),
+      }),
+    );
+
+    expect(html).toContain('data-testid="saved-history-mobile-hand-strip"');
+    expect(html).toContain('data-testid="saved-history-desktop-hand-list"');
+    expect(html).toContain("Saved hand unavailable");
+  });
+});
+
+describe("shouldLoadSelectedHandDetail", () => {
+  it("waits for the current archive summary and ignores stale or cached selections", () => {
+    const detail = buildSummaryOnlyDetail();
+
+    expect(
+      shouldLoadSelectedHandDetail({
+        archiveId: detail.archiveId,
+        detail,
+        selectedHandNumber: 1,
+        handDetailsByNumber: {},
+      }),
+    ).toBe(true);
+    expect(
+      shouldLoadSelectedHandDetail({
+        archiveId: "NEXT",
+        detail,
+        selectedHandNumber: 1,
+        handDetailsByNumber: {},
+      }),
+    ).toBe(false);
+    expect(
+      shouldLoadSelectedHandDetail({
+        archiveId: detail.archiveId,
+        detail,
+        selectedHandNumber: 999,
+        handDetailsByNumber: {},
+      }),
+    ).toBe(false);
+    expect(
+      shouldLoadSelectedHandDetail({
+        archiveId: detail.archiveId,
+        detail,
+        selectedHandNumber: 1,
+        handDetailsByNumber: {
+          1: buildDetail().hands[0],
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/poker-client/src/pages/SavedGameDetail.tsx
+++ b/poker-client/src/pages/SavedGameDetail.tsx
@@ -148,6 +148,7 @@ type TranslationFn = (
 type SavedGameDetailViewProps = {
   detail: SavedGameDetail;
   selectedHand: SavedGameHandDetail | null;
+  selectedHandLoadError?: string | null;
   selectedHandNumber: number | null;
   locale: string;
   localeTag: string;
@@ -169,6 +170,13 @@ type SavedGameDetailShellProps = {
 
 type MobileDetailSection = "overview" | "actions" | "review" | "session";
 
+type SelectedHandLoadState = {
+  archiveId: string;
+  detail: SavedGameDetail | null;
+  selectedHandNumber: number | null;
+  handDetailsByNumber: Record<number, SavedGameHandDetail>;
+};
+
 const MOBILE_DETAIL_SECTIONS: Array<{
   id: MobileDetailSection;
   labelKey: MessageKey;
@@ -178,6 +186,24 @@ const MOBILE_DETAIL_SECTIONS: Array<{
   { id: "review", labelKey: "history.mobileSection.review" },
   { id: "session", labelKey: "history.mobileSection.session" },
 ];
+
+export const shouldLoadSelectedHandDetail = ({
+  archiveId,
+  detail,
+  selectedHandNumber,
+  handDetailsByNumber,
+}: SelectedHandLoadState) => {
+  if (!archiveId || !detail || detail.archiveId !== archiveId) {
+    return false;
+  }
+  if (selectedHandNumber === null) {
+    return false;
+  }
+  if (!detail.hands.some((hand) => hand.handNumber === selectedHandNumber)) {
+    return false;
+  }
+  return !handDetailsByNumber[selectedHandNumber];
+};
 
 const SectionShell: React.FC<{
   children: React.ReactNode;
@@ -190,6 +216,22 @@ const SectionShell: React.FC<{
   >
     {children}
   </section>
+);
+
+const SelectedHandErrorPanel: React.FC<{
+  handNumber: number;
+  error: string;
+  t: TranslationFn;
+  testId?: string;
+}> = ({ handNumber, error, t, testId }) => (
+  <SectionShell testId={testId}>
+    <h2 className="text-lg font-bold text-white">
+      {t("history.handLabel", { handNumber })}
+    </h2>
+    <div className="mt-4 rounded-xl border border-rose-400/50 bg-rose-500/10 px-4 py-5 text-sm text-rose-100">
+      {error}
+    </div>
+  </SectionShell>
 );
 
 const SummaryStatCard: React.FC<{
@@ -566,6 +608,7 @@ export const SavedGameDetailShell: React.FC<SavedGameDetailShellProps> = ({
 export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
   detail,
   selectedHand,
+  selectedHandLoadError = null,
   selectedHandNumber,
   locale,
   localeTag,
@@ -638,6 +681,15 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
                 ))}
               </div>
             </SectionShell>
+
+            {!selectedHand && selectedHandNumber !== null && selectedHandLoadError && (
+              <SelectedHandErrorPanel
+                handNumber={selectedHandNumber}
+                error={selectedHandLoadError}
+                t={t}
+                testId="saved-history-mobile-selected-hand-error"
+              />
+            )}
 
             {selectedHand && (
               <>
@@ -903,6 +955,15 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
                 </div>
               </SectionShell>
 
+              {!selectedHand && selectedHandNumber !== null && selectedHandLoadError && (
+                <SelectedHandErrorPanel
+                  handNumber={selectedHandNumber}
+                  error={selectedHandLoadError}
+                  t={t}
+                  testId="saved-history-desktop-selected-hand-error"
+                />
+              )}
+
               {selectedHand && (
                 <SectionShell>
                   <h2 className="text-lg font-bold text-white">
@@ -935,6 +996,9 @@ export const SavedGameDetailPage: React.FC = () => {
   const [handDetailsByNumber, setHandDetailsByNumber] = useState<
     Record<number, SavedGameHandDetail>
   >({});
+  const [handLoadErrorsByNumber, setHandLoadErrorsByNumber] = useState<
+    Record<number, string>
+  >({});
   const [selectedHandNumber, setSelectedHandNumber] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -951,7 +1015,10 @@ export const SavedGameDetailPage: React.FC = () => {
 
       setIsLoading(true);
       setError(null);
+      setDetail(null);
+      setSelectedHandNumber(null);
       setHandDetailsByNumber({});
+      setHandLoadErrorsByNumber({});
       try {
         const nextDetail = await savedGameHistoryService.getSavedGameDetail(
           archiveId,
@@ -991,17 +1058,22 @@ export const SavedGameDetailPage: React.FC = () => {
     let cancelled = false;
 
     const loadSelectedHand = async () => {
-      if (!archiveId || selectedHandNumber === null) {
+      if (
+        !shouldLoadSelectedHandDetail({
+          archiveId,
+          detail,
+          selectedHandNumber,
+          handDetailsByNumber,
+        })
+      ) {
         return;
       }
-      if (handDetailsByNumber[selectedHandNumber]) {
-        return;
-      }
+      const handNumber = selectedHandNumber as number;
 
       try {
         const handDetail = await savedGameHistoryService.getSavedGameHandDetail(
           archiveId,
-          selectedHandNumber,
+          handNumber,
           locale,
         );
         if (!cancelled) {
@@ -1009,14 +1081,24 @@ export const SavedGameDetailPage: React.FC = () => {
             ...current,
             [handDetail.handNumber]: handDetail,
           }));
+          setHandLoadErrorsByNumber((current) => {
+            if (!(handDetail.handNumber in current)) {
+              return current;
+            }
+            const next = { ...current };
+            delete next[handDetail.handNumber];
+            return next;
+          });
         }
       } catch (loadError) {
         if (!cancelled) {
-          setError(
-            loadError instanceof Error
-              ? loadError.message
-              : t("history.detailLoadFailed"),
-          );
+          setHandLoadErrorsByNumber((current) => ({
+            ...current,
+            [handNumber]:
+              loadError instanceof Error
+                ? loadError.message
+                : t("history.detailLoadFailed"),
+          }));
         }
       }
     };
@@ -1026,7 +1108,7 @@ export const SavedGameDetailPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [archiveId, handDetailsByNumber, locale, selectedHandNumber, t]);
+  }, [archiveId, detail, handDetailsByNumber, locale, selectedHandNumber, t]);
 
   const localeTag = useMemo(
     () => (locale === "zh_hans" ? "zh-Hans-CN" : "en-US"),
@@ -1034,6 +1116,8 @@ export const SavedGameDetailPage: React.FC = () => {
   );
   const selectedHand =
     selectedHandNumber === null ? null : handDetailsByNumber[selectedHandNumber] ?? null;
+  const selectedHandLoadError =
+    selectedHandNumber === null ? null : handLoadErrorsByNumber[selectedHandNumber] ?? null;
 
   return (
     <>
@@ -1067,6 +1151,7 @@ export const SavedGameDetailPage: React.FC = () => {
         <SavedGameDetailView
           detail={detail}
           selectedHand={selectedHand}
+          selectedHandLoadError={selectedHandLoadError}
           selectedHandNumber={selectedHandNumber}
           locale={locale}
           localeTag={localeTag}

--- a/poker-client/src/pages/SavedGameDetail.tsx
+++ b/poker-client/src/pages/SavedGameDetail.tsx
@@ -8,6 +8,7 @@ import type {
   SavedGameAnalysisStatus,
   SavedGameDetail,
   SavedGameHandAnalysis,
+  SavedGameHandDetail,
   SavedGameLocalizedAnalysis,
 } from "poker-types";
 import { Card } from "@/components/Card";
@@ -146,6 +147,7 @@ type TranslationFn = (
 
 type SavedGameDetailViewProps = {
   detail: SavedGameDetail;
+  selectedHand: SavedGameHandDetail | null;
   selectedHandNumber: number | null;
   locale: string;
   localeTag: string;
@@ -316,7 +318,7 @@ const ParticipantStandingsCards: React.FC<{
 
 const SeatList: React.FC<{
   detail: SavedGameDetail;
-  selectedHand: SavedGameDetail["hands"][number];
+  selectedHand: SavedGameHandDetail;
   t: TranslationFn;
 }> = ({ detail, selectedHand, t }) => (
   <div className="space-y-2">
@@ -348,7 +350,7 @@ const SeatList: React.FC<{
 );
 
 const ActionList: React.FC<{
-  selectedHand: SavedGameDetail["hands"][number];
+  selectedHand: SavedGameHandDetail;
   t: TranslationFn;
   compact?: boolean;
 }> = ({ selectedHand, t, compact = false }) => (
@@ -377,7 +379,7 @@ const ActionList: React.FC<{
 
 const NetSummary: React.FC<{
   detail: SavedGameDetail;
-  selectedHand: SavedGameDetail["hands"][number];
+  selectedHand: SavedGameHandDetail;
   t: TranslationFn;
 }> = ({ detail, selectedHand, t }) => (
   <div className="rounded-xl border border-emerald-700/60 bg-emerald-900/25 p-4">
@@ -408,7 +410,7 @@ const NetSummary: React.FC<{
 );
 
 const AnalysisPanel: React.FC<{
-  selectedHand: SavedGameDetail["hands"][number];
+  selectedHand: SavedGameHandDetail;
   selectedHandAnalysis: ReturnType<typeof getDisplayedAnalysis> | null;
   t: TranslationFn;
 }> = ({ selectedHand, selectedHandAnalysis, t }) => (
@@ -490,7 +492,7 @@ const MobileHandStripButton: React.FC<{
       </span>
     </div>
     <p className="mt-2 text-xs text-emerald-100/60">
-      {t("history.handPot", { amount: hand.history.settlement.totalPot })}
+      {t("history.handPot", { amount: hand.totalPot })}
     </p>
   </button>
 );
@@ -563,6 +565,7 @@ export const SavedGameDetailShell: React.FC<SavedGameDetailShellProps> = ({
 
 export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
   detail,
+  selectedHand,
   selectedHandNumber,
   locale,
   localeTag,
@@ -572,9 +575,6 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
   onSelectHandNumber,
 }) => {
   const [mobileSection, setMobileSection] = useState<MobileDetailSection>("overview");
-
-  const selectedHand =
-    detail.hands.find((hand) => hand.handNumber === selectedHandNumber) ?? null;
   const selectedHandAnalysis = selectedHand
     ? getDisplayedAnalysis(selectedHand.analysis, locale)
     : null;
@@ -892,7 +892,7 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
                             </div>
                             <p className="mt-1 text-xs text-emerald-100/60">
                               {t("history.handPot", {
-                                amount: hand.history.settlement.totalPot,
+                                amount: hand.totalPot,
                               })}
                             </p>
                           </>
@@ -932,6 +932,9 @@ export const SavedGameDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const { locale, t } = useLocalization();
   const [detail, setDetail] = useState<SavedGameDetail | null>(null);
+  const [handDetailsByNumber, setHandDetailsByNumber] = useState<
+    Record<number, SavedGameHandDetail>
+  >({});
   const [selectedHandNumber, setSelectedHandNumber] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -948,6 +951,7 @@ export const SavedGameDetailPage: React.FC = () => {
 
       setIsLoading(true);
       setError(null);
+      setHandDetailsByNumber({});
       try {
         const nextDetail = await savedGameHistoryService.getSavedGameDetail(
           archiveId,
@@ -983,10 +987,53 @@ export const SavedGameDetailPage: React.FC = () => {
     };
   }, [archiveId, locale, t]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSelectedHand = async () => {
+      if (!archiveId || selectedHandNumber === null) {
+        return;
+      }
+      if (handDetailsByNumber[selectedHandNumber]) {
+        return;
+      }
+
+      try {
+        const handDetail = await savedGameHistoryService.getSavedGameHandDetail(
+          archiveId,
+          selectedHandNumber,
+          locale,
+        );
+        if (!cancelled) {
+          setHandDetailsByNumber((current) => ({
+            ...current,
+            [handDetail.handNumber]: handDetail,
+          }));
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : t("history.detailLoadFailed"),
+          );
+        }
+      }
+    };
+
+    void loadSelectedHand();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [archiveId, handDetailsByNumber, locale, selectedHandNumber, t]);
+
   const localeTag = useMemo(
     () => (locale === "zh_hans" ? "zh-Hans-CN" : "en-US"),
     [locale],
   );
+  const selectedHand =
+    selectedHandNumber === null ? null : handDetailsByNumber[selectedHandNumber] ?? null;
 
   return (
     <>
@@ -1019,6 +1066,7 @@ export const SavedGameDetailPage: React.FC = () => {
       {!isLoading && !error && detail && (
         <SavedGameDetailView
           detail={detail}
+          selectedHand={selectedHand}
           selectedHandNumber={selectedHandNumber}
           locale={locale}
           localeTag={localeTag}

--- a/poker-client/src/services/saved-game-history.service.ts
+++ b/poker-client/src/services/saved-game-history.service.ts
@@ -1,4 +1,8 @@
-import type { SavedGameDetail, SavedGameSummary } from "poker-types";
+import type {
+  SavedGameDetail,
+  SavedGameHandDetail,
+  SavedGameSummary,
+} from "poker-types";
 import { resolveServerResourceUrl } from "./socket.service";
 
 async function requestJson<T>(path: string): Promise<T> {
@@ -28,6 +32,17 @@ export const savedGameHistoryService = {
     const query = new URLSearchParams({ locale });
     return requestJson<SavedGameDetail>(
       `/api/history/games/${archiveId}?${query.toString()}`,
+    );
+  },
+
+  getSavedGameHandDetail(
+    archiveId: string,
+    handNumber: number,
+    locale: string,
+  ): Promise<SavedGameHandDetail> {
+    const query = new URLSearchParams({ locale });
+    return requestJson<SavedGameHandDetail>(
+      `/api/history/games/${archiveId}/hands/${handNumber}?${query.toString()}`,
     );
   },
 };

--- a/poker-server/src/common/interfaces/saved-game-archive-storage.interface.ts
+++ b/poker-server/src/common/interfaces/saved-game-archive-storage.interface.ts
@@ -1,6 +1,7 @@
 import type {
   SavedGameDetail,
   SavedGameHandAnalysis,
+  SavedGameHandDetail,
   SavedGameReviewTargets,
   SavedGameSummary,
 } from 'poker-types';
@@ -12,6 +13,11 @@ export interface ISavedGameArchiveStorageService {
     archiveId: string,
     userId: string,
   ): Promise<SavedGameDetail | null>;
+  getSavedGameHandDetailForUser(
+    archiveId: string,
+    userId: string,
+    handNumber: number,
+  ): Promise<SavedGameHandDetail | null>;
   getSavedGameReviewTargets(
     archiveId: string,
   ): Promise<SavedGameReviewTargets | null>;

--- a/poker-server/src/saved-game-history.controller.spec.ts
+++ b/poker-server/src/saved-game-history.controller.spec.ts
@@ -12,6 +12,7 @@ describe('SavedGameHistoryController', () => {
   let savedGameStorageService: {
     listSavedGamesForUser: jest.Mock;
     getSavedGameDetailForUser: jest.Mock;
+    getSavedGameHandDetailForUser: jest.Mock;
   };
   let savedGameReviewService: {
     scheduleHandLocalization: jest.Mock;
@@ -24,6 +25,7 @@ describe('SavedGameHistoryController', () => {
     savedGameStorageService = {
       listSavedGamesForUser: jest.fn(),
       getSavedGameDetailForUser: jest.fn(),
+      getSavedGameHandDetailForUser: jest.fn(),
     };
     savedGameReviewService = {
       scheduleHandLocalization: jest.fn().mockResolvedValue(undefined),
@@ -81,30 +83,11 @@ describe('SavedGameHistoryController', () => {
     ]);
   });
 
-  it('returns saved game detail for the authenticated user', async () => {
+  it('returns saved game detail summary for the authenticated user without scheduling archive-wide localization', async () => {
     authService.getCurrentSession.mockResolvedValue({
       user: { id: 'user-alice' },
     });
-    savedGameStorageService.getSavedGameDetailForUser
-      .mockResolvedValueOnce({
-        archiveId: 'ROOM1',
-        roomId: 'ROOM1',
-        requesterUserId: 'user-alice',
-        requesterPlayerId: 'alice',
-        handCount: 2,
-        hands: [
-          {
-            handNumber: 1,
-            analysis: {
-              status: 'ready',
-              headline: 'Play tighter preflop',
-              summary: 'Fold more offsuit broadways.',
-              keyAdjustments: ['Fold KJo UTG'],
-            },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
+    savedGameStorageService.getSavedGameDetailForUser.mockResolvedValue({
       archiveId: 'ROOM1',
       roomId: 'ROOM1',
       requesterUserId: 'user-alice',
@@ -113,24 +96,17 @@ describe('SavedGameHistoryController', () => {
       hands: [
         {
           handNumber: 1,
+          totalPot: 80,
+          actionCount: 3,
           analysis: {
             status: 'ready',
             headline: 'Play tighter preflop',
             summary: 'Fold more offsuit broadways.',
             keyAdjustments: ['Fold KJo UTG'],
-            localizedByLocale: {
-              zh_hans: {
-                status: 'pending',
-                headline: null,
-                summary: null,
-                keyAdjustments: [],
-              },
-            },
           },
         },
       ],
     });
-    savedGameReviewService.scheduleHandLocalization.mockResolvedValue(true);
 
     const result = await controller.getSavedGameDetail(
       'ROOM1',
@@ -144,7 +120,130 @@ describe('SavedGameHistoryController', () => {
     ).toHaveBeenNthCalledWith(1, 'ROOM1', 'user-alice');
     expect(
       savedGameStorageService.getSavedGameDetailForUser,
-    ).toHaveBeenNthCalledWith(2, 'ROOM1', 'user-alice');
+    ).toHaveBeenCalledTimes(1);
+    expect(savedGameReviewService.scheduleHandLocalization).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        archiveId: 'ROOM1',
+        requesterUserId: 'user-alice',
+        hands: [
+          expect.objectContaining({
+            totalPot: 80,
+            actionCount: 3,
+            analysis: expect.objectContaining({
+              status: 'ready',
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('returns a requested hand detail and schedules localization only for that hand', async () => {
+    authService.getCurrentSession.mockResolvedValue({
+      user: { id: 'user-alice' },
+    });
+    savedGameStorageService.getSavedGameHandDetailForUser
+      .mockResolvedValueOnce({
+        handNumber: 1,
+        history: {
+          roomId: 'ROOM1',
+          handNumber: 1,
+          requesterPlayerId: 'alice',
+          version: 1,
+          dealerPosition: 1,
+          smallBlindPosition: 1,
+          bigBlindPosition: 2,
+          blinds: {
+            smallBlind: 5,
+            bigBlind: 10,
+          },
+          communityCardsByStreet: {
+            preFlop: [],
+            flop: [],
+            turn: [],
+            river: [],
+          },
+          seats: [],
+          actions: [],
+          settlement: {
+            isShowdown: false,
+            revealedPlayerIds: [],
+            totalPot: 15,
+            payouts: [],
+            winners: [],
+            netByPlayerId: {},
+          },
+        },
+        analysis: {
+          status: 'ready',
+          headline: 'Play tighter preflop',
+          summary: 'Fold more offsuit broadways.',
+          keyAdjustments: ['Fold KJo UTG'],
+        },
+      })
+      .mockResolvedValueOnce({
+        handNumber: 1,
+        history: {
+          roomId: 'ROOM1',
+          handNumber: 1,
+          requesterPlayerId: 'alice',
+          version: 1,
+          dealerPosition: 1,
+          smallBlindPosition: 1,
+          bigBlindPosition: 2,
+          blinds: {
+            smallBlind: 5,
+            bigBlind: 10,
+          },
+          communityCardsByStreet: {
+            preFlop: [],
+            flop: [],
+            turn: [],
+            river: [],
+          },
+          seats: [],
+          actions: [],
+          settlement: {
+            isShowdown: false,
+            revealedPlayerIds: [],
+            totalPot: 15,
+            payouts: [],
+            winners: [],
+            netByPlayerId: {},
+          },
+        },
+        analysis: {
+          status: 'ready',
+          headline: 'Play tighter preflop',
+          summary: 'Fold more offsuit broadways.',
+          keyAdjustments: ['Fold KJo UTG'],
+          localizedByLocale: {
+            zh_hans: {
+              status: 'pending',
+              headline: null,
+              summary: null,
+              keyAdjustments: [],
+            },
+          },
+        },
+      });
+    savedGameReviewService.scheduleHandLocalization.mockResolvedValue(true);
+
+    const result = await (controller as any).getSavedGameHandDetail(
+      'ROOM1',
+      1,
+      { headers: { cookie: 'poker_session=token-alice' } } as any,
+      'zh_hans',
+      undefined,
+    );
+
+    expect(
+      savedGameStorageService.getSavedGameHandDetailForUser,
+    ).toHaveBeenNthCalledWith(1, 'ROOM1', 'user-alice', 1);
+    expect(
+      savedGameStorageService.getSavedGameHandDetailForUser,
+    ).toHaveBeenNthCalledWith(2, 'ROOM1', 'user-alice', 1);
     expect(savedGameReviewService.scheduleHandLocalization).toHaveBeenCalledWith(
       {
         archiveId: 'ROOM1',
@@ -155,19 +254,14 @@ describe('SavedGameHistoryController', () => {
     );
     expect(result).toEqual(
       expect.objectContaining({
-        archiveId: 'ROOM1',
-        requesterUserId: 'user-alice',
-        hands: [
-          expect.objectContaining({
-            analysis: expect.objectContaining({
-              localizedByLocale: expect.objectContaining({
-                zh_hans: expect.objectContaining({
-                  status: 'pending',
-                }),
-              }),
+        handNumber: 1,
+        analysis: expect.objectContaining({
+          localizedByLocale: expect.objectContaining({
+            zh_hans: expect.objectContaining({
+              status: 'pending',
             }),
           }),
-        ],
+        }),
       }),
     );
   });

--- a/poker-server/src/saved-game-history.controller.ts
+++ b/poker-server/src/saved-game-history.controller.ts
@@ -5,6 +5,7 @@ import {
   Inject,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Query,
   Req,
   UnauthorizedException,
@@ -51,35 +52,50 @@ export class SavedGameHistoryController {
     if (!detail) {
       throw new NotFoundException('Saved game unavailable');
     }
-    const readyHands = detail.hands.filter(
-      (hand) => hand.analysis.status === 'ready',
-    );
-    if (readyHands.length === 0) {
+    return detail;
+  }
+
+  @Get(':archiveId/hands/:handNumber')
+  async getSavedGameHandDetail(
+    @Param('archiveId') archiveId: string,
+    @Param('handNumber', ParseIntPipe) handNumber: number,
+    @Req() request: Request,
+    @Query('locale') locale?: string,
+    @Headers('authorization') authorization?: string,
+  ) {
+    const current = await this.getCurrentSession(request, authorization);
+    const detail =
+      await this.savedGameArchiveStorageService.getSavedGameHandDetailForUser(
+        archiveId,
+        current.user.id,
+        handNumber,
+      );
+    if (!detail) {
+      throw new NotFoundException('Saved hand unavailable');
+    }
+    if (detail.analysis.status !== 'ready') {
       return detail;
     }
 
-    const localizationWrites = await Promise.all(
-      readyHands.map((hand) =>
-        this.savedGameReviewService.scheduleHandLocalization({
-          archiveId,
-          requesterUserId: current.user.id,
-          handNumber: hand.handNumber,
-          locale,
-        }),
-      ),
-    );
-    const didUpdateLocalizationState = localizationWrites.some(Boolean);
+    const didUpdateLocalizationState =
+      await this.savedGameReviewService.scheduleHandLocalization({
+        archiveId,
+        requesterUserId: current.user.id,
+        handNumber,
+        locale,
+      });
     if (!didUpdateLocalizationState) {
       return detail;
     }
 
     const refreshedDetail =
-      await this.savedGameArchiveStorageService.getSavedGameDetailForUser(
+      await this.savedGameArchiveStorageService.getSavedGameHandDetailForUser(
         archiveId,
         current.user.id,
+        handNumber,
       );
     if (!refreshedDetail) {
-      throw new NotFoundException('Saved game unavailable');
+      throw new NotFoundException('Saved hand unavailable');
     }
     return refreshedDetail;
   }

--- a/poker-server/src/storage/json-storage.service.ts
+++ b/poker-server/src/storage/json-storage.service.ts
@@ -657,9 +657,37 @@ export class JsonStorageService
       blinds: archive.blinds,
       participants,
       hands: playerView.hands.map((hand) => ({
-        ...hand,
+        handNumber: hand.handNumber,
+        totalPot: hand.history.settlement.totalPot,
+        actionCount: hand.history.actions.length,
         analysis: this.normalizeSavedGameHandAnalysis(hand.analysis),
       })),
+    };
+  }
+
+  async getSavedGameHandDetailForUser(
+    archiveId: string,
+    userId: string,
+    handNumber: number,
+  ): Promise<SavedGameHandDetail | null> {
+    await this.ensureDirectories();
+    const archive = await this.readSavedGameArchive(archiveId);
+    if (!archive) {
+      return null;
+    }
+
+    const playerView = archive.playerViews[userId];
+    const hand = playerView?.hands.find(
+      (candidate) => candidate.handNumber === handNumber,
+    );
+    if (!hand) {
+      return null;
+    }
+
+    return {
+      handNumber: hand.handNumber,
+      history: hand.history,
+      analysis: this.normalizeSavedGameHandAnalysis(hand.analysis),
     };
   }
 

--- a/poker-server/test/unit/json-storage.service.spec.ts
+++ b/poker-server/test/unit/json-storage.service.spec.ts
@@ -1336,14 +1336,25 @@ describe('JsonStorageService', () => {
           ) => Promise<any | null>;
         }
       ).getSavedGameDetailForUser;
+      const getSavedGameHandDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameHandDetailForUser?: (
+            archiveId: string,
+            userId: string,
+            handNumber: number,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameHandDetailForUser;
 
       expect(typeof archiveEndedRoom).toBe('function');
       expect(typeof listSavedGamesForUser).toBe('function');
       expect(typeof getSavedGameDetailForUser).toBe('function');
+      expect(typeof getSavedGameHandDetailForUser).toBe('function');
       if (
         typeof archiveEndedRoom !== 'function' ||
         typeof listSavedGamesForUser !== 'function' ||
-        typeof getSavedGameDetailForUser !== 'function'
+        typeof getSavedGameDetailForUser !== 'function' ||
+        typeof getSavedGameHandDetailForUser !== 'function'
       ) {
         return;
       }
@@ -1381,9 +1392,8 @@ describe('JsonStorageService', () => {
           hands: expect.arrayContaining([
             expect.objectContaining({
               handNumber: 1,
-              history: expect.objectContaining({
-                requesterPlayerId: 'alice',
-              }),
+              totalPot: 40,
+              actionCount: 4,
               analysis: expect.objectContaining({
                 status: 'pending',
               }),
@@ -1392,6 +1402,14 @@ describe('JsonStorageService', () => {
         }),
       );
 
+      const aliceHandDetail = await getSavedGameHandDetailForUser.call(
+        service,
+        archived!.archiveId,
+        'user-alice',
+        1,
+      );
+      expect(aliceHandDetail?.history.requesterPlayerId).toBe('alice');
+
       await service.deleteRoom(roomId);
 
       const archivedAfterDelete = await getSavedGameDetailForUser.call(
@@ -1399,9 +1417,22 @@ describe('JsonStorageService', () => {
         archived!.archiveId,
         'user-alice',
       );
-      expect(archivedAfterDelete?.hands[0].history.requesterPlayerId).toBe('alice');
+      expect(archivedAfterDelete?.hands[0]).toEqual(
+        expect.objectContaining({
+          handNumber: 1,
+          totalPot: 40,
+          actionCount: 4,
+        }),
+      );
+      const archivedHandAfterDelete = await getSavedGameHandDetailForUser.call(
+        service,
+        archived!.archiveId,
+        'user-alice',
+        1,
+      );
+      expect(archivedHandAfterDelete?.history.requesterPlayerId).toBe('alice');
       expect(
-        archivedAfterDelete?.hands[0].history.seats.find(
+        archivedHandAfterDelete?.history.seats.find(
           (seat: any) => seat.playerId === 'bob',
         ),
       ).toEqual(

--- a/poker-types/src/history.types.ts
+++ b/poker-types/src/history.types.ts
@@ -141,8 +141,15 @@ export type SavedGameHandDetail = {
   analysis: SavedGameHandAnalysis;
 };
 
+export type SavedGameHandSummary = {
+  handNumber: number;
+  totalPot: number;
+  actionCount: number;
+  analysis: SavedGameHandAnalysis;
+};
+
 export type SavedGameDetail = SavedGameSummary & {
-  hands: SavedGameHandDetail[];
+  hands: SavedGameHandSummary[];
 };
 
 export type SavedGameReviewTarget = {


### PR DESCRIPTION
## Summary

- split saved-history archive detail into lightweight hand summaries plus lazy per-hand detail fetches
- stop archive-detail reads from scheduling localization work across every ready hand

## Linked Issue

Closes #183

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/183#issuecomment-4273514172

## Validation

- pnpm --dir poker-server test:unit -- saved-game-history.controller.spec.ts json-storage.service.spec.ts --runInBand
- pnpm --dir poker-client test -- SavedGameDetail.spec.ts
- pnpm --dir poker-client build
- pnpm --dir poker-server build
- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep '8\.15b:' --reporter=line
