### PR TITLE
fix: stop saved-history AI reviews from including hands after a user leaves

### DIFF
--- a/poker-server/src/storage/json-storage.service.ts
+++ b/poker-server/src/storage/json-storage.service.ts
@@ -48,6 +48,12 @@ type ArchivedRoomPlayer = Room['players'][number] & {
   isRobot?: boolean;
 };
 
+type SavedGameArchivePlayerView = {
+  requesterUserId: string;
+  requesterPlayerId: string;
+  hands: SavedGameHandDetail[];
+};
+
 type SavedGameArchiveRecord = {
   archiveId: string;
   roomId: string;
@@ -57,14 +63,7 @@ type SavedGameArchiveRecord = {
   handCount: number;
   blinds: SavedGameSummary['blinds'];
   participants: SavedGameParticipant[];
-  playerViews: Record<
-    string,
-    {
-      requesterUserId: string;
-      requesterPlayerId: string;
-      hands: SavedGameHandDetail[];
-    }
-  >;
+  playerViews: Record<string, SavedGameArchivePlayerView>;
 };
 
 @Injectable()
@@ -514,14 +513,7 @@ export class JsonStorageService
       }
 
       const archivedPlayers = room.players as ArchivedRoomPlayer[];
-      const participantViews = new Map<
-        string,
-        {
-          requesterUserId: string;
-          requesterPlayerId: string;
-          hands: SavedGameHandDetail[];
-        }
-      >();
+      const participantViews = new Map<string, SavedGameArchivePlayerView>();
 
       for (const player of archivedPlayers) {
         if (!player.userId) {
@@ -536,14 +528,22 @@ export class JsonStorageService
           continue;
         }
 
-        participantViews.set(player.userId, {
-          requesterUserId: player.userId,
-          requesterPlayerId: player.id,
-          hands: exportPayload.hands.map((hand) => ({
+        const normalizedHands = this.filterSavedGameHandsForRequester(
+          exportPayload.hands.map((hand) => ({
             handNumber: hand.handNumber,
             history: hand,
             analysis: this.createPendingSavedGameAnalysis(room.lastActivityAt),
           })),
+          player.id,
+        );
+        if (normalizedHands.length === 0) {
+          continue;
+        }
+
+        participantViews.set(player.userId, {
+          requesterUserId: player.userId,
+          requesterPlayerId: player.id,
+          hands: normalizedHands,
         });
       }
 
@@ -570,7 +570,10 @@ export class JsonStorageService
           }
           return left.playerName.localeCompare(right.playerName);
         });
-      const handCount = participantViews.values().next().value?.hands.length ?? 0;
+      const handCount = Array.from(participantViews.values()).reduce(
+        (max, view) => Math.max(max, view.hands.length),
+        0,
+      );
 
       const archiveRecord: SavedGameArchiveRecord = {
         archiveId,
@@ -594,18 +597,9 @@ export class JsonStorageService
 
       await Promise.all(
         Array.from(participantViews.values()).map((view) =>
-          this.writeSavedGameIndexForUser({
-            archiveId,
-            roomId,
-            requesterUserId: view.requesterUserId,
-            requesterPlayerId: view.requesterPlayerId,
-            createdAt: concludedAt,
-            startedAt,
-            concludedAt,
-            handCount,
-            blinds: archiveRecord.blinds,
-            participants,
-          }),
+          this.writeSavedGameIndexForUser(
+            this.buildSavedGameSummary(archiveRecord, view),
+          ),
         ),
       );
 
@@ -620,10 +614,30 @@ export class JsonStorageService
         this.getSavedGameUserIndexPath(userId),
       )) ?? [];
 
-    return savedGames.map((summary) => ({
-      ...summary,
-      participants: this.normalizeSavedGameParticipants(summary.participants),
-    }));
+    const normalizedSummaries = await Promise.all(
+      savedGames.map(async (summary) => {
+        const archive = await this.readSavedGameArchive(summary.archiveId);
+        if (!archive) {
+          return {
+            ...summary,
+            participants: this.normalizeSavedGameParticipants(summary.participants),
+          };
+        }
+
+        const playerView = this.getNormalizedSavedGamePlayerView(
+          archive.playerViews[userId],
+        );
+        if (!playerView) {
+          return null;
+        }
+
+        return this.buildSavedGameSummary(archive, playerView);
+      }),
+    );
+
+    return normalizedSummaries.filter(
+      (summary): summary is SavedGameSummary => Boolean(summary),
+    );
   }
 
   async getSavedGameDetailForUser(
@@ -636,7 +650,9 @@ export class JsonStorageService
       return null;
     }
 
-    const playerView = archive.playerViews[userId];
+    const playerView = this.getNormalizedSavedGamePlayerView(
+      archive.playerViews[userId],
+    );
     if (!playerView) {
       return null;
     }
@@ -653,7 +669,7 @@ export class JsonStorageService
       createdAt: archive.createdAt,
       startedAt: archive.startedAt,
       concludedAt: archive.concludedAt,
-      handCount: archive.handCount,
+      handCount: playerView.hands.length,
       blinds: archive.blinds,
       participants,
       hands: playerView.hands.map((hand) => ({
@@ -676,7 +692,9 @@ export class JsonStorageService
       return null;
     }
 
-    const playerView = archive.playerViews[userId];
+    const playerView = this.getNormalizedSavedGamePlayerView(
+      archive.playerViews[userId],
+    );
     const hand = playerView?.hands.find(
       (candidate) => candidate.handNumber === handNumber,
     );
@@ -702,14 +720,17 @@ export class JsonStorageService
 
     return {
       archiveId,
-      playerViews: Object.values(archive.playerViews).map((view) => ({
-        requesterUserId: view.requesterUserId,
-        requesterPlayerId: view.requesterPlayerId,
-        hands: view.hands.map((hand) => ({
-          handNumber: hand.handNumber,
-          history: hand.history,
+      playerViews: Object.values(archive.playerViews)
+        .map((view) => this.getNormalizedSavedGamePlayerView(view))
+        .filter((view): view is SavedGameArchivePlayerView => Boolean(view))
+        .map((view) => ({
+          requesterUserId: view.requesterUserId,
+          requesterPlayerId: view.requesterPlayerId,
+          hands: view.hands.map((hand) => ({
+            handNumber: hand.handNumber,
+            history: hand.history,
+          })),
         })),
-      })),
     };
   }
 
@@ -726,7 +747,9 @@ export class JsonStorageService
         return;
       }
 
-      const playerView = archive.playerViews[userId];
+      const playerView = this.getNormalizedSavedGamePlayerView(
+        archive.playerViews[userId],
+      );
       if (!playerView) {
         return;
       }
@@ -761,7 +784,9 @@ export class JsonStorageService
       return null;
     }
 
-    const playerView = archive.playerViews[userId];
+    const playerView = this.getNormalizedSavedGamePlayerView(
+      archive.playerViews[userId],
+    );
     const hand = playerView?.hands.find((candidate) => candidate.handNumber === handNumber);
     return hand ? this.normalizeSavedGameHandAnalysis(hand.analysis) : null;
   }
@@ -782,7 +807,9 @@ export class JsonStorageService
         return;
       }
 
-      const playerView = archive.playerViews[userId];
+      const playerView = this.getNormalizedSavedGamePlayerView(
+        archive.playerViews[userId],
+      );
       if (!playerView) {
         return;
       }
@@ -1209,6 +1236,63 @@ export class JsonStorageService
     return participants.filter((participant) =>
       shouldIncludeArchivedRankingParticipant(participant),
     );
+  }
+
+  private filterSavedGameHandsForRequester(
+    hands: SavedGameHandDetail[],
+    requesterPlayerId: string,
+  ): SavedGameHandDetail[] {
+    return hands.filter((hand) =>
+      hand.history.seats.some((seat) => seat.playerId === requesterPlayerId),
+    );
+  }
+
+  private getNormalizedSavedGamePlayerView(
+    view?: SavedGameArchivePlayerView,
+  ): SavedGameArchivePlayerView | null {
+    if (!view) {
+      return null;
+    }
+
+    const hands = this.filterSavedGameHandsForRequester(
+      view.hands,
+      view.requesterPlayerId,
+    );
+    if (hands.length === 0) {
+      return null;
+    }
+
+    return {
+      ...view,
+      hands,
+    };
+  }
+
+  private buildSavedGameSummary(
+    archive: Pick<
+      SavedGameArchiveRecord,
+      | 'archiveId'
+      | 'roomId'
+      | 'createdAt'
+      | 'startedAt'
+      | 'concludedAt'
+      | 'blinds'
+      | 'participants'
+    >,
+    playerView: SavedGameArchivePlayerView,
+  ): SavedGameSummary {
+    return {
+      archiveId: archive.archiveId,
+      roomId: archive.roomId,
+      requesterUserId: playerView.requesterUserId,
+      requesterPlayerId: playerView.requesterPlayerId,
+      createdAt: archive.createdAt,
+      startedAt: archive.startedAt,
+      concludedAt: archive.concludedAt,
+      handCount: playerView.hands.length,
+      blinds: archive.blinds,
+      participants: this.normalizeSavedGameParticipants(archive.participants),
+    };
   }
 
   private async readSavedGameArchive(

--- a/poker-server/test/unit/json-storage.service.spec.ts
+++ b/poker-server/test/unit/json-storage.service.spec.ts
@@ -632,6 +632,239 @@ describe('JsonStorageService', () => {
     await service.persistRoom(room);
   };
 
+  const seedPostLeaveHandLeakScenario = async (roomId: string) => {
+    await seedCompletedHands(roomId);
+
+    const handTwoPath = path.join(testRoomsDir, roomId, 'hands', '2.jsonl');
+    const handTwoEvents = [
+      {
+        recordId: 'leave-hand-2-started',
+        seq: 1,
+        roomId,
+        handNumber: 2,
+        street: 'PRE_FLOP',
+        timestamp: 200,
+        type: 'HAND_STARTED',
+        actor: { source: 'HAND_SERVICE' },
+        payload: {
+          handNumber: 2,
+          dealerPosition: 1,
+          smallBlindPosition: 1,
+          bigBlindPosition: 2,
+          pot: 30,
+          currentBet: 20,
+          lastRaiseSize: 20,
+          currentPlayerTurn: 'bob',
+          activePlayerIds: ['bob', 'charlie'],
+          dealtPlayerIds: ['bob', 'charlie'],
+          positionLabelsByPlayerId: {
+            bob: 'BTN/SB',
+            charlie: 'BB',
+          },
+          potContributions: {
+            bob: 10,
+            charlie: 20,
+          },
+          communityCards: [],
+          players: [
+            {
+              playerId: 'bob',
+              playerName: 'Bob',
+              position: 1,
+              status: 'connected',
+              chips: 990,
+              currentBet: 10,
+              totalBuyIn: 1000,
+              lastAction: null,
+              isActiveInHand: true,
+              positionLabel: 'BTN/SB',
+              cards: [createCard('4', 'hearts'), createCard('3', 'diamonds')],
+            },
+            {
+              playerId: 'charlie',
+              playerName: 'Charlie',
+              position: 2,
+              status: 'connected',
+              chips: 980,
+              currentBet: 20,
+              totalBuyIn: 1000,
+              lastAction: null,
+              isActiveInHand: true,
+              positionLabel: 'BB',
+              cards: [createCard('A', 'clubs'), createCard('Q', 'clubs')],
+            },
+          ],
+        },
+      },
+      {
+        recordId: 'leave-hand-2-action',
+        seq: 2,
+        roomId,
+        handNumber: 2,
+        street: 'PRE_FLOP',
+        timestamp: 210,
+        type: 'PLAYER_ACTION',
+        actor: {
+          source: 'BETTING_SERVICE',
+          playerId: 'bob',
+          playerName: 'Bob',
+        },
+        payload: {
+          action: 'fold',
+          amount: null,
+          playerStatus: 'folded',
+          playerChips: 990,
+          playerCurrentBet: 10,
+          pot: 30,
+          currentBet: 20,
+          request: {
+            action: 'fold',
+            actionId: 'leave-hand-2-action-1',
+          },
+          decision: {
+            currentPlayerTurnBefore: 'bob',
+            playerStatusBefore: 'connected',
+            playerChipsBefore: 990,
+            playerCurrentBetBefore: 10,
+            potBefore: 30,
+            currentBetBefore: 20,
+            lastRaiseSizeBefore: 20,
+            callAmountBefore: 10,
+            minimumRaiseBy: 20,
+            minimumRaiseTo: 40,
+            maximumBetTo: 1000,
+            facingBet: true,
+            legalActions: ['fold', 'call', 'raise', 'all-in'],
+            activePlayerIds: ['bob', 'charlie'],
+            communityCards: [],
+            potContributions: { bob: 10, charlie: 20 },
+            players: [],
+          },
+          result: {
+            resolvedAction: 'fold',
+            displayKind: 'fold',
+            committedAmount: 0,
+            totalBetAfterAction: 10,
+            playerStatusAfter: 'folded',
+            playerChipsAfter: 990,
+            playerCurrentBetAfter: 10,
+            potAfter: 30,
+            currentBetAfter: 20,
+            lastRaiseSizeAfter: 20,
+            activePlayerIds: ['charlie'],
+            potContributions: { bob: 10, charlie: 20 },
+            players: [],
+          },
+        },
+      },
+      {
+        recordId: 'leave-hand-2-settled',
+        seq: 3,
+        roomId,
+        handNumber: 2,
+        street: 'PRE_FLOP',
+        timestamp: 211,
+        type: 'HAND_SETTLED',
+        actor: { source: 'EVENTS_GATEWAY' },
+        payload: {
+          handNumber: 2,
+          isShowdown: false,
+          revealedPlayerIds: [],
+          result: {
+            winners: [
+              {
+                playerId: 'charlie',
+                playerName: 'Charlie',
+                hand: null,
+                amountWon: 30,
+              },
+            ],
+            playerHands: [
+              {
+                playerId: 'bob',
+                playerName: 'Bob',
+                cards: [],
+                hand: null,
+                resultStatus: 'folded_pre_showdown',
+                cardsVisibility: 'hidden',
+                seatPosition: 1,
+              },
+              {
+                playerId: 'charlie',
+                playerName: 'Charlie',
+                cards: [],
+                hand: null,
+                resultStatus: 'hidden_contender',
+                cardsVisibility: 'hidden',
+                seatPosition: 2,
+              },
+            ],
+            totalPot: 30,
+            payouts: [
+              {
+                segmentIndex: 0,
+                potType: 'MAIN',
+                amount: 30,
+                eligiblePlayers: ['bob', 'charlie'],
+                winnerShares: [{ playerId: 'charlie', amountWon: 30 }],
+                uncontested: true,
+              },
+            ],
+            netByPlayerId: {
+              bob: -10,
+              charlie: 10,
+            },
+          },
+        },
+      },
+    ];
+    await fs.writeFile(
+      handTwoPath,
+      `${handTwoEvents.map((event) => JSON.stringify(event)).join('\n')}\n`,
+      'utf8',
+    );
+
+    const endedRoom = await service.getRoom(roomId);
+    if (!endedRoom) {
+      throw new Error('Expected ended room to exist');
+    }
+
+    const alice = endedRoom.players.find((player) => player.id === 'alice');
+    const bob = endedRoom.players.find((player) => player.id === 'bob');
+    if (!alice || !bob) {
+      throw new Error('Expected seeded players to exist');
+    }
+
+    endedRoom.players = [
+      {
+        ...alice,
+        userId: 'user-alice',
+        status: 'left',
+        socketId: '',
+        cards: null,
+        currentBet: 0,
+        lastAction: null,
+      },
+      {
+        ...bob,
+        userId: 'user-bob',
+      },
+      {
+        ...createRoomPlayer({
+          id: 'charlie',
+          name: 'Charlie',
+          position: 2,
+          chips: 1010,
+          totalBuyIn: 1000,
+        }),
+        userId: 'user-charlie',
+        emoji: '🐼',
+      },
+    ] as any;
+    endedRoom.lastActivityAt = 320;
+    await service.persistRoom(endedRoom);
+  };
+
   describe('persistRoom', () => {
     it('should save room to room snapshot file', async () => {
       const room = createMockRoom('TEST123');
@@ -1448,6 +1681,217 @@ describe('JsonStorageService', () => {
         'user-intruder',
       );
       expect(unauthorizedDetail).toBeNull();
+    });
+
+    it('excludes post-leave hands from saved-game ownership and review targets', async () => {
+      const roomId = 'ROOMARCHIVE-LEFT-USER';
+      await seedPostLeaveHandLeakScenario(roomId);
+
+      const archiveEndedRoom = (
+        service as JsonStorageService & {
+          archiveEndedRoom?: (roomId: string) => Promise<{ archiveId: string } | null>;
+        }
+      ).archiveEndedRoom;
+      const listSavedGamesForUser = (
+        service as JsonStorageService & {
+          listSavedGamesForUser?: (userId: string) => Promise<any[]>;
+        }
+      ).listSavedGamesForUser;
+      const getSavedGameDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameDetailForUser?: (
+            archiveId: string,
+            userId: string,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameDetailForUser;
+      const getSavedGameHandDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameHandDetailForUser?: (
+            archiveId: string,
+            userId: string,
+            handNumber: number,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameHandDetailForUser;
+      const getSavedGameReviewTargets = (
+        service as JsonStorageService & {
+          getSavedGameReviewTargets?: (archiveId: string) => Promise<any | null>;
+        }
+      ).getSavedGameReviewTargets;
+
+      expect(typeof archiveEndedRoom).toBe('function');
+      expect(typeof listSavedGamesForUser).toBe('function');
+      expect(typeof getSavedGameDetailForUser).toBe('function');
+      expect(typeof getSavedGameHandDetailForUser).toBe('function');
+      expect(typeof getSavedGameReviewTargets).toBe('function');
+      if (
+        typeof archiveEndedRoom !== 'function' ||
+        typeof listSavedGamesForUser !== 'function' ||
+        typeof getSavedGameDetailForUser !== 'function' ||
+        typeof getSavedGameHandDetailForUser !== 'function' ||
+        typeof getSavedGameReviewTargets !== 'function'
+      ) {
+        return;
+      }
+
+      const archived = await archiveEndedRoom.call(service, roomId);
+      const archiveId = archived?.archiveId;
+      if (!archiveId) {
+        throw new Error('Expected archive id');
+      }
+
+      const aliceGames = await listSavedGamesForUser.call(service, 'user-alice');
+      expect(aliceGames).toEqual([
+        expect.objectContaining({
+          archiveId,
+          requesterUserId: 'user-alice',
+          requesterPlayerId: 'alice',
+          handCount: 1,
+        }),
+      ]);
+
+      const aliceDetail = await getSavedGameDetailForUser.call(
+        service,
+        archiveId,
+        'user-alice',
+      );
+      expect(aliceDetail?.handCount).toBe(1);
+      expect(aliceDetail?.hands.map((hand: any) => hand.handNumber)).toEqual([1]);
+
+      const leakedHandDetail = await getSavedGameHandDetailForUser.call(
+        service,
+        archiveId,
+        'user-alice',
+        2,
+      );
+      expect(leakedHandDetail).toBeNull();
+
+      const reviewTargets = await getSavedGameReviewTargets.call(service, archiveId);
+      const aliceReviewTarget = reviewTargets?.playerViews.find(
+        (view: any) => view.requesterUserId === 'user-alice',
+      );
+      expect(aliceReviewTarget?.hands.map((hand: any) => hand.handNumber)).toEqual([1]);
+    });
+
+    it('suppresses leaked post-leave hands from stale archive and user-index records', async () => {
+      const roomId = 'ROOMARCHIVE-LEFT-USER-LEGACY';
+      await seedPostLeaveHandLeakScenario(roomId);
+
+      const archiveEndedRoom = (
+        service as JsonStorageService & {
+          archiveEndedRoom?: (roomId: string) => Promise<{ archiveId: string } | null>;
+        }
+      ).archiveEndedRoom;
+      const listSavedGamesForUser = (
+        service as JsonStorageService & {
+          listSavedGamesForUser?: (userId: string) => Promise<any[]>;
+        }
+      ).listSavedGamesForUser;
+      const getSavedGameDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameDetailForUser?: (
+            archiveId: string,
+            userId: string,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameDetailForUser;
+      const getSavedGameHandDetailForUser = (
+        service as JsonStorageService & {
+          getSavedGameHandDetailForUser?: (
+            archiveId: string,
+            userId: string,
+            handNumber: number,
+          ) => Promise<any | null>;
+        }
+      ).getSavedGameHandDetailForUser;
+      const getSavedGameReviewTargets = (
+        service as JsonStorageService & {
+          getSavedGameReviewTargets?: (archiveId: string) => Promise<any | null>;
+        }
+      ).getSavedGameReviewTargets;
+
+      expect(typeof archiveEndedRoom).toBe('function');
+      expect(typeof listSavedGamesForUser).toBe('function');
+      expect(typeof getSavedGameDetailForUser).toBe('function');
+      expect(typeof getSavedGameHandDetailForUser).toBe('function');
+      expect(typeof getSavedGameReviewTargets).toBe('function');
+      if (
+        typeof archiveEndedRoom !== 'function' ||
+        typeof listSavedGamesForUser !== 'function' ||
+        typeof getSavedGameDetailForUser !== 'function' ||
+        typeof getSavedGameHandDetailForUser !== 'function' ||
+        typeof getSavedGameReviewTargets !== 'function'
+      ) {
+        return;
+      }
+
+      const archived = await archiveEndedRoom.call(service, roomId);
+      const archiveId = archived?.archiveId;
+      if (!archiveId) {
+        throw new Error('Expected archive id');
+      }
+
+      const archivePath = path.join(
+        testDataDir,
+        'saved-games',
+        'archives',
+        `${archiveId}.json`,
+      );
+      const userIndexPath = path.join(
+        testDataDir,
+        'saved-games',
+        'users',
+        'user-alice.json',
+      );
+
+      const archiveRecord = JSON.parse(
+        await fs.readFile(archivePath, 'utf8'),
+      ) as {
+        handCount: number;
+        playerViews: Record<string, { hands: any[] }>;
+      };
+      const leakedHand = archiveRecord.playerViews['user-bob'].hands.find(
+        (hand) => hand.handNumber === 2,
+      );
+      if (!leakedHand) {
+        throw new Error('Expected leaked hand source');
+      }
+
+      archiveRecord.handCount = 2;
+      archiveRecord.playerViews['user-alice'].hands.push(leakedHand);
+      await fs.writeFile(archivePath, JSON.stringify(archiveRecord, null, 2));
+
+      const userIndex = JSON.parse(
+        await fs.readFile(userIndexPath, 'utf8'),
+      ) as Array<{ handCount: number }>;
+      userIndex[0].handCount = 2;
+      await fs.writeFile(userIndexPath, JSON.stringify(userIndex, null, 2));
+
+      const aliceGames = await listSavedGamesForUser.call(service, 'user-alice');
+      expect(aliceGames[0]?.handCount).toBe(1);
+
+      const aliceDetail = await getSavedGameDetailForUser.call(
+        service,
+        archiveId,
+        'user-alice',
+      );
+      expect(aliceDetail?.handCount).toBe(1);
+      expect(aliceDetail?.hands.map((hand: any) => hand.handNumber)).toEqual([1]);
+
+      const leakedHandDetail = await getSavedGameHandDetailForUser.call(
+        service,
+        archiveId,
+        'user-alice',
+        2,
+      );
+      expect(leakedHandDetail).toBeNull();
+
+      const reviewTargets = await getSavedGameReviewTargets.call(service, archiveId);
+      const aliceReviewTarget = reviewTargets?.playerViews.find(
+        (view: any) => view.requesterUserId === 'user-alice',
+      );
+      expect(aliceReviewTarget?.hands.map((hand: any) => hand.handNumber)).toEqual([1]);
     });
 
     it('omits zero-activity left robots from archived saved-game participants', async () => {


### PR DESCRIPTION
## Summary

- filter archived saved-history hands by requester seat membership on both write and read paths
- normalize stale archive and saved-game index reads so leaked post-leave hands disappear without manual cleanup

## Linked Issue

Closes #187

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/187#issuecomment-4280944520

## Validation

- pnpm --dir poker-server exec jest poker-server/test/unit/json-storage.service.spec.ts --runInBand
- pnpm --dir poker-server exec jest src/game/saved-game-review.service.spec.ts src/saved-game-history.controller.spec.ts --runInBand
- pnpm --dir poker-server build
