### PR TITLE
feat: let users retry failed saved-game AI reviews

### DIFF
--- a/poker-client/src/i18n/messages.ts
+++ b/poker-client/src/i18n/messages.ts
@@ -459,6 +459,9 @@ export const EN_MESSAGES = {
   "history.analysisStatus.ready": "Ready",
   "history.analysisStatus.failed": "Failed",
   "history.analysisStatus.unavailable": "Unavailable",
+  "history.retryReview": "Retry Review",
+  "history.retryTranslation": "Retry Translation",
+  "history.retryingReview": "Retrying review…",
 
   "game.confirmAction.title": "Confirm Action",
   "game.confirmAction.reviewHint": "Review the hand context before committing to this move.",
@@ -955,6 +958,9 @@ const ZH_HANS_MESSAGES: Record<MessageKey, string> = {
   "history.analysisStatus.ready": "已完成",
   "history.analysisStatus.failed": "失败",
   "history.analysisStatus.unavailable": "不可用",
+  "history.retryReview": "重试复盘",
+  "history.retryTranslation": "重试翻译",
+  "history.retryingReview": "正在重试复盘…",
 
   "game.confirmAction.title": "确认操作",
   "game.confirmAction.reviewHint": "提交前先确认当前牌局信息。",

--- a/poker-client/src/pages/SavedGameDetail.spec.ts
+++ b/poker-client/src/pages/SavedGameDetail.spec.ts
@@ -439,6 +439,53 @@ describe("SavedGameDetailView", () => {
     expect(html).toContain("Insufficient credits");
   });
 
+  it("renders a retry review action for unavailable selected-hand analysis", () => {
+    const detail = buildDetail();
+    const unavailableHand = {
+      ...detail.hands[0],
+      analysis: {
+        status: "unavailable" as const,
+        updatedAt: 1_710_000_955_000,
+        headline: null,
+        summary: null,
+        keyAdjustments: [],
+        failureReason: "Missing AI provider configuration",
+      },
+    };
+    const html = renderToStaticMarkup(
+      React.createElement(SavedGameDetailView as any, {
+        detail: {
+          ...detail,
+          hands: [
+            {
+              handNumber: unavailableHand.handNumber,
+              totalPot: unavailableHand.history.settlement.totalPot,
+              actionCount: unavailableHand.history.actions.length,
+              analysis: unavailableHand.analysis,
+            },
+            detail.hands[1],
+          ],
+        },
+        selectedHand: unavailableHand,
+        selectedHandLoadError: null,
+        selectedHandNumber: 1,
+        locale: "en" satisfies Locale,
+        localeTag: "en-US",
+        t,
+        onBackToHistory: vi.fn(),
+        onBackToLobby: vi.fn(),
+        onSelectHandNumber: vi.fn(),
+        onRetrySelectedHandAnalysis: vi.fn(),
+        retryActionLabelKey: "history.retryReview",
+        isRetryingSelectedHandAnalysis: false,
+      }),
+    );
+
+    expect(html).toContain('data-testid="saved-history-retry-analysis-button"');
+    expect(html).toContain("history.retryReview");
+    expect(html).toContain("Missing AI provider configuration");
+  });
+
   it("renders a disabled retry translation action while retry is in flight", () => {
     const detail = buildDetail();
     const localizedFailureHand = {

--- a/poker-client/src/pages/SavedGameDetail.spec.ts
+++ b/poker-client/src/pages/SavedGameDetail.spec.ts
@@ -391,6 +391,105 @@ describe("SavedGameDetailView", () => {
     expect(html).toContain('data-testid="saved-history-desktop-hand-list"');
     expect(html).toContain("Saved hand unavailable");
   });
+
+  it("renders a retry review action for failed selected-hand analysis", () => {
+    const detail = buildDetail();
+    const failedHand = {
+      ...detail.hands[0],
+      analysis: {
+        status: "failed" as const,
+        updatedAt: 1_710_000_950_000,
+        headline: null,
+        summary: null,
+        keyAdjustments: [],
+        failureReason: "Insufficient credits",
+      },
+    };
+    const html = renderToStaticMarkup(
+      React.createElement(SavedGameDetailView as any, {
+        detail: {
+          ...detail,
+          hands: [
+            {
+              handNumber: failedHand.handNumber,
+              totalPot: failedHand.history.settlement.totalPot,
+              actionCount: failedHand.history.actions.length,
+              analysis: failedHand.analysis,
+            },
+            detail.hands[1],
+          ],
+        },
+        selectedHand: failedHand,
+        selectedHandLoadError: null,
+        selectedHandNumber: 1,
+        locale: "en" satisfies Locale,
+        localeTag: "en-US",
+        t,
+        onBackToHistory: vi.fn(),
+        onBackToLobby: vi.fn(),
+        onSelectHandNumber: vi.fn(),
+        onRetrySelectedHandAnalysis: vi.fn(),
+        retryActionLabelKey: "history.retryReview",
+        isRetryingSelectedHandAnalysis: false,
+      }),
+    );
+
+    expect(html).toContain('data-testid="saved-history-retry-analysis-button"');
+    expect(html).toContain("history.retryReview");
+    expect(html).toContain("Insufficient credits");
+  });
+
+  it("renders a disabled retry translation action while retry is in flight", () => {
+    const detail = buildDetail();
+    const localizedFailureHand = {
+      ...detail.hands[0],
+      analysis: {
+        ...detail.hands[0].analysis,
+        localizedByLocale: {
+          en: detail.hands[0].analysis.localizedByLocale?.en,
+          zh_hans: {
+            status: "failed" as const,
+            updatedAt: 1_710_000_960_000,
+            headline: null,
+            summary: null,
+            keyAdjustments: [],
+            failureReason: "Insufficient credits",
+          },
+        },
+      },
+    };
+    const html = renderToStaticMarkup(
+      React.createElement(SavedGameDetailView as any, {
+        detail: {
+          ...detail,
+          hands: [
+            {
+              handNumber: localizedFailureHand.handNumber,
+              totalPot: localizedFailureHand.history.settlement.totalPot,
+              actionCount: localizedFailureHand.history.actions.length,
+              analysis: localizedFailureHand.analysis,
+            },
+            detail.hands[1],
+          ],
+        },
+        selectedHand: localizedFailureHand,
+        selectedHandLoadError: null,
+        selectedHandNumber: 1,
+        locale: "zh_hans" satisfies Locale,
+        localeTag: "zh-Hans-CN",
+        t,
+        onBackToHistory: vi.fn(),
+        onBackToLobby: vi.fn(),
+        onSelectHandNumber: vi.fn(),
+        onRetrySelectedHandAnalysis: vi.fn(),
+        retryActionLabelKey: "history.retryTranslation",
+        isRetryingSelectedHandAnalysis: true,
+      }),
+    );
+
+    expect(html).toContain("history.retryingReview");
+    expect(html).toContain('disabled=""');
+  });
 });
 
 describe("shouldLoadSelectedHandDetail", () => {

--- a/poker-client/src/pages/SavedGameDetail.tsx
+++ b/poker-client/src/pages/SavedGameDetail.tsx
@@ -144,7 +144,7 @@ const getRetryActionLabelKey = (
   analysis: SavedGameHandAnalysis,
   locale: string,
 ): MessageKey | null => {
-  if (analysis.status === "failed") {
+  if (analysis.status === "failed" || analysis.status === "unavailable") {
     return "history.retryReview";
   }
 

--- a/poker-client/src/pages/SavedGameDetail.tsx
+++ b/poker-client/src/pages/SavedGameDetail.tsx
@@ -140,6 +140,24 @@ const getDisplayedAnalysis = (
   };
 };
 
+const getRetryActionLabelKey = (
+  analysis: SavedGameHandAnalysis,
+  locale: string,
+): MessageKey | null => {
+  if (analysis.status === "failed") {
+    return "history.retryReview";
+  }
+
+  const requestedLocale = getRequestedAnalysisLocale(locale);
+  if (requestedLocale === "en") {
+    return null;
+  }
+
+  return analysis.localizedByLocale?.[requestedLocale]?.status === "failed"
+    ? "history.retryTranslation"
+    : null;
+};
+
 type TranslationFn = (
   key: MessageKey,
   values?: Record<string, string | number>,
@@ -156,6 +174,9 @@ type SavedGameDetailViewProps = {
   onBackToHistory: () => void;
   onBackToLobby: () => void;
   onSelectHandNumber: (handNumber: number) => void;
+  onRetrySelectedHandAnalysis?: () => void;
+  retryActionLabelKey?: MessageKey | null;
+  isRetryingSelectedHandAnalysis?: boolean;
 };
 
 type SavedGameDetailShellProps = {
@@ -454,8 +475,18 @@ const NetSummary: React.FC<{
 const AnalysisPanel: React.FC<{
   selectedHand: SavedGameHandDetail;
   selectedHandAnalysis: ReturnType<typeof getDisplayedAnalysis> | null;
+  onRetry?: () => void;
+  retryActionLabelKey?: MessageKey | null;
+  isRetrying?: boolean;
   t: TranslationFn;
-}> = ({ selectedHand, selectedHandAnalysis, t }) => (
+}> = ({
+  selectedHand,
+  selectedHandAnalysis,
+  onRetry,
+  retryActionLabelKey = null,
+  isRetrying = false,
+  t,
+}) => (
   <div className="rounded-xl border border-emerald-700/60 bg-emerald-900/25 p-4">
     <p className="text-xs uppercase tracking-wide text-emerald-100/60">
       {t(getAnalysisStatusKey(selectedHandAnalysis?.status ?? "pending"))}
@@ -484,6 +515,17 @@ const AnalysisPanel: React.FC<{
         {selectedHandAnalysis?.failureReason || t("history.analysisPending")}
       </p>
     )}
+    {retryActionLabelKey && onRetry ? (
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={isRetrying}
+        data-testid="saved-history-retry-analysis-button"
+        className="mt-4 rounded-lg border border-emerald-400/60 bg-emerald-400/10 px-3 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-400/20 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isRetrying ? t("history.retryingReview") : t(retryActionLabelKey)}
+      </button>
+    ) : null}
   </div>
 );
 
@@ -616,6 +658,9 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
   onBackToHistory,
   onBackToLobby,
   onSelectHandNumber,
+  onRetrySelectedHandAnalysis,
+  retryActionLabelKey = null,
+  isRetryingSelectedHandAnalysis = false,
 }) => {
   const [mobileSection, setMobileSection] = useState<MobileDetailSection>("overview");
   const selectedHandAnalysis = selectedHand
@@ -810,6 +855,9 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
                       <AnalysisPanel
                         selectedHand={selectedHand}
                         selectedHandAnalysis={selectedHandAnalysis}
+                        onRetry={onRetrySelectedHandAnalysis}
+                        retryActionLabelKey={retryActionLabelKey}
+                        isRetrying={isRetryingSelectedHandAnalysis}
                         t={t}
                       />
                     </div>
@@ -973,6 +1021,9 @@ export const SavedGameDetailView: React.FC<SavedGameDetailViewProps> = ({
                     <AnalysisPanel
                       selectedHand={selectedHand}
                       selectedHandAnalysis={selectedHandAnalysis}
+                      onRetry={onRetrySelectedHandAnalysis}
+                      retryActionLabelKey={retryActionLabelKey}
+                      isRetrying={isRetryingSelectedHandAnalysis}
                       t={t}
                     />
                   </div>
@@ -1000,6 +1051,7 @@ export const SavedGameDetailPage: React.FC = () => {
     Record<number, string>
   >({});
   const [selectedHandNumber, setSelectedHandNumber] = useState<number | null>(null);
+  const [retryingHandNumber, setRetryingHandNumber] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -1118,6 +1170,67 @@ export const SavedGameDetailPage: React.FC = () => {
     selectedHandNumber === null ? null : handDetailsByNumber[selectedHandNumber] ?? null;
   const selectedHandLoadError =
     selectedHandNumber === null ? null : handLoadErrorsByNumber[selectedHandNumber] ?? null;
+  const retryActionLabelKey = selectedHand
+    ? getRetryActionLabelKey(selectedHand.analysis, locale)
+    : null;
+
+  const updateHandCaches = (handDetail: SavedGameHandDetail) => {
+    setHandDetailsByNumber((current) => ({
+      ...current,
+      [handDetail.handNumber]: handDetail,
+    }));
+    setDetail((current) =>
+      current
+        ? {
+            ...current,
+            hands: current.hands.map((hand) =>
+              hand.handNumber === handDetail.handNumber
+                ? {
+                    ...hand,
+                    analysis: handDetail.analysis,
+                  }
+                : hand,
+            ),
+          }
+        : current,
+    );
+    setHandLoadErrorsByNumber((current) => {
+      if (!(handDetail.handNumber in current)) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[handDetail.handNumber];
+      return next;
+    });
+  };
+
+  const handleRetrySelectedHandAnalysis = async () => {
+    if (!archiveId || selectedHandNumber === null || !retryActionLabelKey) {
+      return;
+    }
+
+    setRetryingHandNumber(selectedHandNumber);
+    try {
+      const refreshedHand = await savedGameHistoryService.retrySavedGameHandReview(
+        archiveId,
+        selectedHandNumber,
+        locale,
+      );
+      updateHandCaches(refreshedHand);
+    } catch (retryError) {
+      setHandLoadErrorsByNumber((current) => ({
+        ...current,
+        [selectedHandNumber]:
+          retryError instanceof Error
+            ? retryError.message
+            : t("history.detailLoadFailed"),
+      }));
+    } finally {
+      setRetryingHandNumber((current) =>
+        current === selectedHandNumber ? null : current,
+      );
+    }
+  };
 
   return (
     <>
@@ -1159,6 +1272,9 @@ export const SavedGameDetailPage: React.FC = () => {
           onBackToHistory={() => navigate("/history")}
           onBackToLobby={() => navigate("/", { replace: true })}
           onSelectHandNumber={setSelectedHandNumber}
+          onRetrySelectedHandAnalysis={handleRetrySelectedHandAnalysis}
+          retryActionLabelKey={retryActionLabelKey}
+          isRetryingSelectedHandAnalysis={retryingHandNumber === selectedHandNumber}
         />
       )}
     </>

--- a/poker-client/src/services/saved-game-history.service.ts
+++ b/poker-client/src/services/saved-game-history.service.ts
@@ -5,9 +5,12 @@ import type {
 } from "poker-types";
 import { resolveServerResourceUrl } from "./socket.service";
 
-async function requestJson<T>(path: string): Promise<T> {
+async function requestJson<T>(
+  path: string,
+  init?: { method?: "GET" | "POST" },
+): Promise<T> {
   const response = await fetch(resolveServerResourceUrl(path), {
-    method: "GET",
+    method: init?.method ?? "GET",
     credentials: "include",
   });
 
@@ -43,6 +46,18 @@ export const savedGameHistoryService = {
     const query = new URLSearchParams({ locale });
     return requestJson<SavedGameHandDetail>(
       `/api/history/games/${archiveId}/hands/${handNumber}?${query.toString()}`,
+    );
+  },
+
+  retrySavedGameHandReview(
+    archiveId: string,
+    handNumber: number,
+    locale: string,
+  ): Promise<SavedGameHandDetail> {
+    const query = new URLSearchParams({ locale });
+    return requestJson<SavedGameHandDetail>(
+      `/api/history/games/${archiveId}/hands/${handNumber}/retry?${query.toString()}`,
+      { method: "POST" },
     );
   },
 };

--- a/poker-server/src/game/saved-game-review.service.spec.ts
+++ b/poker-server/src/game/saved-game-review.service.spec.ts
@@ -7,6 +7,7 @@ describe('SavedGameReviewService', () => {
     updateSavedGameHandAnalysis: jest.Mock;
     getSavedGameHandAnalysis: jest.Mock;
     mergeSavedGameHandLocalization: jest.Mock;
+    getSavedGameHandDetailForUser: jest.Mock;
   };
   let robotAgentService: {
     isConfigured: jest.Mock;
@@ -21,6 +22,7 @@ describe('SavedGameReviewService', () => {
       updateSavedGameHandAnalysis: jest.fn().mockResolvedValue(undefined),
       getSavedGameHandAnalysis: jest.fn(),
       mergeSavedGameHandLocalization: jest.fn().mockResolvedValue(true),
+      getSavedGameHandDetailForUser: jest.fn(),
     };
     robotAgentService = {
       isConfigured: jest.fn(),
@@ -322,5 +324,170 @@ describe('SavedGameReviewService', () => {
     expect(
       archiveStorageService.updateSavedGameHandAnalysis,
     ).not.toHaveBeenCalled();
+  });
+
+  it('retries a failed canonical review by resetting it to pending and requeueing generation', async () => {
+    archiveStorageService.getSavedGameHandDetailForUser.mockResolvedValue({
+      handNumber: 7,
+      history: {
+        roomId: 'ROOM1',
+        handNumber: 7,
+        requesterPlayerId: 'player-alice',
+      },
+      analysis: {
+        status: 'failed',
+        failureReason: 'Insufficient credits',
+      },
+    });
+    robotAgentService.getConfigurationError.mockReturnValue(null);
+    jest
+      .spyOn(service as any, 'generateStructuredReview')
+      .mockResolvedValue({
+        headline: 'Retry succeeded',
+        summary: 'Provider recovered after retry.',
+        keyAdjustments: ['Review the hand again'],
+      });
+    jest
+      .spyOn(service as any, 'localizeReviewText')
+      .mockResolvedValue({
+        headline: '重试成功',
+        summary: '提供商恢复后已成功生成。',
+        keyAdjustments: ['重新查看这手牌'],
+      });
+
+    await expect(
+      service.retryHandReview({
+        archiveId: 'ROOM1',
+        requesterUserId: 'user-alice',
+        handNumber: 7,
+        locale: 'en',
+      }),
+    ).resolves.toBe(true);
+
+    expect(
+      archiveStorageService.updateSavedGameHandAnalysis,
+    ).toHaveBeenNthCalledWith(
+      1,
+      'ROOM1',
+      'user-alice',
+      7,
+      expect.objectContaining({
+        status: 'pending',
+        failureReason: null,
+      }),
+    );
+
+    await (service as any).reviewQueue;
+
+    expect(
+      archiveStorageService.updateSavedGameHandAnalysis,
+    ).toHaveBeenNthCalledWith(
+      2,
+      'ROOM1',
+      'user-alice',
+      7,
+      expect.objectContaining({
+        status: 'ready',
+        headline: 'Retry succeeded',
+      }),
+    );
+  });
+
+  it('retries a failed localized review for the requested locale without rerunning canonical analysis', async () => {
+    archiveStorageService.getSavedGameHandAnalysis
+      .mockResolvedValueOnce({
+        status: 'ready',
+        headline: 'Canonical review',
+        summary: 'Keep pressure on later streets.',
+        keyAdjustments: ['Bet bigger on the turn'],
+        localizedByLocale: {
+          en: {
+            status: 'ready',
+            headline: 'Canonical review',
+            summary: 'Keep pressure on later streets.',
+            keyAdjustments: ['Bet bigger on the turn'],
+          },
+          zh_hans: {
+            status: 'failed',
+            headline: null,
+            summary: null,
+            keyAdjustments: [],
+            failureReason: 'Insufficient credits',
+          },
+        },
+      })
+      .mockResolvedValue({
+        status: 'ready',
+        headline: 'Canonical review',
+        summary: 'Keep pressure on later streets.',
+        keyAdjustments: ['Bet bigger on the turn'],
+        localizedByLocale: {
+          en: {
+            status: 'ready',
+            headline: 'Canonical review',
+            summary: 'Keep pressure on later streets.',
+            keyAdjustments: ['Bet bigger on the turn'],
+          },
+          zh_hans: {
+            status: 'pending',
+            headline: null,
+            summary: null,
+            keyAdjustments: [],
+            failureReason: null,
+          },
+        },
+      });
+    robotAgentService.getConfigurationError.mockReturnValue(null);
+    const generateStructuredReviewSpy = jest.spyOn(
+      service as any,
+      'generateStructuredReview',
+    );
+    jest
+      .spyOn(service as any, 'localizeReviewText')
+      .mockResolvedValue({
+        headline: '规范复盘',
+        summary: '在后续街道持续施压。',
+        keyAdjustments: ['转牌下注更大'],
+      });
+
+    await expect(
+      service.retryHandReview({
+        archiveId: 'ROOM1',
+        requesterUserId: 'user-alice',
+        handNumber: 8,
+        locale: 'zh_hans',
+      }),
+    ).resolves.toBe(true);
+
+    expect(generateStructuredReviewSpy).not.toHaveBeenCalled();
+    expect(
+      archiveStorageService.mergeSavedGameHandLocalization,
+    ).toHaveBeenNthCalledWith(
+      1,
+      'ROOM1',
+      'user-alice',
+      8,
+      'zh_hans',
+      expect.objectContaining({
+        status: 'pending',
+        failureReason: null,
+      }),
+    );
+
+    await (service as any).reviewQueue;
+
+    expect(
+      archiveStorageService.mergeSavedGameHandLocalization,
+    ).toHaveBeenNthCalledWith(
+      2,
+      'ROOM1',
+      'user-alice',
+      8,
+      'zh_hans',
+      expect.objectContaining({
+        status: 'ready',
+        headline: '规范复盘',
+      }),
+    );
   });
 });

--- a/poker-server/src/game/saved-game-review.service.ts
+++ b/poker-server/src/game/saved-game-review.service.ts
@@ -21,6 +21,7 @@ export class SavedGameReviewService {
   private readonly logger = new Logger(SavedGameReviewService.name);
   private reviewQueue: Promise<void> = Promise.resolve();
   private readonly queuedArchiveIds = new Set<string>();
+  private readonly queuedHandReviewKeys = new Set<string>();
   private readonly queuedLocalizationKeys = new Set<string>();
 
   constructor(
@@ -122,52 +123,35 @@ export class SavedGameReviewService {
 
     for (const playerView of targets.playerViews) {
       for (const hand of playerView.hands) {
-        try {
-          const review = await this.generateStructuredReview({
-            archiveId,
-            requesterPlayerId: playerView.requesterPlayerId,
-            handHistory: hand.history,
-          });
-          const localizedByLocale: SavedGameHandAnalysis['localizedByLocale'] = {
-            en: this.buildLocalizedReadyEntry(review),
-          };
-          for (const locale of PREWARMED_REVIEW_LOCALES) {
-            if (locale === 'en') {
-              continue;
-            }
-            try {
-              const localizedReview = await this.localizeReviewText({
-                locale,
-                canonicalReview: review,
-              });
-              localizedByLocale[locale] =
-                this.buildLocalizedReadyEntry(localizedReview);
-            } catch (error) {
-              localizedByLocale[locale] = this.buildLocalizedFailureEntry(
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to localize review',
-              );
-            }
-          }
-          await this.savedGameArchiveStorageService.updateSavedGameHandAnalysis(
-            archiveId,
-            playerView.requesterUserId,
-            hand.handNumber,
-            this.buildCanonicalReadyAnalysis(review, localizedByLocale),
-          );
-        } catch (error) {
-          const failureReason =
-            error instanceof Error ? error.message : 'Failed to generate review';
-          await this.savedGameArchiveStorageService.updateSavedGameHandAnalysis(
-            archiveId,
-            playerView.requesterUserId,
-            hand.handNumber,
-            this.buildUnavailableAnalysis('failed', failureReason),
-          );
-        }
+        await this.reviewSingleHand({
+          archiveId,
+          requesterUserId: playerView.requesterUserId,
+          requesterPlayerId: playerView.requesterPlayerId,
+          handNumber: hand.handNumber,
+          handHistory: hand.history,
+        });
       }
     }
+  }
+
+  async retryHandReview(params: {
+    archiveId: string;
+    requesterUserId: string;
+    handNumber: number;
+    locale?: string;
+  }): Promise<boolean> {
+    const locale = this.normalizeLocale(params.locale);
+    if (
+      locale !== 'en' &&
+      (await this.retryFailedLocalization({
+        ...params,
+        locale,
+      }))
+    ) {
+      return true;
+    }
+
+    return this.retryFailedCanonicalReview(params);
   }
 
   private async markArchiveUnavailable(
@@ -307,6 +291,151 @@ export class SavedGameReviewService {
     }
   }
 
+  private async retryFailedCanonicalReview(params: {
+    archiveId: string;
+    requesterUserId: string;
+    handNumber: number;
+  }): Promise<boolean> {
+    const handDetail =
+      await this.savedGameArchiveStorageService.getSavedGameHandDetailForUser(
+        params.archiveId,
+        params.requesterUserId,
+        params.handNumber,
+      );
+    if (
+      !handDetail ||
+      (handDetail.analysis.status !== 'failed' &&
+        handDetail.analysis.status !== 'unavailable')
+    ) {
+      return false;
+    }
+
+    await this.savedGameArchiveStorageService.updateSavedGameHandAnalysis(
+      params.archiveId,
+      params.requesterUserId,
+      params.handNumber,
+      this.buildPendingAnalysis(),
+    );
+
+    const configError = this.robotAgentService.getConfigurationError();
+    if (configError) {
+      await this.savedGameArchiveStorageService.updateSavedGameHandAnalysis(
+        params.archiveId,
+        params.requesterUserId,
+        params.handNumber,
+        this.buildUnavailableAnalysis('unavailable', configError),
+      );
+      return true;
+    }
+
+    const queueKey = [
+      params.archiveId,
+      params.requesterUserId,
+      params.handNumber,
+    ].join(':');
+    if (this.queuedHandReviewKeys.has(queueKey)) {
+      return true;
+    }
+
+    this.queuedHandReviewKeys.add(queueKey);
+    const runReview = async () => {
+      try {
+        await this.reviewSingleHand({
+          archiveId: params.archiveId,
+          requesterUserId: params.requesterUserId,
+          requesterPlayerId: handDetail.history.requesterPlayerId,
+          handNumber: params.handNumber,
+          handHistory: handDetail.history,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown review error';
+        this.logger.error(
+          `Saved game review retry failed for ${queueKey}: ${message}`,
+        );
+      } finally {
+        this.queuedHandReviewKeys.delete(queueKey);
+      }
+    };
+
+    this.reviewQueue = this.reviewQueue
+      .catch(() => undefined)
+      .then(runReview);
+    return true;
+  }
+
+  private async retryFailedLocalization(params: {
+    archiveId: string;
+    requesterUserId: string;
+    handNumber: number;
+    locale: string;
+  }): Promise<boolean> {
+    const analysis =
+      await this.savedGameArchiveStorageService.getSavedGameHandAnalysis(
+        params.archiveId,
+        params.requesterUserId,
+        params.handNumber,
+      );
+    if (!analysis || analysis.status !== 'ready') {
+      return false;
+    }
+
+    const existingLocalization = analysis.localizedByLocale?.[params.locale];
+    if (existingLocalization?.status !== 'failed') {
+      return false;
+    }
+
+    const configError = this.robotAgentService.getConfigurationError();
+    if (configError) {
+      await this.savedGameArchiveStorageService.mergeSavedGameHandLocalization(
+        params.archiveId,
+        params.requesterUserId,
+        params.handNumber,
+        params.locale,
+        this.buildLocalizedFailureEntry(configError),
+      );
+      return true;
+    }
+
+    await this.savedGameArchiveStorageService.mergeSavedGameHandLocalization(
+      params.archiveId,
+      params.requesterUserId,
+      params.handNumber,
+      params.locale,
+      this.buildLocalizedPendingEntry(),
+    );
+
+    const queueKey = [
+      params.archiveId,
+      params.requesterUserId,
+      params.handNumber,
+      params.locale,
+    ].join(':');
+    if (this.queuedLocalizationKeys.has(queueKey)) {
+      return true;
+    }
+
+    this.queuedLocalizationKeys.add(queueKey);
+    const runLocalization = async () => {
+      try {
+        await this.finishQueuedHandLocalization(params);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown localization error';
+        this.logger.error(
+          `Saved game localization retry failed for ${queueKey}: ${message}`,
+        );
+      } finally {
+        this.queuedLocalizationKeys.delete(queueKey);
+      }
+    };
+
+    this.reviewQueue = this.reviewQueue
+      .catch(() => undefined)
+      .then(runLocalization);
+    return true;
+  }
+
   private async generateStructuredReview(params: {
     archiveId: string;
     requesterPlayerId: string;
@@ -423,6 +552,19 @@ export class SavedGameReviewService {
     };
   }
 
+  private buildPendingAnalysis(): SavedGameHandAnalysis {
+    return {
+      status: 'pending',
+      updatedAt: Date.now(),
+      provider: 'ai-robot-config',
+      headline: null,
+      summary: null,
+      keyAdjustments: [],
+      failureReason: null,
+      localizedByLocale: {},
+    };
+  }
+
   private buildLocalizedPendingEntry(): SavedGameLocalizedAnalysis {
     return {
       status: 'pending',
@@ -509,6 +651,59 @@ export class SavedGameReviewService {
       return 'Simplified Chinese (zh_hans)';
     }
     return locale;
+  }
+
+  private async reviewSingleHand(params: {
+    archiveId: string;
+    requesterUserId: string;
+    requesterPlayerId: string;
+    handNumber: number;
+    handHistory: CompletedHandHistoryExport;
+  }): Promise<void> {
+    try {
+      const review = await this.generateStructuredReview({
+        archiveId: params.archiveId,
+        requesterPlayerId: params.requesterPlayerId,
+        handHistory: params.handHistory,
+      });
+      const localizedByLocale: SavedGameHandAnalysis['localizedByLocale'] = {
+        en: this.buildLocalizedReadyEntry(review),
+      };
+      for (const locale of PREWARMED_REVIEW_LOCALES) {
+        if (locale === 'en') {
+          continue;
+        }
+        try {
+          const localizedReview = await this.localizeReviewText({
+            locale,
+            canonicalReview: review,
+          });
+          localizedByLocale[locale] =
+            this.buildLocalizedReadyEntry(localizedReview);
+        } catch (error) {
+          localizedByLocale[locale] = this.buildLocalizedFailureEntry(
+            error instanceof Error
+              ? error.message
+              : 'Failed to localize review',
+          );
+        }
+      }
+      await this.savedGameArchiveStorageService.updateSavedGameHandAnalysis(
+        params.archiveId,
+        params.requesterUserId,
+        params.handNumber,
+        this.buildCanonicalReadyAnalysis(review, localizedByLocale),
+      );
+    } catch (error) {
+      const failureReason =
+        error instanceof Error ? error.message : 'Failed to generate review';
+      await this.savedGameArchiveStorageService.updateSavedGameHandAnalysis(
+        params.archiveId,
+        params.requesterUserId,
+        params.handNumber,
+        this.buildUnavailableAnalysis('failed', failureReason),
+      );
+    }
   }
 
 }

--- a/poker-server/src/saved-game-history.controller.spec.ts
+++ b/poker-server/src/saved-game-history.controller.spec.ts
@@ -16,6 +16,7 @@ describe('SavedGameHistoryController', () => {
   };
   let savedGameReviewService: {
     scheduleHandLocalization: jest.Mock;
+    retryHandReview: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -29,6 +30,7 @@ describe('SavedGameHistoryController', () => {
     };
     savedGameReviewService = {
       scheduleHandLocalization: jest.fn().mockResolvedValue(undefined),
+      retryHandReview: jest.fn().mockResolvedValue(false),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -272,5 +274,108 @@ describe('SavedGameHistoryController', () => {
     await expect(
       controller.listSavedGames({ headers: {} } as any, undefined),
     ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('retries a failed hand review for the authenticated user and returns refreshed hand detail', async () => {
+    authService.getCurrentSession.mockResolvedValue({
+      user: { id: 'user-alice' },
+    });
+    savedGameStorageService.getSavedGameHandDetailForUser
+      .mockResolvedValueOnce({
+        handNumber: 2,
+        history: {
+          roomId: 'ROOM1',
+          handNumber: 2,
+          requesterPlayerId: 'alice',
+          version: 1,
+          dealerPosition: 1,
+          smallBlindPosition: 1,
+          bigBlindPosition: 2,
+          blinds: { smallBlind: 5, bigBlind: 10 },
+          communityCardsByStreet: {
+            preFlop: [],
+            flop: [],
+            turn: [],
+            river: [],
+          },
+          seats: [],
+          actions: [],
+          settlement: {
+            isShowdown: false,
+            revealedPlayerIds: [],
+            totalPot: 15,
+            payouts: [],
+            winners: [],
+            netByPlayerId: {},
+          },
+        },
+        analysis: {
+          status: 'failed',
+          failureReason: 'Insufficient credits',
+        },
+      })
+      .mockResolvedValueOnce({
+        handNumber: 2,
+        history: {
+          roomId: 'ROOM1',
+          handNumber: 2,
+          requesterPlayerId: 'alice',
+          version: 1,
+          dealerPosition: 1,
+          smallBlindPosition: 1,
+          bigBlindPosition: 2,
+          blinds: { smallBlind: 5, bigBlind: 10 },
+          communityCardsByStreet: {
+            preFlop: [],
+            flop: [],
+            turn: [],
+            river: [],
+          },
+          seats: [],
+          actions: [],
+          settlement: {
+            isShowdown: false,
+            revealedPlayerIds: [],
+            totalPot: 15,
+            payouts: [],
+            winners: [],
+            netByPlayerId: {},
+          },
+        },
+        analysis: {
+          status: 'pending',
+          failureReason: null,
+        },
+      });
+    savedGameReviewService.retryHandReview.mockResolvedValue(true);
+
+    const result = await (controller as any).retrySavedGameHandReview(
+      'ROOM1',
+      2,
+      { headers: { cookie: 'poker_session=token-alice' } } as any,
+      'en',
+      undefined,
+    );
+
+    expect(savedGameReviewService.retryHandReview).toHaveBeenCalledWith({
+      archiveId: 'ROOM1',
+      requesterUserId: 'user-alice',
+      handNumber: 2,
+      locale: 'en',
+    });
+    expect(
+      savedGameStorageService.getSavedGameHandDetailForUser,
+    ).toHaveBeenNthCalledWith(1, 'ROOM1', 'user-alice', 2);
+    expect(
+      savedGameStorageService.getSavedGameHandDetailForUser,
+    ).toHaveBeenNthCalledWith(2, 'ROOM1', 'user-alice', 2);
+    expect(result).toEqual(
+      expect.objectContaining({
+        handNumber: 2,
+        analysis: expect.objectContaining({
+          status: 'pending',
+        }),
+      }),
+    );
   });
 });

--- a/poker-server/src/saved-game-history.controller.ts
+++ b/poker-server/src/saved-game-history.controller.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   Param,
   ParseIntPipe,
+  Post,
   Query,
   Req,
   UnauthorizedException,
@@ -87,6 +88,44 @@ export class SavedGameHistoryController {
     if (!didUpdateLocalizationState) {
       return detail;
     }
+
+    const refreshedDetail =
+      await this.savedGameArchiveStorageService.getSavedGameHandDetailForUser(
+        archiveId,
+        current.user.id,
+        handNumber,
+      );
+    if (!refreshedDetail) {
+      throw new NotFoundException('Saved hand unavailable');
+    }
+    return refreshedDetail;
+  }
+
+  @Post(':archiveId/hands/:handNumber/retry')
+  async retrySavedGameHandReview(
+    @Param('archiveId') archiveId: string,
+    @Param('handNumber', ParseIntPipe) handNumber: number,
+    @Req() request: Request,
+    @Query('locale') locale?: string,
+    @Headers('authorization') authorization?: string,
+  ) {
+    const current = await this.getCurrentSession(request, authorization);
+    const detail =
+      await this.savedGameArchiveStorageService.getSavedGameHandDetailForUser(
+        archiveId,
+        current.user.id,
+        handNumber,
+      );
+    if (!detail) {
+      throw new NotFoundException('Saved hand unavailable');
+    }
+
+    await this.savedGameReviewService.retryHandReview({
+      archiveId,
+      requesterUserId: current.user.id,
+      handNumber,
+      locale,
+    });
 
     const refreshedDetail =
       await this.savedGameArchiveStorageService.getSavedGameHandDetailForUser(


### PR DESCRIPTION
## Summary

- add a hand-scoped saved-history retry endpoint for failed review generation and failed localized review entries
- add a shared saved-history retry button so desktop and mobile detail views can requeue the selected hand and refresh immediately
- cover canonical retry, localized retry, controller wiring, and retry-button UI states with focused specs

## Linked Issue

Closes #185

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/185#issuecomment-4276146072

## Validation

- pnpm --dir poker-server exec jest src/saved-game-history.controller.spec.ts src/game/saved-game-review.service.spec.ts --runInBand
- pnpm --dir poker-client test --run src/pages/SavedGameDetail.spec.ts
- pnpm --dir poker-server build
- pnpm --dir poker-client build
- Manual browser verification not run for this change
- Live provider verification not run for this change
