### PR TITLE
feat: improve AI robot personalities and pressure defense

### DIFF
--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -3655,31 +3655,35 @@ export class EventsGateway
       );
       const isPair = firstCard.rank === secondCard.rank;
       const isSuited = firstCard.suit === secondCard.suit;
+      const highRank = getRankValue(firstCard.rank);
+      const lowRank = getRankValue(secondCard.rank);
       const rankGap = Math.abs(
-        getRankValue(firstCard.rank) - getRankValue(secondCard.rank),
+        highRank - lowRank,
       );
+      const isBroadwayCombo =
+        highRank >= getRankValue('J') && lowRank >= getRankValue('10');
+      const isSuitedAce =
+        firstCard.rank === 'A' && isSuited && lowRank >= getRankValue('5');
+      const isSuitedConnector =
+        isSuited && rankGap <= 1 && lowRank >= getRankValue('8');
+      const isHighSuitedCombo =
+        isSuited &&
+        highRank >= getRankValue('10') &&
+        lowRank >= getRankValue('8');
 
       if (isPair) {
-        return getRankValue(firstCard.rank) >= getRankValue('7')
-          ? 'strong'
-          : 'medium';
+        return highRank >= getRankValue('7') ? 'strong' : 'medium';
       }
       if (
-        (firstCard.rank === 'A' && getRankValue(secondCard.rank) >= getRankValue('10')) ||
-        (getRankValue(firstCard.rank) >= getRankValue('K') &&
-          getRankValue(secondCard.rank) >= getRankValue('J')) ||
+        (firstCard.rank === 'A' && lowRank >= getRankValue('10')) ||
+        (highRank >= getRankValue('K') && lowRank >= getRankValue('J')) ||
         (isSuited &&
-          getRankValue(firstCard.rank) >= getRankValue('Q') &&
-          getRankValue(secondCard.rank) >= getRankValue('10'))
+          highRank >= getRankValue('Q') &&
+          lowRank >= getRankValue('10'))
       ) {
         return 'strong';
       }
-      if (
-        isSuited ||
-        rankGap <= 1 ||
-        (getRankValue(firstCard.rank) >= getRankValue('10') &&
-          getRankValue(secondCard.rank) >= getRankValue('9'))
-      ) {
+      if (isBroadwayCombo || isSuitedAce || isSuitedConnector || isHighSuitedCombo) {
         return 'medium';
       }
       return 'weak';
@@ -3808,6 +3812,17 @@ export class EventsGateway
     return 0.07 + context.personality.tuning.defend / 250;
   }
 
+  private getRobotStrongPotOddsLimit(context: RobotTurnContext): number {
+    return Math.min(0.46, this.getRobotDefendPotOddsLimit(context) + 0.08);
+  }
+
+  private getRobotStrongStackPressureLimit(context: RobotTurnContext): number {
+    return Math.min(
+      0.33,
+      this.getRobotDefendStackPressureLimit(context) + 0.08,
+    );
+  }
+
   private getRobotJamStackPressureThreshold(
     context: RobotTurnContext,
   ): number {
@@ -3836,17 +3851,24 @@ export class EventsGateway
     const defendPotOddsLimit = this.getRobotDefendPotOddsLimit(context);
     const defendStackPressureLimit =
       this.getRobotDefendStackPressureLimit(context);
+    const strongPotOddsLimit = this.getRobotStrongPotOddsLimit(context);
+    const strongStackPressureLimit =
+      this.getRobotStrongStackPressureLimit(context);
     const jamStackPressureThreshold =
       this.getRobotJamStackPressureThreshold(context);
     const jamBbThreshold = this.getRobotJamBbThreshold(context);
     const canReasonablyDefend =
-      potOdds <= defendPotOddsLimit || stackPressure <= defendStackPressureLimit;
+      potOdds <= defendPotOddsLimit &&
+      stackPressure <= defendStackPressureLimit;
+    const canStrongContinue =
+      potOdds <= strongPotOddsLimit &&
+      stackPressure <= strongStackPressureLimit;
 
     if (strength === 'strong') {
       if (
         context.legalActions.allIn.enabled &&
-        (stackPressure >= jamStackPressureThreshold ||
-          effectiveStackBb <= jamBbThreshold)
+        (effectiveStackBb <= jamBbThreshold ||
+          (stackPressure >= jamStackPressureThreshold && canStrongContinue))
       ) {
         return { action: 'all-in' };
       }
@@ -3863,11 +3885,17 @@ export class EventsGateway
       if (!facingBet && context.legalActions.check.enabled) {
         return { action: 'check' };
       }
-      if (context.legalActions.call.enabled) {
+      if (context.legalActions.call.enabled && canStrongContinue) {
         return { action: 'call' };
       }
       if (context.legalActions.check.enabled) {
         return { action: 'check' };
+      }
+      if (context.legalActions.fold.enabled) {
+        return { action: 'fold' };
+      }
+      if (context.legalActions.call.enabled) {
+        return { action: 'call' };
       }
       return { action: 'fold' };
     }
@@ -3912,15 +3940,16 @@ export class EventsGateway
     if (!facingBet && context.legalActions.check.enabled) {
       return { action: 'check' };
     }
-      if (
-        context.legalActions.call.enabled &&
-        context.personality.tuning.defend >= 55 &&
-        context.personality.tuning.bluff >= 50 &&
-        potOdds <= 0.16 &&
-        stackPressure <= 0.08
-      ) {
-        return { action: 'call' };
-      }
+    if (
+      context.legalActions.call.enabled &&
+      context.personality.tuning.defend >= 54 &&
+      (context.personality.tuning.bluff >= 50 ||
+        context.personality.tuning.pressure >= 70) &&
+      potOdds <= 0.16 &&
+      stackPressure <= 0.08
+    ) {
+      return { action: 'call' };
+    }
     if (context.legalActions.check.enabled) {
       return { action: 'check' };
     }

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -149,6 +149,10 @@ export class EventsGateway
     new Map();
   private roomActionQueues: Map<string, Promise<void>> = new Map();
   private robotTurnTimers: Map<string, NodeJS.Timeout> = new Map();
+  private activeRobotTurnExecutions: Map<
+    string,
+    { playerId: string; handNumber: number }
+  > = new Map();
   private pendingRobotActionDecisions: Map<
     string,
     PersistedRobotDecisionMetadata
@@ -305,6 +309,7 @@ export class EventsGateway
       clearTimeout(timer);
     }
     this.runCountDecisionTimers.clear();
+    this.activeRobotTurnExecutions.clear();
     this.abandonedRoomSince.clear();
   }
 
@@ -1088,6 +1093,7 @@ export class EventsGateway
           connectionStatus: player.connectionStatus ?? 'connected',
         });
         this.emitReadyStateUpdated(data.roomId, room);
+        this.resumeRobotTurnIfNeeded(room);
 
         this.logger.log(
           `Player ${player.name} reconnected to room ${data.roomId}`,
@@ -3442,6 +3448,13 @@ export class EventsGateway
       Math.floor(Math.random() * (upperBound - minDelayMs + 1)) + minDelayMs,
     );
     const handNumber = room.currentHand?.handNumber;
+    if (
+      handNumber === undefined ||
+      handNumber === null ||
+      this.isRobotTurnExecutionActive(room.id, player.id, handNumber)
+    ) {
+      return;
+    }
 
     const timer = setTimeout(async () => {
       this.robotTurnTimers.delete(room.id);
@@ -3457,6 +3470,38 @@ export class EventsGateway
     }, delayMs);
 
     this.robotTurnTimers.set(room.id, timer);
+  }
+
+  private isRobotTurnExecutionActive(
+    roomId: string,
+    playerId: string,
+    handNumber: number,
+  ): boolean {
+    const activeExecution = this.activeRobotTurnExecutions.get(roomId);
+    return Boolean(
+      activeExecution &&
+        activeExecution.playerId === playerId &&
+        activeExecution.handNumber === handNumber,
+    );
+  }
+
+  private resumeRobotTurnIfNeeded(room: any): void {
+    const hand = room?.currentHand;
+    if (!room?.id || !hand?.currentPlayerTurn || this.robotTurnTimers.has(room.id)) {
+      return;
+    }
+
+    const currentPlayer = room.players.find(
+      (player: any) => player.id === hand.currentPlayerTurn,
+    );
+    if (
+      !currentPlayer?.isRobot ||
+      this.isRobotTurnExecutionActive(room.id, currentPlayer.id, hand.handNumber)
+    ) {
+      return;
+    }
+
+    this.emitPlayerTurn(room, currentPlayer);
   }
 
   private resolveRobotLegalActions(room: any, robotPlayerId: string) {
@@ -3981,74 +4026,92 @@ export class EventsGateway
     if (hand.currentPlayerTurn !== robotPlayerId) {
       return;
     }
-
-    const roomSnapshot = JSON.parse(JSON.stringify(room));
-    const context = this.buildRobotTurnContext(roomSnapshot, robotPlayerId);
-
-    let selectedAction: RobotActionDecision;
-    if (!this.robotAgentService.isConfigured()) {
-      selectedAction = this.buildRobotFallbackDecision(
-        this.resolveRobotFallbackAction(context),
-        'provider-unavailable',
-        0,
-      );
-    } else {
-      try {
-        selectedAction = await this.robotAgentService.decideAction({
-          context,
-          validateAction: (candidate) => {
-            const validation = this.bettingService.validateAction(
-              roomSnapshot,
-              robotPlayerId,
-              candidate.action,
-              candidate.action === 'raise' ? candidate.amount : undefined,
-            );
-            return {
-              valid: validation.valid,
-              reason: validation.reason,
-              legalActions: context.legalActions,
-            };
-          },
-        });
-      } catch (error) {
-        this.logger.warn(
-          `Robot agent fallback in room ${roomId}: ${
-            error instanceof Error ? error.message : 'unknown error'
-          }`,
-        );
-        selectedAction = this.buildRobotFallbackDecision(
-          this.resolveRobotFallbackAction(context),
-          toRobotFallbackCause(error),
-          this.getRobotFallbackRetryCount(error),
-        );
-      }
+    if (this.isRobotTurnExecutionActive(roomId, robotPlayerId, hand.handNumber)) {
+      return;
     }
 
-    const actionId = `robot-${hand.handNumber}-${Date.now()}`;
-    const tempSocketId = `robot:${roomId}:${robotPlayerId}:${Date.now()}`;
-    this.pendingRobotActionDecisions.set(
-      this.getPendingRobotActionDecisionKey(tempSocketId, actionId),
-      selectedAction.persistedDecision,
-    );
-    this.socketToPlayer.set(tempSocketId, { roomId, playerId: robotPlayerId });
+    this.activeRobotTurnExecutions.set(roomId, {
+      playerId: robotPlayerId,
+      handNumber: hand.handNumber,
+    });
 
     try {
-      await this.handlePlayerAction(
-        {
-          id: tempSocketId,
-          emit: () => undefined,
-        } as unknown as Socket,
-        {
-          action: selectedAction.action,
-          amount: selectedAction.amount,
-          actionId,
-        },
-      );
-    } finally {
-      this.pendingRobotActionDecisions.delete(
+      const roomSnapshot = JSON.parse(JSON.stringify(room));
+      const context = this.buildRobotTurnContext(roomSnapshot, robotPlayerId);
+
+      let selectedAction: RobotActionDecision;
+      if (!this.robotAgentService.isConfigured()) {
+        selectedAction = this.buildRobotFallbackDecision(
+          this.resolveRobotFallbackAction(context),
+          'provider-unavailable',
+          0,
+        );
+      } else {
+        try {
+          selectedAction = await this.robotAgentService.decideAction({
+            context,
+            validateAction: (candidate) => {
+              const validation = this.bettingService.validateAction(
+                roomSnapshot,
+                robotPlayerId,
+                candidate.action,
+                candidate.action === 'raise' ? candidate.amount : undefined,
+              );
+              return {
+                valid: validation.valid,
+                reason: validation.reason,
+                legalActions: context.legalActions,
+              };
+            },
+          });
+        } catch (error) {
+          this.logger.warn(
+            `Robot agent fallback in room ${roomId}: ${
+              error instanceof Error ? error.message : 'unknown error'
+            }`,
+          );
+          selectedAction = this.buildRobotFallbackDecision(
+            this.resolveRobotFallbackAction(context),
+            toRobotFallbackCause(error),
+            this.getRobotFallbackRetryCount(error),
+          );
+        }
+      }
+
+      const actionId = `robot-${hand.handNumber}-${Date.now()}`;
+      const tempSocketId = `robot:${roomId}:${robotPlayerId}:${Date.now()}`;
+      this.pendingRobotActionDecisions.set(
         this.getPendingRobotActionDecisionKey(tempSocketId, actionId),
+        selectedAction.persistedDecision,
       );
-      this.socketToPlayer.delete(tempSocketId);
+      this.socketToPlayer.set(tempSocketId, { roomId, playerId: robotPlayerId });
+
+      try {
+        await this.handlePlayerAction(
+          {
+            id: tempSocketId,
+            emit: () => undefined,
+          } as unknown as Socket,
+          {
+            action: selectedAction.action,
+            amount: selectedAction.amount,
+            actionId,
+          },
+        );
+      } finally {
+        this.pendingRobotActionDecisions.delete(
+          this.getPendingRobotActionDecisionKey(tempSocketId, actionId),
+        );
+        this.socketToPlayer.delete(tempSocketId);
+      }
+    } finally {
+      const activeExecution = this.activeRobotTurnExecutions.get(roomId);
+      if (
+        activeExecution?.playerId === robotPlayerId &&
+        activeExecution.handNumber === hand.handNumber
+      ) {
+        this.activeRobotTurnExecutions.delete(roomId);
+      }
     }
   }
 

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -3787,44 +3787,186 @@ export class EventsGateway
     return 'weak';
   }
 
-  private selectRobotRaiseIncrement(
-    legalRaise: RobotTurnContext['legalActions']['raise'],
-    raiseSizeBias: RobotTurnContext['personality']['tuning']['raiseSizeBias'],
-  ): number | null {
-    if (!legalRaise.enabled) {
-      return null;
+  private roundRobotRaiseIncrementUp(value: number, minIncrement: number): number {
+    if (!Number.isFinite(value) || value <= 0) {
+      return minIncrement;
     }
 
-    const candidates = legalRaise.suggestedIncrements.length
-      ? legalRaise.suggestedIncrements
-      : [legalRaise.minIncrement, legalRaise.maxIncrement];
-    const uniqueCandidates = [...new Set(candidates)]
+    return Math.ceil(value / minIncrement) * minIncrement;
+  }
+
+  private getRobotMeaningfulRaiseFloor(
+    context: RobotTurnContext,
+    legalRaise: RobotTurnContext['legalActions']['raise'],
+  ): number {
+    const amountToCall = context.legalActions.call.amountToCall;
+    const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
+    let floor = legalRaise.minIncrement;
+
+    if (facingBet) {
+      floor = Math.max(
+        floor,
+        Math.min(
+          legalRaise.maxIncrement,
+          this.roundRobotRaiseIncrementUp(
+            legalRaise.minIncrement * 2,
+            legalRaise.minIncrement,
+          ),
+        ),
+      );
+    } else if (context.table.pot >= context.rules.bigBlind * 4) {
+      floor = Math.max(
+        floor,
+        Math.min(
+          legalRaise.maxIncrement,
+          this.roundRobotRaiseIncrementUp(
+            Math.max(legalRaise.minIncrement * 2, context.table.pot / 3),
+            legalRaise.minIncrement,
+          ),
+        ),
+      );
+    }
+
+    return floor;
+  }
+
+  private getRobotRaiseCandidates(
+    context: RobotTurnContext,
+    legalRaise: RobotTurnContext['legalActions']['raise'],
+    requestedAmount?: number,
+  ): number[] {
+    const amountToCall = context.legalActions.call.amountToCall;
+    const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
+    const includeEscalationCandidates =
+      facingBet || context.table.pot >= context.rules.bigBlind * 4;
+    const derivedCandidates = [
+      legalRaise.minIncrement,
+      ...(includeEscalationCandidates
+        ? [legalRaise.minIncrement * 2, legalRaise.minIncrement * 3]
+        : []),
+      ...legalRaise.suggestedIncrements,
+      requestedAmount,
+      legalRaise.maxIncrement,
+    ];
+
+    return [...new Set(derivedCandidates)]
+      .filter((value): value is number => Number.isFinite(value))
+      .map((value) => Math.floor(value))
       .filter(
         (value) =>
           value >= legalRaise.minIncrement && value <= legalRaise.maxIncrement,
       )
       .sort((left, right) => left - right);
+  }
+
+  private getRobotRaiseCeiling(
+    context: RobotTurnContext,
+    legalRaise: RobotTurnContext['legalActions']['raise'],
+    meaningfulFloor: number,
+  ): number {
+    const amountToCall = context.legalActions.call.amountToCall;
+    const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
+
+    if (facingBet) {
+      return Math.max(
+        meaningfulFloor,
+        Math.min(legalRaise.maxIncrement, legalRaise.minIncrement * 3),
+      );
+    }
+
+    if (context.table.pot >= context.rules.bigBlind * 4) {
+      return Math.max(
+        meaningfulFloor,
+        Math.min(
+          legalRaise.maxIncrement,
+          this.roundRobotRaiseIncrementUp(
+            Math.max(meaningfulFloor, context.table.pot / 2),
+            legalRaise.minIncrement,
+          ),
+        ),
+      );
+    }
+
+    return Math.max(
+      meaningfulFloor,
+      Math.min(legalRaise.maxIncrement, legalRaise.minIncrement * 3),
+    );
+  }
+
+  private selectRobotRaiseIncrement(
+    context: RobotTurnContext,
+    raiseSizeBias: RobotTurnContext['personality']['tuning']['raiseSizeBias'],
+  ): number | null {
+    const legalRaise = context.legalActions.raise;
+    if (!legalRaise.enabled) {
+      return null;
+    }
+
+    const uniqueCandidates = this.getRobotRaiseCandidates(context, legalRaise);
     if (!uniqueCandidates.length) {
       return legalRaise.minIncrement;
     }
-    const boundedPressureCap = Math.max(
-      legalRaise.minIncrement,
-      Math.min(legalRaise.maxIncrement, legalRaise.minIncrement * 3),
+    const meaningfulFloor = this.getRobotMeaningfulRaiseFloor(context, legalRaise);
+    const meaningfulCeiling = this.getRobotRaiseCeiling(
+      context,
+      legalRaise,
+      meaningfulFloor,
     );
-    const boundedCandidates = uniqueCandidates.filter(
-      (value) => value <= boundedPressureCap,
+    const sizeCandidates = uniqueCandidates.filter(
+      (value) => value >= meaningfulFloor,
     );
-    const sizeCandidates = boundedCandidates.length
+    const boundedCandidates = sizeCandidates.filter(
+      (value) => value <= meaningfulCeiling,
+    );
+    const candidateWindow = boundedCandidates.length
       ? boundedCandidates
-      : uniqueCandidates;
+      : sizeCandidates.length
+        ? sizeCandidates
+        : uniqueCandidates;
 
     if (raiseSizeBias === 'small') {
-      return sizeCandidates[0];
+      return candidateWindow[0];
     }
     if (raiseSizeBias === 'large') {
-      return sizeCandidates[sizeCandidates.length - 1];
+      return candidateWindow[candidateWindow.length - 1];
     }
-    return sizeCandidates[Math.floor(sizeCandidates.length / 2)];
+    return candidateWindow[Math.floor(candidateWindow.length / 2)];
+  }
+
+  private normalizeRobotActionCandidate(
+    context: RobotTurnContext,
+    action: RobotActionCandidate,
+  ): RobotActionCandidate {
+    if (action.action !== 'raise') {
+      return action;
+    }
+
+    const legalRaise = context.legalActions.raise;
+    if (!legalRaise.enabled) {
+      return action;
+    }
+
+    const requestedAmount = Math.max(
+      legalRaise.minIncrement,
+      Math.min(legalRaise.maxIncrement, Math.floor(action.amount ?? legalRaise.minIncrement)),
+    );
+    const meaningfulFloor = this.getRobotMeaningfulRaiseFloor(context, legalRaise);
+    const candidates = this.getRobotRaiseCandidates(
+      context,
+      legalRaise,
+      requestedAmount,
+    );
+    const normalizedAmount =
+      candidates.find(
+        (value) => value >= Math.max(requestedAmount, meaningfulFloor),
+      ) ??
+      candidates[candidates.length - 1] ??
+      requestedAmount;
+
+    return {
+      action: 'raise',
+      amount: normalizedAmount,
+    };
   }
 
   private getRobotPressureMetrics(context: RobotTurnContext) {
@@ -3890,7 +4032,7 @@ export class EventsGateway
     } = this.getRobotPressureMetrics(context);
     const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
     const raiseAmount = this.selectRobotRaiseIncrement(
-      context.legalActions.raise,
+      context,
       context.personality.tuning.raiseSizeBias,
     );
     const defendPotOddsLimit = this.getRobotDefendPotOddsLimit(context);
@@ -4078,6 +4220,10 @@ export class EventsGateway
         }
       }
 
+      const normalizedAction = this.normalizeRobotActionCandidate(
+        context,
+        selectedAction,
+      );
       const actionId = `robot-${hand.handNumber}-${Date.now()}`;
       const tempSocketId = `robot:${roomId}:${robotPlayerId}:${Date.now()}`;
       this.pendingRobotActionDecisions.set(
@@ -4093,8 +4239,8 @@ export class EventsGateway
             emit: () => undefined,
           } as unknown as Socket,
           {
-            action: selectedAction.action,
-            amount: selectedAction.amount,
+            action: normalizedAction.action,
+            amount: normalizedAction.amount,
             actionId,
           },
         );

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -3591,6 +3591,8 @@ export class EventsGateway
           aggression: personalityProfile.aggression,
           bluff: personalityProfile.bluff,
           pressure: personalityProfile.pressure,
+          defend: personalityProfile.defend,
+          jam: personalityProfile.jam,
           raiseSizeBias: personalityProfile.raiseSizeBias,
         },
       },
@@ -3776,32 +3778,85 @@ export class EventsGateway
     return sizeCandidates[Math.floor(sizeCandidates.length / 2)];
   }
 
-  private resolveRobotFallbackAction(
-    context: RobotTurnContext,
-  ): RobotActionCandidate {
-    const strength = this.getRobotFallbackStrength(context);
+  private getRobotPressureMetrics(context: RobotTurnContext) {
     const amountToCall = context.legalActions.call.amountToCall;
-    const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
+    const potOdds =
+      amountToCall > 0
+        ? amountToCall / Math.max(1, context.table.pot + amountToCall)
+        : 0;
     const stackPressure =
       amountToCall > 0
         ? amountToCall / Math.max(1, context.hero.chips + context.hero.currentBet)
         : 0;
+    const effectiveStackBb =
+      Math.max(0, context.hero.chips + context.hero.currentBet) /
+      Math.max(1, context.rules.bigBlind);
+
+    return {
+      amountToCall,
+      potOdds,
+      stackPressure,
+      effectiveStackBb,
+    };
+  }
+
+  private getRobotDefendPotOddsLimit(context: RobotTurnContext): number {
+    return 0.14 + context.personality.tuning.defend / 200;
+  }
+
+  private getRobotDefendStackPressureLimit(context: RobotTurnContext): number {
+    return 0.07 + context.personality.tuning.defend / 250;
+  }
+
+  private getRobotJamStackPressureThreshold(
+    context: RobotTurnContext,
+  ): number {
+    return 0.46 - context.personality.tuning.jam / 500;
+  }
+
+  private getRobotJamBbThreshold(context: RobotTurnContext): number {
+    return 5 + context.personality.tuning.jam / 25;
+  }
+
+  private resolveRobotFallbackAction(
+    context: RobotTurnContext,
+  ): RobotActionCandidate {
+    const strength = this.getRobotFallbackStrength(context);
+    const {
+      amountToCall,
+      potOdds,
+      stackPressure,
+      effectiveStackBb,
+    } = this.getRobotPressureMetrics(context);
+    const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
     const raiseAmount = this.selectRobotRaiseIncrement(
       context.legalActions.raise,
       context.personality.tuning.raiseSizeBias,
     );
+    const defendPotOddsLimit = this.getRobotDefendPotOddsLimit(context);
+    const defendStackPressureLimit =
+      this.getRobotDefendStackPressureLimit(context);
+    const jamStackPressureThreshold =
+      this.getRobotJamStackPressureThreshold(context);
+    const jamBbThreshold = this.getRobotJamBbThreshold(context);
+    const canReasonablyDefend =
+      potOdds <= defendPotOddsLimit || stackPressure <= defendStackPressureLimit;
 
     if (strength === 'strong') {
       if (
         context.legalActions.allIn.enabled &&
-        (stackPressure >= 0.65 || context.hero.chips <= context.rules.bigBlind * 8)
+        (stackPressure >= jamStackPressureThreshold ||
+          effectiveStackBb <= jamBbThreshold)
       ) {
         return { action: 'all-in' };
       }
       if (
         raiseAmount !== null &&
         ((!facingBet && context.personality.tuning.pressure >= 60) ||
-          context.personality.tuning.aggression >= 60)
+          (facingBet &&
+            context.personality.tuning.aggression >= 60 &&
+            potOdds <= 0.42 &&
+            stackPressure <= 0.42))
       ) {
         return { action: 'raise', amount: raiseAmount };
       }
@@ -3828,19 +3883,23 @@ export class EventsGateway
       if (
         facingBet &&
         raiseAmount !== null &&
-        context.personality.tuning.aggression >= 75 &&
-        amountToCall <= context.rules.bigBlind * 2
+        context.personality.tuning.aggression >= 68 &&
+        potOdds <= 0.33 &&
+        stackPressure <= 0.22
       ) {
         return { action: 'raise', amount: raiseAmount };
       }
       if (
+        context.legalActions.allIn.enabled &&
+        context.personality.tuning.jam >= 70 &&
+        effectiveStackBb <= 5 &&
+        potOdds <= 0.3
+      ) {
+        return { action: 'all-in' };
+      }
+      if (
         context.legalActions.call.enabled &&
-        stackPressure <=
-          (context.personality.key === 'tight'
-            ? 0.08
-            : context.personality.key === 'chaotic'
-              ? 0.2
-              : 0.14)
+        canReasonablyDefend
       ) {
         return { action: 'call' };
       }
@@ -3855,8 +3914,9 @@ export class EventsGateway
     }
       if (
         context.legalActions.call.enabled &&
-        context.personality.tuning.bluff >= 55 &&
-        amountToCall <= context.rules.bigBlind &&
+        context.personality.tuning.defend >= 55 &&
+        context.personality.tuning.bluff >= 50 &&
+        potOdds <= 0.16 &&
         stackPressure <= 0.08
       ) {
         return { action: 'call' };

--- a/poker-server/src/events/events.gateway.ts
+++ b/poker-server/src/events/events.gateway.ts
@@ -19,6 +19,7 @@ import {
   RobotActionDecision,
   RobotDecisionError,
   RobotTurnContext,
+  getRobotPersonalityProfile,
   toRobotFallbackCause,
 } from '../game/robot-agent.service';
 import { SavedGameReviewService } from '../game/saved-game-review.service';
@@ -82,6 +83,8 @@ import {
   RunCount,
   shouldIncludeLiveRankingPlayer,
 } from 'poker-types';
+import { getRankValue } from '../common/utils/deck';
+import { evaluateHand } from '../common/utils/hand-evaluator';
 import { roomEvent, roomWrite } from '../storage/room-write.factory';
 
 const resolveGatewayCorsOrigin = ():
@@ -3548,10 +3551,7 @@ export class EventsGateway
       throw new Error('Cannot resolve legal robot actions');
     }
 
-    const revealedHoleCardsByPlayerId: Record<
-      string,
-      Array<{ rank: string; suit: string }>
-    > = {};
+    const revealedHoleCardsByPlayerId: Record<string, Card[]> = {};
     for (const playerId of hand.revealedPlayerIds ?? []) {
       const revealedPlayer = room.players.find(
         (player: any) => player.id === playerId,
@@ -3568,6 +3568,9 @@ export class EventsGateway
         action: player.lastAction,
         bettingRound: hand.bettingRound,
       }));
+    const personalityProfile = getRobotPersonalityProfile(
+      robotPlayer.robotPersonality,
+    );
 
     return {
       schemaVersion: '1.0',
@@ -3580,6 +3583,16 @@ export class EventsGateway
         bigBlind: room.config.bigBlind,
         bettingRound: hand.bettingRound,
         raiseFormat: 'increment_over_call',
+      },
+      personality: {
+        key: personalityProfile.key,
+        summary: personalityProfile.summary,
+        tuning: {
+          aggression: personalityProfile.aggression,
+          bluff: personalityProfile.bluff,
+          pressure: personalityProfile.pressure,
+          raiseSizeBias: personalityProfile.raiseSizeBias,
+        },
       },
       hero: {
         playerId: robotPlayer.id,
@@ -3626,17 +3639,236 @@ export class EventsGateway
     };
   }
 
-  private resolveRobotFallbackAction(
-    room: any,
-    robotPlayerId: string,
-  ): RobotActionCandidate {
-    const checkValidation = this.bettingService.validateAction(
-      room,
-      robotPlayerId,
-      'check',
+  private getRobotFallbackStrength(
+    context: RobotTurnContext,
+  ): 'weak' | 'medium' | 'strong' {
+    const allCards = [
+      ...context.hero.holeCards,
+      ...context.table.communityCards,
+    ];
+
+    if (context.table.communityCards.length < 3) {
+      const [firstCard, secondCard] = [...context.hero.holeCards].sort(
+        (left, right) => getRankValue(right.rank) - getRankValue(left.rank),
+      );
+      const isPair = firstCard.rank === secondCard.rank;
+      const isSuited = firstCard.suit === secondCard.suit;
+      const rankGap = Math.abs(
+        getRankValue(firstCard.rank) - getRankValue(secondCard.rank),
+      );
+
+      if (isPair) {
+        return getRankValue(firstCard.rank) >= getRankValue('7')
+          ? 'strong'
+          : 'medium';
+      }
+      if (
+        (firstCard.rank === 'A' && getRankValue(secondCard.rank) >= getRankValue('10')) ||
+        (getRankValue(firstCard.rank) >= getRankValue('K') &&
+          getRankValue(secondCard.rank) >= getRankValue('J')) ||
+        (isSuited &&
+          getRankValue(firstCard.rank) >= getRankValue('Q') &&
+          getRankValue(secondCard.rank) >= getRankValue('10'))
+      ) {
+        return 'strong';
+      }
+      if (
+        isSuited ||
+        rankGap <= 1 ||
+        (getRankValue(firstCard.rank) >= getRankValue('10') &&
+          getRankValue(secondCard.rank) >= getRankValue('9'))
+      ) {
+        return 'medium';
+      }
+      return 'weak';
+    }
+
+    const handEvaluation = evaluateHand(allCards, {
+      useShortDeckRules: context.rules.variant === 'shortDeck',
+    });
+    if (
+      handEvaluation.rank === 'TWO_PAIR' ||
+      handEvaluation.rank === 'THREE_OF_A_KIND' ||
+      handEvaluation.rank === 'STRAIGHT' ||
+      handEvaluation.rank === 'FLUSH' ||
+      handEvaluation.rank === 'FULL_HOUSE' ||
+      handEvaluation.rank === 'FOUR_OF_A_KIND' ||
+      handEvaluation.rank === 'STRAIGHT_FLUSH' ||
+      handEvaluation.rank === 'ROYAL_FLUSH'
+    ) {
+      return 'strong';
+    }
+
+    if (handEvaluation.rank === 'ONE_PAIR') {
+      const highestBoardRank = [...context.table.communityCards]
+        .sort((left, right) => getRankValue(right.rank) - getRankValue(left.rank))[0]
+        ?.rank;
+      const isPocketPair =
+        context.hero.holeCards[0]?.rank === context.hero.holeCards[1]?.rank;
+      const isOverpair =
+        Boolean(highestBoardRank) &&
+        isPocketPair &&
+        getRankValue(context.hero.holeCards[0].rank) > getRankValue(highestBoardRank!);
+      const heroPairsBoard = context.hero.holeCards.some((card) =>
+        context.table.communityCards.some((boardCard) => boardCard.rank === card.rank),
+      );
+      const isTopPair = context.hero.holeCards.some(
+        (card) => card.rank === highestBoardRank,
+      );
+
+      return isOverpair || isTopPair || heroPairsBoard ? 'medium' : 'weak';
+    }
+
+    const suitCounts = allCards.reduce<Record<string, number>>((counts, card) => {
+      counts[card.suit] = (counts[card.suit] || 0) + 1;
+      return counts;
+    }, {});
+    if (
+      Object.entries(suitCounts).some(
+        ([suit, count]) =>
+          count >= 4 &&
+          context.hero.holeCards.some((card) => card.suit === suit),
+      )
+    ) {
+      return 'medium';
+    }
+
+    return 'weak';
+  }
+
+  private selectRobotRaiseIncrement(
+    legalRaise: RobotTurnContext['legalActions']['raise'],
+    raiseSizeBias: RobotTurnContext['personality']['tuning']['raiseSizeBias'],
+  ): number | null {
+    if (!legalRaise.enabled) {
+      return null;
+    }
+
+    const candidates = legalRaise.suggestedIncrements.length
+      ? legalRaise.suggestedIncrements
+      : [legalRaise.minIncrement, legalRaise.maxIncrement];
+    const uniqueCandidates = [...new Set(candidates)]
+      .filter(
+        (value) =>
+          value >= legalRaise.minIncrement && value <= legalRaise.maxIncrement,
+      )
+      .sort((left, right) => left - right);
+    if (!uniqueCandidates.length) {
+      return legalRaise.minIncrement;
+    }
+    const boundedPressureCap = Math.max(
+      legalRaise.minIncrement,
+      Math.min(legalRaise.maxIncrement, legalRaise.minIncrement * 3),
     );
-    if (checkValidation.valid) {
+    const boundedCandidates = uniqueCandidates.filter(
+      (value) => value <= boundedPressureCap,
+    );
+    const sizeCandidates = boundedCandidates.length
+      ? boundedCandidates
+      : uniqueCandidates;
+
+    if (raiseSizeBias === 'small') {
+      return sizeCandidates[0];
+    }
+    if (raiseSizeBias === 'large') {
+      return sizeCandidates[sizeCandidates.length - 1];
+    }
+    return sizeCandidates[Math.floor(sizeCandidates.length / 2)];
+  }
+
+  private resolveRobotFallbackAction(
+    context: RobotTurnContext,
+  ): RobotActionCandidate {
+    const strength = this.getRobotFallbackStrength(context);
+    const amountToCall = context.legalActions.call.amountToCall;
+    const facingBet = amountToCall > 0 && context.legalActions.call.enabled;
+    const stackPressure =
+      amountToCall > 0
+        ? amountToCall / Math.max(1, context.hero.chips + context.hero.currentBet)
+        : 0;
+    const raiseAmount = this.selectRobotRaiseIncrement(
+      context.legalActions.raise,
+      context.personality.tuning.raiseSizeBias,
+    );
+
+    if (strength === 'strong') {
+      if (
+        context.legalActions.allIn.enabled &&
+        (stackPressure >= 0.65 || context.hero.chips <= context.rules.bigBlind * 8)
+      ) {
+        return { action: 'all-in' };
+      }
+      if (
+        raiseAmount !== null &&
+        ((!facingBet && context.personality.tuning.pressure >= 60) ||
+          context.personality.tuning.aggression >= 60)
+      ) {
+        return { action: 'raise', amount: raiseAmount };
+      }
+      if (!facingBet && context.legalActions.check.enabled) {
+        return { action: 'check' };
+      }
+      if (context.legalActions.call.enabled) {
+        return { action: 'call' };
+      }
+      if (context.legalActions.check.enabled) {
+        return { action: 'check' };
+      }
+      return { action: 'fold' };
+    }
+
+    if (strength === 'medium') {
+      if (
+        !facingBet &&
+        raiseAmount !== null &&
+        context.personality.tuning.pressure >= 60
+      ) {
+        return { action: 'raise', amount: raiseAmount };
+      }
+      if (
+        facingBet &&
+        raiseAmount !== null &&
+        context.personality.tuning.aggression >= 75 &&
+        amountToCall <= context.rules.bigBlind * 2
+      ) {
+        return { action: 'raise', amount: raiseAmount };
+      }
+      if (
+        context.legalActions.call.enabled &&
+        stackPressure <=
+          (context.personality.key === 'tight'
+            ? 0.08
+            : context.personality.key === 'chaotic'
+              ? 0.2
+              : 0.14)
+      ) {
+        return { action: 'call' };
+      }
+      if (context.legalActions.check.enabled) {
+        return { action: 'check' };
+      }
+      return { action: 'fold' };
+    }
+
+    if (!facingBet && context.legalActions.check.enabled) {
       return { action: 'check' };
+    }
+      if (
+        context.legalActions.call.enabled &&
+        context.personality.tuning.bluff >= 55 &&
+        amountToCall <= context.rules.bigBlind &&
+        stackPressure <= 0.08
+      ) {
+        return { action: 'call' };
+      }
+    if (context.legalActions.check.enabled) {
+      return { action: 'check' };
+    }
+    if (context.legalActions.fold.enabled) {
+      return { action: 'fold' };
+    }
+    if (context.legalActions.call.enabled) {
+      return { action: 'call' };
     }
     return { action: 'fold' };
   }
@@ -3667,7 +3899,7 @@ export class EventsGateway
     let selectedAction: RobotActionDecision;
     if (!this.robotAgentService.isConfigured()) {
       selectedAction = this.buildRobotFallbackDecision(
-        this.resolveRobotFallbackAction(roomSnapshot, robotPlayerId),
+        this.resolveRobotFallbackAction(context),
         'provider-unavailable',
         0,
       );
@@ -3696,7 +3928,7 @@ export class EventsGateway
           }`,
         );
         selectedAction = this.buildRobotFallbackDecision(
-          this.resolveRobotFallbackAction(roomSnapshot, robotPlayerId),
+          this.resolveRobotFallbackAction(context),
           toRobotFallbackCause(error),
           this.getRobotFallbackRetryCount(error),
         );

--- a/poker-server/src/game/game.service.ts
+++ b/poker-server/src/game/game.service.ts
@@ -6,6 +6,8 @@ import {
   Player,
   PlayerStatus,
   ReadyPhase,
+  ROBOT_PERSONALITIES,
+  RobotPersonality,
 } from 'poker-types';
 import { IStorageService } from '../common/interfaces/storage.interface';
 import { generateRoomId, generatePlayerId } from '../common/utils/id-generator';
@@ -38,6 +40,11 @@ const isDisconnected = (player: Player): boolean =>
 
 const resolveReconnectStatus = (status: PlayerStatus): PlayerStatus =>
   status === 'disconnected' ? 'connected' : status;
+
+const pickRandomRobotPersonality = (): RobotPersonality => {
+  const index = Math.floor(Math.random() * ROBOT_PERSONALITIES.length);
+  return ROBOT_PERSONALITIES[index] ?? 'balanced';
+};
 
 @Injectable()
 export class GameService {
@@ -362,6 +369,7 @@ export class GameService {
       socketId: '',
       name: uniqueName,
       isRobot: true,
+      robotPersonality: pickRandomRobotPersonality(),
       emoji: robotEmoji,
       chips: initialChips,
       totalBuyIn: initialBuyIn,

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
+  Card,
   PersistedRobotDecisionMetadata,
   PersistedRobotFallbackCause,
   PlayerAction,
+  ROBOT_PERSONALITIES,
+  RobotPersonality,
 } from 'poker-types';
 import { z } from 'zod';
 import {
@@ -40,6 +43,76 @@ export class RobotDecisionError extends Error {
   }
 }
 
+export type RobotPersonalityProfile = {
+  key: RobotPersonality;
+  label: string;
+  summary: string;
+  aggression: number;
+  bluff: number;
+  pressure: number;
+  raiseSizeBias: 'small' | 'medium' | 'large';
+};
+
+export const DEFAULT_ROBOT_PERSONALITY: RobotPersonality = 'balanced';
+
+const ROBOT_PERSONALITY_PROFILES: Record<
+  RobotPersonality,
+  RobotPersonalityProfile
+> = {
+  tight: {
+    key: 'tight',
+    label: 'Tight',
+    summary:
+      'Protect chips, avoid marginal bluffs, and pressure mostly with strong value.',
+    aggression: 28,
+    bluff: 12,
+    pressure: 25,
+    raiseSizeBias: 'small',
+  },
+  balanced: {
+    key: 'balanced',
+    label: 'Balanced',
+    summary:
+      'Mix value betting, pot control, and selective pressure without drifting too passive.',
+    aggression: 52,
+    bluff: 34,
+    pressure: 48,
+    raiseSizeBias: 'medium',
+  },
+  bully: {
+    key: 'bully',
+    label: 'Bully',
+    summary:
+      'Pressure capped ranges, lean toward initiative, and prefer forcing decisions when the risk is reasonable.',
+    aggression: 72,
+    bluff: 42,
+    pressure: 78,
+    raiseSizeBias: 'large',
+  },
+  chaotic: {
+    key: 'chaotic',
+    label: 'Chaotic',
+    summary:
+      'Take more swings and occasional thin aggression, but stay bounded by stack, street, and legal action limits.',
+    aggression: 66,
+    bluff: 58,
+    pressure: 64,
+    raiseSizeBias: 'medium',
+  },
+};
+
+export const resolveRobotPersonality = (
+  personality?: string | null,
+): RobotPersonality =>
+  ROBOT_PERSONALITIES.includes(personality as RobotPersonality)
+    ? (personality as RobotPersonality)
+    : DEFAULT_ROBOT_PERSONALITY;
+
+export const getRobotPersonalityProfile = (
+  personality?: string | null,
+): RobotPersonalityProfile =>
+  ROBOT_PERSONALITY_PROFILES[resolveRobotPersonality(personality)];
+
 export type RobotTurnContext = {
   schemaVersion: '1.0';
   roomId: string;
@@ -52,6 +125,16 @@ export type RobotTurnContext = {
     bettingRound: 'PRE_FLOP' | 'FLOP' | 'TURN' | 'RIVER' | 'SHOWDOWN';
     raiseFormat: 'increment_over_call';
   };
+  personality: {
+    key: RobotPersonality;
+    summary: string;
+    tuning: {
+      aggression: number;
+      bluff: number;
+      pressure: number;
+      raiseSizeBias: 'small' | 'medium' | 'large';
+    };
+  };
   hero: {
     playerId: string;
     name: string;
@@ -59,13 +142,13 @@ export type RobotTurnContext = {
     chips: number;
     currentBet: number;
     status: string;
-    holeCards: Array<{ rank: string; suit: string }>;
+    holeCards: Card[];
   };
   table: {
     pot: number;
     currentBet: number;
     minRaise: number;
-    communityCards: Array<{ rank: string; suit: string }>;
+    communityCards: Card[];
     playersPublic: Array<{
       playerId: string;
       name: string;
@@ -78,10 +161,7 @@ export type RobotTurnContext = {
       isBigBlind: boolean;
       lastAction: PlayerAction | null;
     }>;
-    revealedHoleCardsByPlayerId: Record<
-      string,
-      Array<{ rank: string; suit: string }>
-    >;
+    revealedHoleCardsByPlayerId: Record<string, Card[]>;
   };
   legalActions: {
     fold: { enabled: boolean };
@@ -153,6 +233,10 @@ TOOL LOOP POLICY
 
 ACTION POLICY
 - Prefer check over fold when check is legal.
+- Use the provided personality profile as a real tendency, not flavor text.
+- Higher aggression and pressure should bias toward initiative and legal raises in reasonable spots.
+- Higher bluff should allow more thin pressure or semi-bluffing, but never punt chips with clearly weak holdings.
+- Respect raiseSizeBias when choosing among legal raise sizes.
 - Raise amount must be integer and legal increment-over-call.
 `;
 

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -27,6 +27,10 @@ export type RobotActionValidation = {
   legalActions?: Record<string, unknown>;
 };
 
+type RobotFinishedStepSnapshot = {
+  text: string;
+};
+
 export type RobotDecisionFailureCode =
   | 'provider-error'
   | 'invalid-final-action'
@@ -318,6 +322,7 @@ export class RobotAgentService {
     for (let attempt = 1; attempt <= maxProviderAttempts; attempt += 1) {
       let finalizedAction: RobotActionDecision | null = null;
       let latestValidAction: RobotActionCandidate | null = null;
+      let latestFinishedStep: RobotFinishedStepSnapshot | null = null;
       let retryCount = 0;
 
       const agent = new ToolLoopAgent({
@@ -328,6 +333,11 @@ export class RobotAgentService {
         output: Output.object({
           schema: ACTION_OUTPUT_SCHEMA,
         }),
+        onFinish: (event: { text: string }) => {
+          latestFinishedStep = {
+            text: event.text,
+          };
+        },
         ...(apiMode === 'responses'
           ? {}
           : { temperature: Number(process.env.AI_ROBOT_TEMPERATURE || '0.3') }),
@@ -419,6 +429,15 @@ export class RobotAgentService {
               validationRetryCount: retryCount,
             },
           };
+        }
+
+        const recoveredProviderOutput = this.recoverProviderOutputFromFinishedStep(
+          latestFinishedStep,
+          params.validateAction,
+          retryCount,
+        );
+        if (recoveredProviderOutput) {
+          return recoveredProviderOutput;
         }
 
         if (attempt < maxProviderAttempts && isTransientRetryable) {
@@ -559,10 +578,151 @@ export class RobotAgentService {
     };
   }
 
+  private recoverProviderOutputFromFinishedStep(
+    latestFinishedStep: RobotFinishedStepSnapshot | null,
+    validateAction: (candidate: RobotActionCandidate) => RobotActionValidation,
+    retryCount: number,
+  ): RobotActionDecision | null {
+    const candidate = this.extractActionCandidateFromText(
+      latestFinishedStep?.text,
+    );
+    if (!candidate) {
+      return null;
+    }
+
+    const normalizedCandidate = this.normalizeAction(candidate);
+    const validation = validateAction(normalizedCandidate);
+    if (!validation.valid) {
+      return null;
+    }
+
+    return {
+      ...normalizedCandidate,
+      persistedDecision: {
+        source: 'provider-output',
+        summary: this.buildRecoveredProviderOutputSummary(retryCount),
+        validationRetryCount: retryCount,
+      },
+    };
+  }
+
+  private extractActionCandidateFromText(
+    text: string | undefined,
+  ): RobotActionCandidate | null {
+    if (!text?.trim()) {
+      return null;
+    }
+
+    for (const candidateText of this.extractJsonCandidateTexts(text)) {
+      try {
+        const parsed = JSON.parse(candidateText) as Record<string, unknown>;
+        if (typeof parsed.action !== 'string') {
+          continue;
+        }
+
+        const candidate = ACTION_OUTPUT_SCHEMA.safeParse({
+          action: parsed.action,
+          amount:
+            parsed.amount == null ? undefined : Number(parsed.amount),
+        });
+        if (candidate.success) {
+          return candidate.data.amount == null
+            ? { action: candidate.data.action }
+            : {
+                action: candidate.data.action,
+                amount: candidate.data.amount,
+              };
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  private extractJsonCandidateTexts(text: string): string[] {
+    const candidates = new Set<string>();
+    const trimmed = text.trim();
+
+    if (trimmed.length > 0) {
+      candidates.add(trimmed);
+    }
+
+    for (const match of text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)) {
+      const fencedBody = match[1]?.trim();
+      if (fencedBody) {
+        candidates.add(fencedBody);
+      }
+    }
+
+    const jsonObjects = this.extractBalancedJsonObjects(text);
+    for (const jsonObject of jsonObjects) {
+      candidates.add(jsonObject);
+    }
+
+    return [...candidates];
+  }
+
+  private extractBalancedJsonObjects(text: string): string[] {
+    const matches: string[] = [];
+
+    for (let start = 0; start < text.length; start += 1) {
+      if (text[start] !== '{') {
+        continue;
+      }
+
+      let depth = 0;
+      let inString = false;
+      let isEscaped = false;
+
+      for (let end = start; end < text.length; end += 1) {
+        const character = text[end];
+
+        if (isEscaped) {
+          isEscaped = false;
+          continue;
+        }
+
+        if (character === '\\') {
+          isEscaped = true;
+          continue;
+        }
+
+        if (character === '"') {
+          inString = !inString;
+          continue;
+        }
+
+        if (inString) {
+          continue;
+        }
+
+        if (character === '{') {
+          depth += 1;
+        } else if (character === '}') {
+          depth -= 1;
+          if (depth === 0) {
+            matches.push(text.slice(start, end + 1));
+            break;
+          }
+        }
+      }
+    }
+
+    return matches;
+  }
+
   private buildProviderOutputSummary(retryCount: number): string {
     return retryCount > 0
       ? `Provider final output accepted after ${retryCount} validation ${retryCount === 1 ? 'retry' : 'retries'}.`
       : 'Provider final output accepted.';
+  }
+
+  private buildRecoveredProviderOutputSummary(retryCount: number): string {
+    return retryCount > 0
+      ? `Recovered provider final output after SDK parse failure with ${retryCount} validation ${retryCount === 1 ? 'retry' : 'retries'}.`
+      : 'Recovered provider final output after SDK parse failure.';
   }
 
   private buildValidatedToolLoopSummary(

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -50,6 +50,8 @@ export type RobotPersonalityProfile = {
   aggression: number;
   bluff: number;
   pressure: number;
+  defend: number;
+  jam: number;
   raiseSizeBias: 'small' | 'medium' | 'large';
 };
 
@@ -67,6 +69,8 @@ const ROBOT_PERSONALITY_PROFILES: Record<
     aggression: 28,
     bluff: 12,
     pressure: 25,
+    defend: 20,
+    jam: 34,
     raiseSizeBias: 'small',
   },
   balanced: {
@@ -77,6 +81,8 @@ const ROBOT_PERSONALITY_PROFILES: Record<
     aggression: 52,
     bluff: 34,
     pressure: 48,
+    defend: 46,
+    jam: 52,
     raiseSizeBias: 'medium',
   },
   bully: {
@@ -87,6 +93,8 @@ const ROBOT_PERSONALITY_PROFILES: Record<
     aggression: 72,
     bluff: 42,
     pressure: 78,
+    defend: 58,
+    jam: 78,
     raiseSizeBias: 'large',
   },
   chaotic: {
@@ -97,6 +105,8 @@ const ROBOT_PERSONALITY_PROFILES: Record<
     aggression: 66,
     bluff: 58,
     pressure: 64,
+    defend: 54,
+    jam: 68,
     raiseSizeBias: 'medium',
   },
 };
@@ -132,6 +142,8 @@ export type RobotTurnContext = {
       aggression: number;
       bluff: number;
       pressure: number;
+      defend: number;
+      jam: number;
       raiseSizeBias: 'small' | 'medium' | 'large';
     };
   };
@@ -236,6 +248,8 @@ ACTION POLICY
 - Use the provided personality profile as a real tendency, not flavor text.
 - Higher aggression and pressure should bias toward initiative and legal raises in reasonable spots.
 - Higher bluff should allow more thin pressure or semi-bluffing, but never punt chips with clearly weak holdings.
+- Higher defend should continue more often when pot price, draw quality, or showdown value justify it.
+- Higher jam should prefer all-in over small raises in short-stack leverage spots.
 - Respect raiseSizeBias when choosing among legal raise sizes.
 - Raise amount must be integer and legal increment-over-call.
 `;

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -223,6 +223,8 @@ const ACTION_OUTPUT_SCHEMA = z.object({
   amount: z.number().optional(),
 });
 
+const DEFAULT_ROBOT_PROVIDER_TIMEOUT_MS = 45_000;
+
 const ROBOT_SYSTEM_PROMPT = `
 You are a poker robot player in a Texas Hold'em game.
 
@@ -259,9 +261,12 @@ export class RobotAgentService {
   private readonly logger = new Logger(RobotAgentService.name);
 
   private getProviderTimeoutMs(): number {
-    const parsed = Number(process.env.AI_ROBOT_PROVIDER_TIMEOUT_MS || '15000');
+    const parsed = Number(
+      process.env.AI_ROBOT_PROVIDER_TIMEOUT_MS ||
+        String(DEFAULT_ROBOT_PROVIDER_TIMEOUT_MS),
+    );
     if (!Number.isFinite(parsed) || parsed <= 0) {
-      return 15000;
+      return DEFAULT_ROBOT_PROVIDER_TIMEOUT_MS;
     }
 
     return Math.floor(parsed);

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -401,6 +401,25 @@ export class RobotAgentService {
           apiMode,
           normalizedError,
         );
+        const providerFinalizationError = new RobotDecisionError(
+          'provider-error',
+          normalizedError.message || 'Robot provider request failed',
+          retryCount,
+        );
+
+        if (latestValidAction) {
+          return {
+            ...latestValidAction,
+            persistedDecision: {
+              source: 'validated-tool-loop',
+              summary: this.buildValidatedToolLoopSummary(
+                providerFinalizationError,
+                retryCount,
+              ),
+              validationRetryCount: retryCount,
+            },
+          };
+        }
 
         if (attempt < maxProviderAttempts && isTransientRetryable) {
           this.logger.warn(

--- a/poker-server/src/game/robot-agent.service.ts
+++ b/poker-server/src/game/robot-agent.service.ts
@@ -258,6 +258,15 @@ ACTION POLICY
 export class RobotAgentService {
   private readonly logger = new Logger(RobotAgentService.name);
 
+  private getProviderTimeoutMs(): number {
+    const parsed = Number(process.env.AI_ROBOT_PROVIDER_TIMEOUT_MS || '15000');
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return 15000;
+    }
+
+    return Math.floor(parsed);
+  }
+
   isConfigured(): boolean {
     return Boolean(
       process.env.AI_ROBOT_API_KEY?.trim() &&
@@ -298,6 +307,7 @@ export class RobotAgentService {
     const apiMode = this.getApiMode();
     const model = this.createConfiguredModel('robot');
     const maxProviderAttempts = apiMode === 'responses' ? 3 : 1;
+    const providerTimeoutMs = this.getProviderTimeoutMs();
     let lastError: Error | null = null;
 
     for (let attempt = 1; attempt <= maxProviderAttempts; attempt += 1) {
@@ -352,8 +362,31 @@ export class RobotAgentService {
         | undefined;
 
       try {
-        result = await agent.generate({
-          prompt: this.buildTurnPrompt(params.context),
+        result = await new Promise<{
+          output?: RobotActionCandidate;
+        }>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            reject(
+              new RobotDecisionError(
+                'provider-error',
+                `Robot provider request timed out after ${providerTimeoutMs}ms`,
+                retryCount,
+              ),
+            );
+          }, providerTimeoutMs);
+
+          agent
+            .generate({
+              prompt: this.buildTurnPrompt(params.context),
+            })
+            .then((value) => {
+              clearTimeout(timeout);
+              resolve(value);
+            })
+            .catch((error) => {
+              clearTimeout(timeout);
+              reject(error);
+            });
         });
       } catch (error) {
         const normalizedError =

--- a/poker-server/test/unit/events.gateway.membership-race.spec.ts
+++ b/poker-server/test/unit/events.gateway.membership-race.spec.ts
@@ -258,6 +258,7 @@ describe('EventsGateway membership mutation serialization', () => {
 
     bettingService = {
       isBettingRoundComplete: jest.fn().mockReturnValue(false),
+      calculateMinRaise: jest.fn().mockReturnValue(10),
     };
 
     storageService = {
@@ -1082,6 +1083,65 @@ describe('EventsGateway membership mutation serialization', () => {
 
     expect(reconnectResult).toEqual({ success: true });
     expect((gateway as any).abandonedRoomSince.has('ROOM1')).toBe(false);
+  });
+
+  it('resumes a pending robot turn when a human reconnects into a room waiting on a robot', async () => {
+    roomState.players.push({
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 2,
+      }),
+      isRobot: true,
+    });
+    roomState.currentHand = {
+      handNumber: 4,
+      dealerPosition: 0,
+      smallBlindPosition: 1,
+      bigBlindPosition: 2,
+      currentPlayerTurn: 'p-robot',
+      bettingRound: 'FLOP',
+      communityCards: [],
+      pot: 30,
+      currentBet: 10,
+      lastRaiseSize: 10,
+      activePlayers: ['p-host', 'p-robot'],
+      roundActions: {},
+      sidePots: [],
+      potContributions: { 'p-host': 10, 'p-bob': 0, 'p-robot': 20 },
+      vpipPlayerIds: ['p-host', 'p-robot'],
+      revealedPlayerIds: [],
+    };
+
+    const emitPlayerTurnSpy = jest
+      .spyOn(gateway as any, 'emitPlayerTurn')
+      .mockImplementation(() => undefined);
+    const reconnectClient = createClient('socket-reconnect', {
+      cookieToken: 'token-bob',
+    });
+
+    const reconnectResult = await gateway.handleReconnect(reconnectClient as any, {
+      roomId: 'ROOM1',
+      playerName: 'Bob',
+      playerId: 'p-bob',
+    });
+
+    expect(reconnectResult).toEqual({ success: true });
+    expect(emitPlayerTurnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+        currentHand: expect.objectContaining({
+          handNumber: 4,
+          currentPlayerTurn: 'p-robot',
+        }),
+      }),
+      expect.objectContaining({
+        id: 'p-robot',
+        isRobot: true,
+      }),
+    );
   });
 
   it('auto-finalizes after run-count timeout resolution reaches a safe paused phase', async () => {

--- a/poker-server/test/unit/events.gateway.robot.spec.ts
+++ b/poker-server/test/unit/events.gateway.robot.spec.ts
@@ -492,6 +492,146 @@ describe('EventsGateway robot player controls', () => {
     );
   });
 
+  it('normalizes provider-backed minimum re-raises upward in contested pots', async () => {
+    bettingService.calculateMinRaise.mockReturnValue(10);
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string, amount?: number) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return amount === 10 || amount === 20
+            ? { valid: true }
+            : { valid: false, reason: 'Raise must use 10 or 20 chips' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        robotPersonality: 'chaotic',
+      }),
+      isRobot: true,
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: 'Q', suit: 'hearts' },
+      ],
+      currentBet: 0,
+    };
+    const villain = {
+      ...createPlayer({
+        id: 'p-villain',
+        socketId: '',
+        name: 'Robot 2',
+        status: 'connected',
+        position: 1,
+        robotPersonality: 'bully',
+      }),
+      isRobot: true,
+      currentBet: 10,
+      cards: [
+        { rank: 'K', suit: 'clubs' },
+        { rank: 'J', suit: 'clubs' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-villain',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, villain],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 9_1,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 55,
+        communityCards: [
+          { rank: 'Q', suit: 'diamonds' },
+          { rank: '7', suit: 'spades' },
+          { rank: '2', suit: 'clubs' },
+        ],
+        bettingRound: 'FLOP',
+        currentBet: 10,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-villain'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 0, 'p-villain': 10 },
+        vpipPlayerIds: ['p-robot', 'p-villain'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [
+        { ...robot, lastAction: 'raise', currentBet: 30, chips: 970 },
+        villain,
+      ],
+      currentHand: {
+        ...room.currentHand,
+        pot: 85,
+        currentBet: 30,
+      },
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(true);
+    robotAgentService.decideAction.mockResolvedValue({
+      action: 'raise',
+      amount: 10,
+      persistedDecision: {
+        source: 'provider-output',
+        summary: 'Provider final output accepted.',
+        validationRetryCount: 0,
+      },
+    });
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 91);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'raise',
+      20,
+      expect.objectContaining({
+        robotDecision: {
+          source: 'provider-output',
+          summary: 'Provider final output accepted.',
+          validationRetryCount: 0,
+        },
+      }),
+    );
+  });
+
   it('passes fallback robot decision metadata into persisted player actions when provider execution fails', async () => {
     const robot = {
       ...createPlayer({
@@ -720,6 +860,132 @@ describe('EventsGateway robot player controls', () => {
       'p-robot',
       'raise',
       20,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('uses a larger-than-minimum fallback raise when the pot is already contested', async () => {
+    bettingService.calculateMinRaise.mockReturnValue(10);
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string, amount?: number) => {
+        void room;
+        void playerId;
+        if (action === 'raise') {
+          return amount === 10 || amount === 20
+            ? { valid: true }
+            : { valid: false, reason: 'Raise must use 10 or 20 chips' };
+        }
+        return { valid: action !== 'fold' };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'bully',
+      }),
+      cards: [
+        { rank: 'Q', suit: 'clubs' },
+        { rank: '7', suit: 'hearts' },
+      ],
+      currentBet: 0,
+    };
+    const villain = {
+      ...createPlayer({
+        id: 'p-villain',
+        socketId: '',
+        name: 'Robot 2',
+        status: 'connected',
+        position: 1,
+      }),
+      isRobot: true,
+      currentBet: 0,
+      cards: [
+        { rank: 'A', suit: 'diamonds' },
+        { rank: 'K', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-villain',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, villain],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 11_1,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 45,
+        communityCards: [
+          { rank: 'Q', suit: 'diamonds' },
+          { rank: '7', suit: 'spades' },
+          { rank: '2', suit: 'clubs' },
+        ],
+        bettingRound: 'FLOP',
+        currentBet: 0,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-villain'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 20, 'p-villain': 25 },
+        vpipPlayerIds: ['p-robot', 'p-villain'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [
+        { ...robot, lastAction: 'raise', currentBet: 20, chips: 980 },
+        villain,
+      ],
+      currentHand: {
+        ...room.currentHand,
+        pot: 65,
+        currentBet: 20,
+      },
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 111);
+
+    const latestCall = bettingService.processAction.mock.calls.at(-1);
+    expect(latestCall?.[0]).toEqual(expect.objectContaining({ id: 'ROOM1' }));
+    expect(latestCall?.[1]).toBe('p-robot');
+    expect(latestCall?.[2]).toBe('raise');
+    expect(latestCall?.[3]).toBeGreaterThan(10);
+    expect(latestCall?.[3]).toBeLessThanOrEqual(30);
+    expect(latestCall?.[4]).toEqual(
       expect.objectContaining({
         robotDecision: expect.objectContaining({
           source: 'deterministic-fallback',

--- a/poker-server/test/unit/events.gateway.robot.spec.ts
+++ b/poker-server/test/unit/events.gateway.robot.spec.ts
@@ -1075,6 +1075,232 @@ describe('EventsGateway robot player controls', () => {
     );
   });
 
+  it('folds weak suited trash pre-flop instead of defending just because stacks are deep', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'balanced',
+      }),
+      cards: [
+        { rank: '7', suit: 'hearts' },
+        { rank: '2', suit: 'hearts' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 100,
+      cards: [
+        { rank: 'A', suit: 'clubs' },
+        { rank: 'K', suit: 'clubs' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 12_3,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 150,
+        communityCards: [],
+        bettingRound: 'PRE_FLOP',
+        currentBet: 100,
+        lastRaiseSize: 80,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 100 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'fold', status: 'folded' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 123);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'fold',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('folds strong but non-premium hands when facing extreme pressure', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'balanced',
+      }),
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: '10', suit: 'diamonds' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 700,
+      cards: [
+        { rank: 'K', suit: 'clubs' },
+        { rank: 'Q', suit: 'clubs' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 12_4,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 780,
+        communityCards: [],
+        bettingRound: 'PRE_FLOP',
+        currentBet: 700,
+        lastRaiseSize: 680,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 700 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'fold', status: 'folded' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 124);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'fold',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
   it('uses all-in instead of a min-raise for bully fallback with a strong short stack', async () => {
     bettingService.validateAction.mockImplementation(
       (room: any, playerId: string, action: string, amount?: number) => {
@@ -1181,6 +1407,119 @@ describe('EventsGateway robot player controls', () => {
       }),
       'p-robot',
       'all-in',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('lets chaotic fallback peel a very cheap weak-hand price occasionally', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'chaotic',
+      }),
+      cards: [
+        { rank: '7', suit: 'clubs' },
+        { rank: '2', suit: 'diamonds' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 20,
+      cards: [
+        { rank: 'A', suit: 'hearts' },
+        { rank: 'K', suit: 'hearts' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 13_1,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 100,
+        communityCards: [],
+        bettingRound: 'PRE_FLOP',
+        currentBet: 20,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 20 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'call' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 131);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'call',
       undefined,
       expect.objectContaining({
         robotDecision: expect.objectContaining({

--- a/poker-server/test/unit/events.gateway.robot.spec.ts
+++ b/poker-server/test/unit/events.gateway.robot.spec.ts
@@ -841,6 +841,240 @@ describe('EventsGateway robot player controls', () => {
     );
   });
 
+  it('uses balanced fallback to defend top pair against a large raise when the price is still reasonable', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'balanced',
+      }),
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: 'Q', suit: 'clubs' },
+      ],
+      currentBet: 20,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 200,
+      cards: [
+        { rank: 'K', suit: 'diamonds' },
+        { rank: 'J', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 12_1,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 420,
+        communityCards: [
+          { rank: 'A', suit: 'hearts' },
+          { rank: '9', suit: 'clubs' },
+          { rank: '4', suit: 'diamonds' },
+        ],
+        bettingRound: 'FLOP',
+        currentBet: 200,
+        lastRaiseSize: 120,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 20, 'p-human': 200 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'call' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 121);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'call',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('uses tight fallback to fold the same large-raise top-pair spot that balanced will defend', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'tight',
+      }),
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: 'Q', suit: 'clubs' },
+      ],
+      currentBet: 20,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 200,
+      cards: [
+        { rank: 'K', suit: 'diamonds' },
+        { rank: 'J', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 12_2,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 420,
+        communityCards: [
+          { rank: 'A', suit: 'hearts' },
+          { rank: '9', suit: 'clubs' },
+          { rank: '4', suit: 'diamonds' },
+        ],
+        bettingRound: 'FLOP',
+        currentBet: 200,
+        lastRaiseSize: 120,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 20, 'p-human': 200 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'fold', status: 'folded' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 122);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'fold',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
   it('uses all-in instead of a min-raise for bully fallback with a strong short stack', async () => {
     bettingService.validateAction.mockImplementation(
       (room: any, playerId: string, action: string, amount?: number) => {

--- a/poker-server/test/unit/events.gateway.robot.spec.ts
+++ b/poker-server/test/unit/events.gateway.robot.spec.ts
@@ -18,11 +18,13 @@ describe('EventsGateway robot player controls', () => {
     status: string;
     position: number;
     isRobot?: boolean;
+    robotPersonality?: string;
   }) => ({
     id: params.id,
     socketId: params.socketId,
     name: params.name,
     isRobot: params.isRobot ?? false,
+    robotPersonality: params.robotPersonality,
     chips: 1000,
     totalBuyIn: 1000,
     handsPlayedCount: 0,
@@ -363,6 +365,7 @@ describe('EventsGateway robot player controls', () => {
         name: 'Robot 1',
         status: 'connected',
         position: 0,
+        robotPersonality: 'chaotic',
       }),
       isRobot: true,
       cards: [
@@ -458,6 +461,15 @@ describe('EventsGateway robot player controls', () => {
 
     await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 9);
 
+    expect(robotAgentService.decideAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          personality: expect.objectContaining({
+            key: 'chaotic',
+          }),
+        }),
+      }),
+    );
     expect(bettingService.processAction).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'ROOM1',
@@ -593,6 +605,589 @@ describe('EventsGateway robot player controls', () => {
             'Deterministic fallback check because invalid final action after 2 validation retries.',
           validationRetryCount: 2,
         },
+      }),
+    );
+  });
+
+  it('uses bully fallback to apply pressure with a legal raise in unopened strong spots', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string, amount?: number) => {
+        void room;
+        void playerId;
+        if (action === 'raise') {
+          return amount === 20
+            ? { valid: true }
+            : { valid: false, reason: 'Raise must use 20 chips' };
+        }
+        return { valid: action !== 'fold' };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'bully',
+      }),
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: 'K', suit: 'hearts' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 10,
+      cards: [
+        { rank: '2', suit: 'clubs' },
+        { rank: '2', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 11,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 20,
+        communityCards: [],
+        bettingRound: 'PRE_FLOP',
+        currentBet: 10,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 10 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [
+        { ...robot, lastAction: 'raise', currentBet: 30, chips: 980 },
+        human,
+      ],
+      currentHand: {
+        ...room.currentHand,
+        pot: 40,
+        currentBet: 30,
+      },
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 11);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'raise',
+      20,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('uses tight fallback to check behind instead of forcing a raise in the same spot', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string, amount?: number) => {
+        void room;
+        void playerId;
+        if (action === 'raise') {
+          return amount === 20
+            ? { valid: true }
+            : { valid: false, reason: 'Raise must use 20 chips' };
+        }
+        return { valid: action !== 'fold' };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'tight',
+      }),
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: 'K', suit: 'hearts' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 10,
+      cards: [
+        { rank: '2', suit: 'clubs' },
+        { rank: '2', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 12,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 20,
+        communityCards: [],
+        bettingRound: 'PRE_FLOP',
+        currentBet: 10,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 10 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'check' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 12);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'check',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('uses all-in instead of a min-raise for bully fallback with a strong short stack', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string, amount?: number) => {
+        void room;
+        void playerId;
+        if (action === 'raise') {
+          return amount === 20
+            ? { valid: true }
+            : { valid: false, reason: 'Raise must use 20 chips' };
+        }
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'bully',
+      }),
+      chips: 60,
+      cards: [
+        { rank: 'A', suit: 'spades' },
+        { rank: 'A', suit: 'hearts' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 40,
+      cards: [
+        { rank: 'K', suit: 'clubs' },
+        { rank: 'Q', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 13,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 50,
+        communityCards: [],
+        bettingRound: 'PRE_FLOP',
+        currentBet: 40,
+        lastRaiseSize: 20,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 40 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'all-in', chips: 0 }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 13);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'all-in',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('treats an underpair as weak and folds instead of continuing like top pair', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'tight',
+      }),
+      cards: [
+        { rank: '2', suit: 'spades' },
+        { rank: '2', suit: 'clubs' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 20,
+      cards: [
+        { rank: 'A', suit: 'diamonds' },
+        { rank: 'K', suit: 'diamonds' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 14,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 30,
+        communityCards: [
+          { rank: 'K', suit: 'hearts' },
+          { rank: 'Q', suit: 'clubs' },
+          { rank: '9', suit: 'spades' },
+        ],
+        bettingRound: 'FLOP',
+        currentBet: 20,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 20 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'fold', status: 'folded' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 14);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'fold',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
+      }),
+    );
+  });
+
+  it('does not mistake a board-only four-flush for the robot drawing hand', async () => {
+    bettingService.validateAction.mockImplementation(
+      (room: any, playerId: string, action: string) => {
+        void room;
+        void playerId;
+        if (action === 'check') {
+          return { valid: false, reason: 'Cannot check facing a bet' };
+        }
+        if (action === 'raise') {
+          return { valid: false, reason: 'Raise unavailable' };
+        }
+        return { valid: true };
+      },
+    );
+
+    const robot = {
+      ...createPlayer({
+        id: 'p-robot',
+        socketId: '',
+        name: 'Robot 1',
+        status: 'connected',
+        position: 0,
+        isRobot: true,
+        robotPersonality: 'balanced',
+      }),
+      cards: [
+        { rank: 'Q', suit: 'clubs' },
+        { rank: 'J', suit: 'spades' },
+      ],
+      currentBet: 10,
+    };
+    const human = {
+      ...createPlayer({
+        id: 'p-human',
+        socketId: 'socket-human',
+        name: 'Human',
+        status: 'connected',
+        position: 1,
+      }),
+      currentBet: 20,
+      cards: [
+        { rank: 'A', suit: 'clubs' },
+        { rank: 'K', suit: 'clubs' },
+      ],
+    };
+    const room = {
+      id: 'ROOM1',
+      hostId: 'p-human',
+      config: {
+        startingChips: 1000,
+        smallBlind: 5,
+        bigBlind: 10,
+        maxPlayers: 10,
+        reconnectGracePeriod: 120000,
+        allowPlayerStreetReveal: true,
+      },
+      players: [robot, human],
+      gameState: 'IN_PROGRESS',
+      currentHand: {
+        handNumber: 15,
+        dealerPosition: 0,
+        smallBlindPosition: 1,
+        bigBlindPosition: 0,
+        currentPlayerTurn: 'p-robot',
+        pot: 30,
+        communityCards: [
+          { rank: 'A', suit: 'hearts' },
+          { rank: 'K', suit: 'hearts' },
+          { rank: '9', suit: 'hearts' },
+          { rank: '2', suit: 'hearts' },
+        ],
+        bettingRound: 'TURN',
+        currentBet: 20,
+        lastRaiseSize: 10,
+        activePlayers: ['p-robot', 'p-human'],
+        roundActions: {},
+        sidePots: [],
+        potContributions: { 'p-robot': 10, 'p-human': 20 },
+        vpipPlayerIds: ['p-robot', 'p-human'],
+        revealedPlayerIds: [],
+      },
+      readyPhase: null,
+      readyPlayerIds: [],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    };
+    const updatedRoom = {
+      ...room,
+      players: [{ ...robot, lastAction: 'fold', status: 'folded' }, human],
+    };
+
+    storageService.getRoom
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(room)
+      .mockResolvedValueOnce(updatedRoom);
+    robotAgentService.isConfigured.mockReturnValue(false);
+    jest
+      .spyOn(gateway as any, 'handleBettingRoundComplete')
+      .mockResolvedValue(undefined);
+
+    await (gateway as any).executeRobotTurn('ROOM1', 'p-robot', 15);
+
+    expect(bettingService.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ROOM1',
+      }),
+      'p-robot',
+      'fold',
+      undefined,
+      expect.objectContaining({
+        robotDecision: expect.objectContaining({
+          source: 'deterministic-fallback',
+          fallbackCause: 'provider-unavailable',
+        }),
       }),
     );
   });

--- a/poker-server/test/unit/game.service.spec.ts
+++ b/poker-server/test/unit/game.service.spec.ts
@@ -1148,10 +1148,12 @@ describe('GameService addPlayerToRoom', () => {
       ],
     });
     storageService.getRoom.mockResolvedValue(room);
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.51);
 
     const { player } = await gameService.addRobotToRoom('ROOM01', 'p-host');
 
     expect(player.isRobot).toBe(true);
+    expect(player.robotPersonality).toBe('bully');
     expect(player.socketId).toBe('');
     expect(player.status).toBe('waiting');
     expect(player.name).toContain('Robot');
@@ -1160,6 +1162,7 @@ describe('GameService addPlayerToRoom', () => {
     expect(storageService.persistRoom.mock.calls[0][1].events.map((event) => event.type)).toEqual([
       'PLAYER_JOINED',
     ]);
+    randomSpy.mockRestore();
   });
 
   it('rejects add robot for non-host player', async () => {

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -53,6 +53,17 @@ describe('RobotAgentService', () => {
       bettingRound: 'FLOP' as const,
       raiseFormat: 'increment_over_call' as const,
     },
+    personality: {
+      key: 'balanced' as const,
+      summary:
+        'Mix value betting, pot control, and selective pressure without drifting too passive.',
+      tuning: {
+        aggression: 52,
+        bluff: 34,
+        pressure: 48,
+        raiseSizeBias: 'medium' as const,
+      },
+    },
     hero: {
       playerId: 'robot-1',
       name: 'Robot 1',
@@ -153,11 +164,15 @@ describe('RobotAgentService', () => {
 
   it('uses structured output with the responses model and returns a validated final action', async () => {
     let capturedConfig: Record<string, unknown> | undefined;
+    let capturedPrompt: string | undefined;
     mockToolLoopAgent.mockImplementation((config) => {
       capturedConfig = config;
       return {
-        generate: jest.fn().mockResolvedValue({
-          output: { action: 'check' },
+        generate: jest.fn().mockImplementation(async ({ prompt }) => {
+          capturedPrompt = prompt;
+          return {
+            output: { action: 'check' },
+          };
         }),
       };
     });
@@ -195,6 +210,9 @@ describe('RobotAgentService', () => {
       (capturedConfig?.tools as Record<string, unknown>)?.done,
     ).toBeUndefined();
     expect(capturedConfig).not.toHaveProperty('temperature');
+    expect(capturedConfig?.instructions).toContain('personality profile');
+    expect(capturedPrompt).toContain('"key":"balanced"');
+    expect(capturedPrompt).toContain('"raiseSizeBias":"medium"');
   });
 
   it('applies responses compatibility fetch for non-Volcengine OpenAI-compatible gateways', () => {

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -164,6 +164,10 @@ describe('RobotAgentService', () => {
     process.env = originalEnv;
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('uses structured output with the responses model and returns a validated final action', async () => {
     let capturedConfig: Record<string, unknown> | undefined;
     let capturedPrompt: string | undefined;
@@ -310,5 +314,30 @@ describe('RobotAgentService', () => {
         validationRetryCount: 0,
       }),
     );
+  });
+
+  it('times out hung provider requests so fallback can recover the turn', async () => {
+    jest.useFakeTimers();
+    process.env.AI_ROBOT_PROVIDER_TIMEOUT_MS = '25';
+
+    mockToolLoopAgent.mockImplementation(() => ({
+      generate: jest.fn(() => new Promise(() => undefined)),
+    }));
+
+    const service = new RobotAgentService();
+    const decisionPromise = service.decideAction({
+      context: createContext(),
+      validateAction,
+    });
+    const rejectionExpectation = expect(decisionPromise).rejects.toEqual(
+      expect.objectContaining<Partial<RobotDecisionError>>({
+        name: 'RobotDecisionError',
+        code: 'provider-error',
+      }),
+    );
+
+    await jest.advanceTimersByTimeAsync(25);
+
+    await rejectionExpectation;
   });
 });

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -298,6 +298,65 @@ describe('RobotAgentService', () => {
     });
   });
 
+  it('recovers a legal provider action from the last finished step text when SDK final parsing fails before any tool action', async () => {
+    mockToolLoopAgent.mockImplementation((config) => ({
+      generate: jest.fn().mockImplementation(async () => {
+        await config.onFinish?.({
+          stepNumber: 0,
+          model: {
+            provider: 'robot-openai-responses',
+            modelId: 'doubao-seed-2-0-pro-260215',
+          },
+          functionId: undefined,
+          metadata: undefined,
+          experimental_context: undefined,
+          content: [
+            {
+              type: 'text',
+              text: '```json\n{"action":"call"}\n```',
+            },
+          ],
+          text: '```json\n{"action":"call"}\n```',
+          reasoningText: undefined,
+          reasoning: [],
+          files: [],
+          sources: [],
+          toolCalls: [],
+          staticToolCalls: [],
+          dynamicToolCalls: [],
+          toolResults: [],
+          staticToolResults: [],
+          dynamicToolResults: [],
+          finishReason: 'stop',
+          rawFinishReason: 'stop',
+          usage: {},
+          warnings: undefined,
+          request: {},
+          response: { messages: [] },
+          providerMetadata: undefined,
+          steps: [],
+          totalUsage: {},
+        });
+        throw new Error('Invalid JSON response');
+      }),
+    }));
+
+    const service = new RobotAgentService();
+    const result = await service.decideAction({
+      context: createContext(),
+      validateAction,
+    });
+
+    expect(result).toEqual({
+      action: 'call',
+      persistedDecision: {
+        source: 'provider-output',
+        summary: 'Recovered provider final output after SDK parse failure.',
+        validationRetryCount: 0,
+      },
+    });
+  });
+
   it('throws a normalized error when the provider never produces a legal action', async () => {
     mockToolLoopAgent.mockImplementation(() => ({
       generate: jest.fn().mockResolvedValue({

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -272,6 +272,32 @@ describe('RobotAgentService', () => {
     });
   });
 
+  it('uses the latest validated tool candidate when final output parsing fails after a legal tool action', async () => {
+    mockToolLoopAgent.mockImplementation((config) => ({
+      generate: jest.fn().mockImplementation(async () => {
+        const attemptAction = (config.tools as Record<string, any>).attempt_action;
+        await attemptAction.execute({ action: 'check' });
+        throw new Error('Invalid JSON response');
+      }),
+    }));
+
+    const service = new RobotAgentService();
+    const result = await service.decideAction({
+      context: createContext(),
+      validateAction,
+    });
+
+    expect(result).toEqual({
+      action: 'check',
+      persistedDecision: {
+        source: 'validated-tool-loop',
+        summary:
+          'Used latest validated tool-loop action after provider finalization failed.',
+        validationRetryCount: 0,
+      },
+    });
+  });
+
   it('throws a normalized error when the provider never produces a legal action', async () => {
     mockToolLoopAgent.mockImplementation(() => ({
       generate: jest.fn().mockResolvedValue({

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -61,6 +61,8 @@ describe('RobotAgentService', () => {
         aggression: 52,
         bluff: 34,
         pressure: 48,
+        defend: 46,
+        jam: 52,
         raiseSizeBias: 'medium' as const,
       },
     },
@@ -213,6 +215,8 @@ describe('RobotAgentService', () => {
     expect(capturedConfig?.instructions).toContain('personality profile');
     expect(capturedPrompt).toContain('"key":"balanced"');
     expect(capturedPrompt).toContain('"raiseSizeBias":"medium"');
+    expect(capturedPrompt).toContain('"defend":46');
+    expect(capturedPrompt).toContain('"jam":52');
   });
 
   it('applies responses compatibility fetch for non-Volcengine OpenAI-compatible gateways', () => {

--- a/poker-server/test/unit/robot-agent.service.spec.ts
+++ b/poker-server/test/unit/robot-agent.service.spec.ts
@@ -340,4 +340,40 @@ describe('RobotAgentService', () => {
 
     await rejectionExpectation;
   });
+
+  it('does not time out robot provider requests at 15 seconds when the default timeout is used', async () => {
+    jest.useFakeTimers();
+    delete process.env.AI_ROBOT_PROVIDER_TIMEOUT_MS;
+
+    mockToolLoopAgent.mockImplementation(() => ({
+      generate: jest.fn(() => new Promise(() => undefined)),
+    }));
+
+    const service = new RobotAgentService();
+    const decisionPromise = service.decideAction({
+      context: createContext(),
+      validateAction,
+    });
+
+    await jest.advanceTimersByTimeAsync(15_000);
+
+    let settled = false;
+    decisionPromise.catch(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    const rejectionExpectation = expect(decisionPromise).rejects.toEqual(
+      expect.objectContaining<Partial<RobotDecisionError>>({
+        name: 'RobotDecisionError',
+        code: 'provider-error',
+      }),
+    );
+
+    await jest.advanceTimersByTimeAsync(30_000);
+
+    await rejectionExpectation;
+  });
 });

--- a/poker-types/src/player.types.ts
+++ b/poker-types/src/player.types.ts
@@ -11,6 +11,15 @@ export type PlayerStatus =
 
 export type PlayerConnectionStatus = "connected" | "disconnected";
 
+export const ROBOT_PERSONALITIES = [
+  "tight",
+  "balanced",
+  "bully",
+  "chaotic",
+] as const;
+
+export type RobotPersonality = (typeof ROBOT_PERSONALITIES)[number];
+
 // Player actions during betting
 export type PlayerAction = "fold" | "check" | "call" | "raise" | "all-in";
 
@@ -19,6 +28,7 @@ export interface Player {
   socketId: string;
   name: string;
   isRobot?: boolean;
+  robotPersonality?: RobotPersonality;
   emoji?: string;
   chips: number;
   totalBuyIn: number;


### PR DESCRIPTION
## Summary
- assign each robot a stable random personality when it joins a room and pass normalized style tuning through the turn context and provider prompt
- replace passive-only fallback with bounded personality-aware fallback heuristics, including proactive pressure, big-raise defense, and short-stack shove logic
- add focused regression coverage for personality wiring, oversized-raise defense, proactive pressure, and shove/guardrail cases

## Linked Issues
- Closes #188
- Closes #193
- Canonical plan comments:
  - #188: https://github.com/grepug/Poker/issues/188#issuecomment-4281077882
  - #193: https://github.com/grepug/Poker/issues/193#issuecomment-4281350498

## Closeout Checklist
- [x] Re-read issues #188 and #193 and reconciled the shipped scope against both issue bodies and canonical plan comments.
- [x] Updated the canonical issue comments to implemented state before refreshing the PR.
- [x] Kept the work scoped to server-side robot behavior with no new host-facing UI.
- [x] Added focused regression coverage for personality assignment, prompt/context wiring, pressure defense, proactive pressure, and shove behavior.

## Checklist Audit
- `Player` now stores an optional `robotPersonality`, with random assignment for newly added robots and balanced fallback for older persisted rooms.
- `RobotTurnContext` now includes explicit personality tuning for aggression, bluff, pressure, defend, jam, and raise-size bias so provider and fallback behavior share the same contract.
- Deterministic fallback now covers proactive bully pressure, balanced defense versus large raises, tight fold contrast in the same spot, short-stack shoves, and existing guardrails such as underpairs and board-only four-flush boards.

## Validation
- `pnpm --dir poker-server exec jest test/unit/robot-agent.service.spec.ts --runInBand`
- `pnpm --dir poker-server exec jest test/unit/events.gateway.robot.spec.ts --runInBand`
- `pnpm --dir poker-server exec jest test/unit/game.service.spec.ts --runInBand`
- `pnpm --dir poker-server exec jest test/unit/robot-agent.service.spec.ts test/unit/events.gateway.robot.spec.ts test/unit/game.service.spec.ts --runInBand`
- `pnpm --dir poker-server build`
- Local PM2-backed frontend/backend instances were started for manual testing on `http://localhost:5225` and `http://localhost:3053`, but no user-confirmed gameplay QA result is recorded yet.
