### PR TITLE
feat: improve mobile table readability

### DIFF
--- a/poker-client/package.json
+++ b/poker-client/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run --config vitest.config.ts",
     "preview": "vite preview",
     "storybook": "node ./scripts/storybook-dev-fast.mjs",
+    "storybook:verify-tableboard-mobile": "node ./scripts/verify-tableboard-mobile-layout.mjs",
     "storybook:full": "STORYBOOK_FAST_MODE=0 storybook dev -p 6006",
     "build-storybook": "STORYBOOK_FAST_MODE=0 storybook build"
   },

--- a/poker-client/scripts/verify-tableboard-mobile-layout.mjs
+++ b/poker-client/scripts/verify-tableboard-mobile-layout.mjs
@@ -1,0 +1,159 @@
+import process from 'node:process';
+import { chromium } from '../../poker-server/node_modules/@playwright/test/index.mjs';
+
+const STORYBOOK_URL = process.env.STORYBOOK_URL ?? 'http://localhost:6007';
+const STORIES = [
+  {
+    label: 'eight-handed-mobile',
+    path: '/?path=/story/poker-tableboard--eight-handed-status-mobile-portrait-393-x-852',
+    minSideGapPx: 8,
+    maxSideGapPx: 10,
+    maxSideBiasedGapPx: 10,
+    minTopBottomGapPx: 7,
+    maxTopBottomGapPx: 9,
+    minSeatWidthPx: 68,
+  },
+  {
+    label: 'ten-handed-mobile',
+    path: '/?path=/story/poker-tableboard--ten-handed-status-mobile-portrait-393-x-852',
+    minSideGapPx: 7.5,
+    maxSideGapPx: 8.5,
+    maxSideBiasedGapPx: 13.5,
+    minTopBottomGapPx: 7.5,
+    maxTopBottomGapPx: 8.5,
+    minSeatWidthPx: 66,
+  },
+];
+
+const measureStory = async (page, story) => {
+  await page.goto(`${STORYBOOK_URL}${story.path}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  const frame = page.frameLocator('#storybook-preview-iframe');
+  await frame.locator('.felt-oval').waitFor({ timeout: 30000 });
+  await page.waitForTimeout(400);
+
+  return frame.locator('.felt-oval').evaluate((feltNode) => {
+    const feltRect = feltNode.getBoundingClientRect();
+    const seatRects = Array.from(
+      document.querySelectorAll('.seat-pod[data-testid^="player-seat-"]'),
+    ).map((seatNode) => {
+      const rect = seatNode.getBoundingClientRect();
+      const centerX = rect.left - feltRect.left + rect.width / 2;
+      const centerY = rect.top - feltRect.top + rect.height / 2;
+      const offsetX = centerX - feltRect.width / 2;
+      const offsetY = centerY - feltRect.height / 2;
+      const sideGap = offsetX < 0 ? rect.left - feltRect.left : feltRect.right - rect.right;
+      return {
+        id: seatNode.getAttribute('data-testid') ?? 'unknown-seat',
+        leftGap: rect.left - feltRect.left,
+        rightGap: feltRect.right - rect.right,
+        topGap: rect.top - feltRect.top,
+        bottomGap: feltRect.bottom - rect.bottom,
+        width: rect.width,
+        sideGap,
+        isSideBiased: Math.abs(offsetX) >= Math.abs(offsetY) * 0.45,
+      };
+    });
+
+    const sideGaps = seatRects.flatMap((seatRect) => [
+      seatRect.leftGap,
+      seatRect.rightGap,
+    ]);
+    const sideBiasedSeatGaps = seatRects
+      .filter((seatRect) => seatRect.isSideBiased)
+      .map((seatRect) => seatRect.sideGap);
+
+    return {
+      seatCount: seatRects.length,
+      minSideGapPx: Math.min(...sideGaps),
+      maxSideGapPx: Math.max(...sideGaps),
+      maxSideBiasedGapPx:
+        sideBiasedSeatGaps.length > 0
+          ? Math.max(...sideBiasedSeatGaps)
+          : 0,
+      minSeatWidthPx: Math.min(...seatRects.map((seatRect) => seatRect.width)),
+      topBottomGapPx: Math.min(
+        ...seatRects.flatMap((seatRect) => [seatRect.topGap, seatRect.bottomGap]),
+      ),
+      seats: seatRects.map((seatRect) => ({
+        id: seatRect.id,
+        leftGap: Number(seatRect.leftGap.toFixed(2)),
+        rightGap: Number(seatRect.rightGap.toFixed(2)),
+        sideGap: Number(seatRect.sideGap.toFixed(2)),
+        isSideBiased: seatRect.isSideBiased,
+        width: Number(seatRect.width.toFixed(2)),
+      })),
+    };
+  });
+};
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const page = await browser.newPage({
+    viewport: { width: 430, height: 932 },
+    deviceScaleFactor: 2,
+  });
+
+  for (const story of STORIES) {
+    const metrics = await measureStory(page, story);
+    console.log(
+      JSON.stringify(
+        {
+          label: story.label,
+          metrics: {
+            ...metrics,
+            minSideGapPx: Number(metrics.minSideGapPx.toFixed(2)),
+            maxSideGapPx: Number(metrics.maxSideGapPx.toFixed(2)),
+            maxSideBiasedGapPx: Number(metrics.maxSideBiasedGapPx.toFixed(2)),
+            minSeatWidthPx: Number(metrics.minSeatWidthPx.toFixed(2)),
+            topBottomGapPx: Number(metrics.topBottomGapPx.toFixed(2)),
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    if (metrics.seatCount < 8) {
+      throw new Error(
+        `[${story.label}] expected at least 8 seats but found ${metrics.seatCount}`,
+      );
+    }
+    if (metrics.minSideGapPx < story.minSideGapPx) {
+      throw new Error(
+        `[${story.label}] min side gap ${metrics.minSideGapPx.toFixed(2)} is below ${story.minSideGapPx}px`,
+      );
+    }
+    if (metrics.minSideGapPx > story.maxSideGapPx) {
+      throw new Error(
+        `[${story.label}] min side gap ${metrics.minSideGapPx.toFixed(2)} is above ${story.maxSideGapPx}px`,
+      );
+    }
+    if (metrics.maxSideBiasedGapPx > story.maxSideBiasedGapPx) {
+      throw new Error(
+        `[${story.label}] side-biased gap ${metrics.maxSideBiasedGapPx.toFixed(2)} is above ${story.maxSideBiasedGapPx}px`,
+      );
+    }
+    if (metrics.topBottomGapPx < story.minTopBottomGapPx) {
+      throw new Error(
+        `[${story.label}] top/bottom gap ${metrics.topBottomGapPx.toFixed(2)} is below ${story.minTopBottomGapPx}px`,
+      );
+    }
+    if (metrics.topBottomGapPx > story.maxTopBottomGapPx) {
+      throw new Error(
+        `[${story.label}] top/bottom gap ${metrics.topBottomGapPx.toFixed(2)} is above ${story.maxTopBottomGapPx}px`,
+      );
+    }
+    if (metrics.minSeatWidthPx < story.minSeatWidthPx) {
+      throw new Error(
+        `[${story.label}] min seat width ${metrics.minSeatWidthPx.toFixed(2)} is below ${story.minSeatWidthPx}px`,
+      );
+    }
+  }
+
+  await page.close();
+} finally {
+  await browser.close();
+}

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -656,11 +656,16 @@ const normalizeTrayAmountForDrop = ({
 };
 
 const SEAT_EDGE_PADDING_PX = 2;
+const MOBILE_SEAT_EDGE_PADDING_PX = 0;
 const FELT_BORDER_WIDTH_PX = 2;
 const SEAT_OUTER_TOP_OVERHANG_PX = 6;
 const SEAT_OUTER_SIDE_OVERHANG_PX = 2;
 const SEAT_OUTER_BOTTOM_OVERHANG_PX = 2;
 const SEAT_PERIMETER_CLEARANCE_PX = 10;
+const MOBILE_SEAT_OUTER_TOP_OVERHANG_PX = 2;
+const MOBILE_SEAT_OUTER_SIDE_OVERHANG_PX = 1;
+const MOBILE_SEAT_OUTER_BOTTOM_OVERHANG_PX = 1;
+const MOBILE_SEAT_PERIMETER_CLEARANCE_PX = 1;
 const SEAT_CENTER_EXCLUSION_PADDING_PX = 8;
 const SEAT_POD_WIDTH_TO_HEIGHT_RATIO = 1.26;
 
@@ -953,7 +958,10 @@ const getOrbitAnchors = ({
 
   const centerX = tableWidth / 2;
   const centerY = tableHeight / 2;
-  const tableInset = SEAT_EDGE_PADDING_PX + FELT_BORDER_WIDTH_PX;
+  const useMobileSeatPerimeter = tableWidth <= MOBILE_BALANCED_ORBIT_MAX_WIDTH_PX;
+  const tableInset =
+    (useMobileSeatPerimeter ? MOBILE_SEAT_EDGE_PADDING_PX : SEAT_EDGE_PADDING_PX) +
+    FELT_BORDER_WIDTH_PX;
   const halfTableWidth = Math.max(tableInset + 1, centerX - tableInset);
   const halfTableHeight = Math.max(tableInset + 1, centerY - tableInset);
   const cornerRadiusX = Math.max(
@@ -964,10 +972,22 @@ const getOrbitAnchors = ({
     0,
     Math.min(halfTableHeight, tableCornerRadiusY - tableInset),
   );
-  const leftExtent = seatWidth / 2 + SEAT_OUTER_SIDE_OVERHANG_PX + SEAT_PERIMETER_CLEARANCE_PX;
-  const rightExtent = seatWidth / 2 + SEAT_OUTER_SIDE_OVERHANG_PX + SEAT_PERIMETER_CLEARANCE_PX;
-  const topExtent = seatHeight / 2 + SEAT_OUTER_TOP_OVERHANG_PX + SEAT_PERIMETER_CLEARANCE_PX;
-  const bottomExtent = seatHeight / 2 + SEAT_OUTER_BOTTOM_OVERHANG_PX + SEAT_PERIMETER_CLEARANCE_PX;
+  const perimeterClearancePx = useMobileSeatPerimeter
+    ? MOBILE_SEAT_PERIMETER_CLEARANCE_PX
+    : SEAT_PERIMETER_CLEARANCE_PX;
+  const sideOverhangPx = useMobileSeatPerimeter
+    ? MOBILE_SEAT_OUTER_SIDE_OVERHANG_PX
+    : SEAT_OUTER_SIDE_OVERHANG_PX;
+  const topOverhangPx = useMobileSeatPerimeter
+    ? MOBILE_SEAT_OUTER_TOP_OVERHANG_PX
+    : SEAT_OUTER_TOP_OVERHANG_PX;
+  const bottomOverhangPx = useMobileSeatPerimeter
+    ? MOBILE_SEAT_OUTER_BOTTOM_OVERHANG_PX
+    : SEAT_OUTER_BOTTOM_OVERHANG_PX;
+  const leftExtent = seatWidth / 2 + sideOverhangPx + perimeterClearancePx;
+  const rightExtent = seatWidth / 2 + sideOverhangPx + perimeterClearancePx;
+  const topExtent = seatHeight / 2 + topOverhangPx + perimeterClearancePx;
+  const bottomExtent = seatHeight / 2 + bottomOverhangPx + perimeterClearancePx;
 
   if (
     leftExtent + rightExtent >= halfTableWidth * 2 ||

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/components/poker";
 import {
   resolveCardsFlyoutDesktopLayout,
+  shouldUseReducedMobileSeatPerimeter,
   shouldRenderCardsFlyoutInBoardStage,
 } from "@/components/poker/game-room-layout";
 import {
@@ -958,7 +959,10 @@ const getOrbitAnchors = ({
 
   const centerX = tableWidth / 2;
   const centerY = tableHeight / 2;
-  const useMobileSeatPerimeter = tableWidth <= MOBILE_BALANCED_ORBIT_MAX_WIDTH_PX;
+  const useMobileSeatPerimeter = shouldUseReducedMobileSeatPerimeter({
+    tableWidth,
+    totalSeats: safeTotal,
+  });
   const tableInset =
     (useMobileSeatPerimeter ? MOBILE_SEAT_EDGE_PADDING_PX : SEAT_EDGE_PADDING_PX) +
     FELT_BORDER_WIDTH_PX;

--- a/poker-client/src/components/GameRoom.tsx
+++ b/poker-client/src/components/GameRoom.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/components/poker";
 import {
   resolveCardsFlyoutDesktopLayout,
+  shouldUseLowSeatMidMobileSeatPerimeter,
   shouldUseReducedMobileSeatPerimeter,
   shouldRenderCardsFlyoutInBoardStage,
 } from "@/components/poker/game-room-layout";
@@ -963,6 +964,10 @@ const getOrbitAnchors = ({
     tableWidth,
     totalSeats: safeTotal,
   });
+  const useBalancedLowSeatMidMobilePerimeter = shouldUseLowSeatMidMobileSeatPerimeter({
+    tableWidth,
+    totalSeats: safeTotal,
+  });
   const tableInset =
     (useMobileSeatPerimeter ? MOBILE_SEAT_EDGE_PADDING_PX : SEAT_EDGE_PADDING_PX) +
     FELT_BORDER_WIDTH_PX;
@@ -983,7 +988,9 @@ const getOrbitAnchors = ({
     ? MOBILE_SEAT_OUTER_SIDE_OVERHANG_PX
     : SEAT_OUTER_SIDE_OVERHANG_PX;
   const topOverhangPx = useMobileSeatPerimeter
-    ? MOBILE_SEAT_OUTER_TOP_OVERHANG_PX
+    ? useBalancedLowSeatMidMobilePerimeter
+      ? MOBILE_SEAT_OUTER_BOTTOM_OVERHANG_PX
+      : MOBILE_SEAT_OUTER_TOP_OVERHANG_PX
     : SEAT_OUTER_TOP_OVERHANG_PX;
   const bottomOverhangPx = useMobileSeatPerimeter
     ? MOBILE_SEAT_OUTER_BOTTOM_OVERHANG_PX

--- a/poker-client/src/components/poker/game-room-layout.spec.ts
+++ b/poker-client/src/components/poker/game-room-layout.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveCardsFlyoutDesktopLayout,
+  shouldUseReducedMobileSeatPerimeter,
   shouldRenderCardsFlyoutInBoardStage,
 } from "./game-room-layout";
 
@@ -45,5 +46,28 @@ describe("game-room-layout", () => {
         showTurnActionDock: true,
       }),
     ).toBe(true);
+  });
+
+  it("limits reduced mobile seat perimeter to dense phone-width tables", () => {
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 355.56,
+        totalSeats: 10,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 500,
+        totalSeats: 10,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 355.56,
+        totalSeats: 6,
+      }),
+    ).toBe(false);
   });
 });

--- a/poker-client/src/components/poker/game-room-layout.spec.ts
+++ b/poker-client/src/components/poker/game-room-layout.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveCardsFlyoutDesktopLayout,
+  shouldUseLowSeatMidMobileSeatPerimeter,
   shouldUseReducedMobileSeatPerimeter,
   shouldRenderCardsFlyoutInBoardStage,
 } from "./game-room-layout";
@@ -101,6 +102,36 @@ describe("game-room-layout", () => {
       shouldUseReducedMobileSeatPerimeter({
         tableWidth: 768,
         totalSeats: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("isolates the low-seat mid-mobile perimeter mode", () => {
+    expect(
+      shouldUseLowSeatMidMobileSeatPerimeter({
+        tableWidth: 470,
+        totalSeats: 2,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseLowSeatMidMobileSeatPerimeter({
+        tableWidth: 430,
+        totalSeats: 2,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldUseLowSeatMidMobileSeatPerimeter({
+        tableWidth: 560,
+        totalSeats: 6,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseLowSeatMidMobileSeatPerimeter({
+        tableWidth: 560,
+        totalSeats: 8,
       }),
     ).toBe(false);
   });

--- a/poker-client/src/components/poker/game-room-layout.spec.ts
+++ b/poker-client/src/components/poker/game-room-layout.spec.ts
@@ -69,5 +69,39 @@ describe("game-room-layout", () => {
         totalSeats: 6,
       }),
     ).toBe(false);
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 470,
+        totalSeats: 2,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 390,
+        totalSeats: 4,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 560,
+        totalSeats: 6,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 500,
+        totalSeats: 2,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseReducedMobileSeatPerimeter({
+        tableWidth: 768,
+        totalSeats: 2,
+      }),
+    ).toBe(false);
   });
 });

--- a/poker-client/src/components/poker/game-room-layout.ts
+++ b/poker-client/src/components/poker/game-room-layout.ts
@@ -4,6 +4,14 @@ type ResolveCardsFlyoutDesktopLayoutArgs = {
   showTurnActionDock: boolean;
 };
 
+type ReducedMobileSeatPerimeterArgs = {
+  tableWidth: number;
+  totalSeats: number;
+};
+
+const DENSE_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX = 430;
+const DENSE_MOBILE_SEAT_PERIMETER_MIN_SEAT_COUNT = 8;
+
 export const resolveCardsFlyoutDesktopLayout = ({
   shouldRenderCardsFlyout,
   isDesktopSideDock,
@@ -29,3 +37,11 @@ export const shouldRenderCardsFlyoutInBoardStage = ({
   isDesktopSideDock,
 }: ResolveCardsFlyoutDesktopLayoutArgs): boolean =>
   shouldRenderCardsFlyout && !isDesktopSideDock;
+
+export const shouldUseReducedMobileSeatPerimeter = ({
+  tableWidth,
+  totalSeats,
+}: ReducedMobileSeatPerimeterArgs): boolean =>
+  tableWidth > 0 &&
+  totalSeats >= DENSE_MOBILE_SEAT_PERIMETER_MIN_SEAT_COUNT &&
+  tableWidth <= DENSE_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX;

--- a/poker-client/src/components/poker/game-room-layout.ts
+++ b/poker-client/src/components/poker/game-room-layout.ts
@@ -11,6 +11,9 @@ type ReducedMobileSeatPerimeterArgs = {
 
 const DENSE_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX = 430;
 const DENSE_MOBILE_SEAT_PERIMETER_MIN_SEAT_COUNT = 8;
+const LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX = 560;
+const LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MIN_WIDTH_PX = 430;
+const LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_SEAT_COUNT = 6;
 
 export const resolveCardsFlyoutDesktopLayout = ({
   shouldRenderCardsFlyout,
@@ -43,5 +46,8 @@ export const shouldUseReducedMobileSeatPerimeter = ({
   totalSeats,
 }: ReducedMobileSeatPerimeterArgs): boolean =>
   tableWidth > 0 &&
-  totalSeats >= DENSE_MOBILE_SEAT_PERIMETER_MIN_SEAT_COUNT &&
-  tableWidth <= DENSE_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX;
+  ((totalSeats >= DENSE_MOBILE_SEAT_PERIMETER_MIN_SEAT_COUNT &&
+    tableWidth <= DENSE_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX) ||
+    (totalSeats <= LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_SEAT_COUNT &&
+      tableWidth > LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MIN_WIDTH_PX &&
+      tableWidth <= LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX));

--- a/poker-client/src/components/poker/game-room-layout.ts
+++ b/poker-client/src/components/poker/game-room-layout.ts
@@ -15,6 +15,15 @@ const LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX = 560;
 const LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MIN_WIDTH_PX = 430;
 const LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_SEAT_COUNT = 6;
 
+export const shouldUseLowSeatMidMobileSeatPerimeter = ({
+  tableWidth,
+  totalSeats,
+}: ReducedMobileSeatPerimeterArgs): boolean =>
+  tableWidth > LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MIN_WIDTH_PX &&
+  tableWidth <= LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX &&
+  totalSeats > 0 &&
+  totalSeats <= LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_SEAT_COUNT;
+
 export const resolveCardsFlyoutDesktopLayout = ({
   shouldRenderCardsFlyout,
   isDesktopSideDock,
@@ -48,6 +57,7 @@ export const shouldUseReducedMobileSeatPerimeter = ({
   tableWidth > 0 &&
   ((totalSeats >= DENSE_MOBILE_SEAT_PERIMETER_MIN_SEAT_COUNT &&
     tableWidth <= DENSE_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX) ||
-    (totalSeats <= LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_SEAT_COUNT &&
-      tableWidth > LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MIN_WIDTH_PX &&
-      tableWidth <= LOW_SEAT_MID_MOBILE_SEAT_PERIMETER_MAX_WIDTH_PX));
+    shouldUseLowSeatMidMobileSeatPerimeter({
+      tableWidth,
+      totalSeats,
+    }));

--- a/poker-client/src/components/poker/seat-orbit-layout.spec.ts
+++ b/poker-client/src/components/poker/seat-orbit-layout.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEqualPerimeterRoundedRailPoints,
+  buildEqualPerimeterRoundedRailPercentAnchors,
+  buildEqualPerimeterRoundedRailPercentAnchorsForFrame,
+} from "@/components/poker/seat-orbit-layout";
+
+const distanceBetween = (
+  first: { x: number; y: number },
+  second: { x: number; y: number },
+) => Math.hypot(first.x - second.x, first.y - second.y);
+
+describe("buildEqualPerimeterRoundedRailPoints", () => {
+  it("pushes corner-adjacent dense seats outward while keeping the orbit symmetric", () => {
+    const roundedRailPoints = buildEqualPerimeterRoundedRailPoints({
+      totalSeats: 13,
+      halfWidth: 41,
+      halfHeight: 36.9,
+    });
+
+    expect(roundedRailPoints).not.toBeNull();
+
+    const topGap = distanceBetween(
+      roundedRailPoints?.[6] ?? { x: 0, y: 0 },
+      roundedRailPoints?.[7] ?? { x: 0, y: 0 },
+    );
+    const leftCornerGap = distanceBetween(
+      roundedRailPoints?.[5] ?? { x: 0, y: 0 },
+      roundedRailPoints?.[6] ?? { x: 0, y: 0 },
+    );
+    const sideGap = distanceBetween(
+      roundedRailPoints?.[3] ?? { x: 0, y: 0 },
+      roundedRailPoints?.[4] ?? { x: 0, y: 0 },
+    );
+
+    expect(Math.abs((roundedRailPoints?.[0]?.x ?? 1))).toBeLessThan(0.01);
+    expect((roundedRailPoints?.[0]?.y ?? 0)).toBeGreaterThan(36.8);
+    expect(Math.abs((roundedRailPoints?.[5]?.x ?? 0))).toBeGreaterThan(33);
+    expect(Math.abs((roundedRailPoints?.[8]?.x ?? 0))).toBeGreaterThan(33);
+    expect(topGap).toBeGreaterThan(22);
+    expect(leftCornerGap).toBeGreaterThan(22);
+    expect(sideGap).toBeGreaterThan(22);
+    expect(
+      Math.abs((roundedRailPoints?.[6]?.x ?? 0) + (roundedRailPoints?.[7]?.x ?? 0)),
+    ).toBeLessThan(0.01);
+    expect(
+      Math.abs((roundedRailPoints?.[3]?.x ?? 0) + (roundedRailPoints?.[10]?.x ?? 0)),
+    ).toBeLessThan(0.3);
+    expect(
+      Math.abs((roundedRailPoints?.[3]?.y ?? 0) - (roundedRailPoints?.[10]?.y ?? 0)),
+    ).toBeLessThan(0.01);
+  });
+});
+
+describe("buildEqualPerimeterRoundedRailPercentAnchorsForFrame", () => {
+  it("keeps dense mobile rail anchors more even after a non-square felt scales them", () => {
+    const feltWidthPx = 355.56;
+    const feltHeightPx = 496;
+    const legacyAnchors = buildEqualPerimeterRoundedRailPercentAnchors({
+      totalSeats: 13,
+      halfWidthPercent: 41,
+      halfHeightPercent: 36.9,
+      centerYPercent: 50,
+    });
+    const frameAwareAnchors = buildEqualPerimeterRoundedRailPercentAnchorsForFrame({
+      totalSeats: 13,
+      feltWidthPx,
+      feltHeightPx,
+      halfWidthPercent: 41,
+      halfHeightPercent: 36.9,
+      centerYPercent: 50,
+    });
+
+    expect(legacyAnchors).not.toBeNull();
+    expect(frameAwareAnchors).not.toBeNull();
+
+    const toPixelPoints = (anchors: Array<{ left: string; top: string }>) =>
+      anchors.map((anchor) => ({
+        x: (Number.parseFloat(anchor.left) / 100) * feltWidthPx,
+        y: (Number.parseFloat(anchor.top) / 100) * feltHeightPx,
+      }));
+
+    const buildGapSpread = (points: Array<{ x: number; y: number }>) => {
+      const gaps = points.map((point, index) =>
+        distanceBetween(point, points[(index + 1) % points.length] ?? point),
+      );
+      return Math.max(...gaps) - Math.min(...gaps);
+    };
+
+    const legacyGapSpread = buildGapSpread(toPixelPoints(legacyAnchors ?? []));
+    const frameAwareGapSpread = buildGapSpread(
+      toPixelPoints(frameAwareAnchors ?? []),
+    );
+
+    expect(frameAwareGapSpread).toBeLessThan(legacyGapSpread - 15);
+    expect(frameAwareGapSpread).toBeLessThan(12);
+  });
+});

--- a/poker-client/src/components/poker/seat-orbit-layout.ts
+++ b/poker-client/src/components/poker/seat-orbit-layout.ts
@@ -5,49 +5,174 @@ type OrbitPoint = {
 
 const DEFAULT_SAMPLE_COUNT = 960;
 const DEFAULT_START_ANGLE = Math.PI / 2;
+const DEFAULT_VISUAL_BALANCE_ORIENTATION_WEIGHT = 0.45;
+const DEFAULT_VISUAL_BALANCE_ORIENTATION_EXPONENT = 1.4;
+const DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_X_RATIO = 0.34;
+const DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_Y_RATIO = 0.3;
 
-const buildCumulativeLengths = (points: OrbitPoint[]) => {
+const buildCumulativeLengths = (
+  points: OrbitPoint[],
+  resolveSegmentWeight: (segment: {
+    startPoint: OrbitPoint;
+    endPoint: OrbitPoint;
+    midpoint: OrbitPoint;
+    dx: number;
+    dy: number;
+    length: number;
+  }) => number = () => 1,
+) => {
   const cumulativeLengths = [0];
 
   for (let index = 1; index < points.length; index += 1) {
     const previousPoint = points[index - 1];
     const currentPoint = points[index];
+    const dx = currentPoint.x - previousPoint.x;
+    const dy = currentPoint.y - previousPoint.y;
+    const length = Math.hypot(dx, dy);
     cumulativeLengths[index] =
       cumulativeLengths[index - 1] +
-      Math.hypot(currentPoint.x - previousPoint.x, currentPoint.y - previousPoint.y);
+      length *
+        resolveSegmentWeight({
+          startPoint: previousPoint,
+          endPoint: currentPoint,
+          midpoint: {
+            x: (previousPoint.x + currentPoint.x) / 2,
+            y: (previousPoint.y + currentPoint.y) / 2,
+          },
+          dx,
+          dy,
+          length,
+        });
   }
 
   return cumulativeLengths;
 };
 
-export const buildEqualArcEllipsePoints = ({
-  totalSeats,
+const buildSampledEllipsePoints = ({
   radiusX,
   radiusY,
-  sampleCount = DEFAULT_SAMPLE_COUNT,
-  startAngle = DEFAULT_START_ANGLE,
+  sampleCount,
+  startAngle,
 }: {
-  totalSeats: number;
   radiusX: number;
   radiusY: number;
-  sampleCount?: number;
-  startAngle?: number;
-}): OrbitPoint[] | null => {
-  if (totalSeats <= 0 || radiusX <= 0 || radiusY <= 0 || sampleCount <= 0) {
-    return null;
-  }
-
-  const safeSampleCount = Math.max(180, Math.floor(sampleCount));
-  const safeSeatCount = Math.floor(totalSeats);
-  const sampledPoints = Array.from({ length: safeSampleCount + 1 }, (_, index) => {
-    const angle = startAngle + (index / safeSampleCount) * Math.PI * 2;
+  sampleCount: number;
+  startAngle: number;
+}) =>
+  Array.from({ length: sampleCount + 1 }, (_, index) => {
+    const angle = startAngle + (index / sampleCount) * Math.PI * 2;
     return {
       x: Math.cos(angle) * radiusX,
       y: Math.sin(angle) * radiusY,
     };
   });
 
-  const cumulativeLengths = buildCumulativeLengths(sampledPoints);
+const buildSampledRoundedRailPoints = ({
+  halfWidth,
+  halfHeight,
+  cornerRadiusX,
+  cornerRadiusY,
+  straightSampleCount,
+  arcSampleCount,
+}: {
+  halfWidth: number;
+  halfHeight: number;
+  cornerRadiusX: number;
+  cornerRadiusY: number;
+  straightSampleCount: number;
+  arcSampleCount: number;
+}) => {
+  const innerHalfWidth = Math.max(0, halfWidth - cornerRadiusX);
+  const innerHalfHeight = Math.max(0, halfHeight - cornerRadiusY);
+  const points: OrbitPoint[] = [];
+  const appendPoint = (point: OrbitPoint) => {
+    points.push(point);
+  };
+
+  for (let index = 0; index <= straightSampleCount; index += 1) {
+    const progress = index / straightSampleCount;
+    appendPoint({
+      x: -innerHalfWidth * progress,
+      y: halfHeight,
+    });
+  }
+
+  for (let index = 1; index <= arcSampleCount; index += 1) {
+    const angle = Math.PI / 2 + (index / arcSampleCount) * (Math.PI / 2);
+    appendPoint({
+      x: -innerHalfWidth + Math.cos(angle) * cornerRadiusX,
+      y: innerHalfHeight + Math.sin(angle) * cornerRadiusY,
+    });
+  }
+
+  for (let index = 1; index <= straightSampleCount; index += 1) {
+    const progress = index / straightSampleCount;
+    appendPoint({
+      x: -halfWidth,
+      y: innerHalfHeight - progress * innerHalfHeight * 2,
+    });
+  }
+
+  for (let index = 1; index <= arcSampleCount; index += 1) {
+    const angle = Math.PI + (index / arcSampleCount) * (Math.PI / 2);
+    appendPoint({
+      x: -innerHalfWidth + Math.cos(angle) * cornerRadiusX,
+      y: -innerHalfHeight + Math.sin(angle) * cornerRadiusY,
+    });
+  }
+
+  for (let index = 1; index <= straightSampleCount * 2; index += 1) {
+    const progress = index / (straightSampleCount * 2);
+    appendPoint({
+      x: -innerHalfWidth + progress * innerHalfWidth * 2,
+      y: -halfHeight,
+    });
+  }
+
+  for (let index = 1; index <= arcSampleCount; index += 1) {
+    const angle = -Math.PI / 2 + (index / arcSampleCount) * (Math.PI / 2);
+    appendPoint({
+      x: innerHalfWidth + Math.cos(angle) * cornerRadiusX,
+      y: -innerHalfHeight + Math.sin(angle) * cornerRadiusY,
+    });
+  }
+
+  for (let index = 1; index <= straightSampleCount; index += 1) {
+    const progress = index / straightSampleCount;
+    appendPoint({
+      x: halfWidth,
+      y: -innerHalfHeight + progress * innerHalfHeight * 2,
+    });
+  }
+
+  for (let index = 1; index <= arcSampleCount; index += 1) {
+    const angle = index / arcSampleCount * (Math.PI / 2);
+    appendPoint({
+      x: innerHalfWidth + Math.cos(angle) * cornerRadiusX,
+      y: innerHalfHeight + Math.sin(angle) * cornerRadiusY,
+    });
+  }
+
+  for (let index = 1; index <= straightSampleCount; index += 1) {
+    const progress = index / straightSampleCount;
+    appendPoint({
+      x: innerHalfWidth * (1 - progress),
+      y: halfHeight,
+    });
+  }
+
+  return points;
+};
+
+const buildPointsFromCumulativeLengths = ({
+  totalSeats,
+  sampledPoints,
+  cumulativeLengths,
+}: {
+  totalSeats: number;
+  sampledPoints: OrbitPoint[];
+  cumulativeLengths: number[];
+}) => {
   const totalLength = cumulativeLengths[cumulativeLengths.length - 1] ?? 0;
   if (totalLength <= 0) {
     return null;
@@ -56,8 +181,8 @@ export const buildEqualArcEllipsePoints = ({
   const points: OrbitPoint[] = [];
   let searchIndex = 0;
 
-  for (let seatIndex = 0; seatIndex < safeSeatCount; seatIndex += 1) {
-    const targetLength = (totalLength * seatIndex) / safeSeatCount;
+  for (let seatIndex = 0; seatIndex < totalSeats; seatIndex += 1) {
+    const targetLength = (totalLength * seatIndex) / totalSeats;
 
     while (
       searchIndex < cumulativeLengths.length - 2 &&
@@ -80,7 +205,144 @@ export const buildEqualArcEllipsePoints = ({
     });
   }
 
-  return points.length === safeSeatCount ? points : null;
+  return points.length === totalSeats ? points : null;
+};
+
+export const buildEqualArcEllipsePoints = ({
+  totalSeats,
+  radiusX,
+  radiusY,
+  sampleCount = DEFAULT_SAMPLE_COUNT,
+  startAngle = DEFAULT_START_ANGLE,
+}: {
+  totalSeats: number;
+  radiusX: number;
+  radiusY: number;
+  sampleCount?: number;
+  startAngle?: number;
+}): OrbitPoint[] | null => {
+  if (totalSeats <= 0 || radiusX <= 0 || radiusY <= 0 || sampleCount <= 0) {
+    return null;
+  }
+
+  const safeSampleCount = Math.max(180, Math.floor(sampleCount));
+  const safeSeatCount = Math.floor(totalSeats);
+  const sampledPoints = buildSampledEllipsePoints({
+    radiusX,
+    radiusY,
+    sampleCount: safeSampleCount,
+    startAngle,
+  });
+  const cumulativeLengths = buildCumulativeLengths(sampledPoints);
+  return buildPointsFromCumulativeLengths({
+    totalSeats: safeSeatCount,
+    sampledPoints,
+    cumulativeLengths,
+  });
+};
+
+export const buildVisualBalancedEllipsePoints = ({
+  totalSeats,
+  radiusX,
+  radiusY,
+  sampleCount = DEFAULT_SAMPLE_COUNT,
+  startAngle = DEFAULT_START_ANGLE,
+  orientationWeight = DEFAULT_VISUAL_BALANCE_ORIENTATION_WEIGHT,
+  orientationExponent = DEFAULT_VISUAL_BALANCE_ORIENTATION_EXPONENT,
+}: {
+  totalSeats: number;
+  radiusX: number;
+  radiusY: number;
+  sampleCount?: number;
+  startAngle?: number;
+  orientationWeight?: number;
+  orientationExponent?: number;
+}): OrbitPoint[] | null => {
+  if (
+    totalSeats <= 0 ||
+    radiusX <= 0 ||
+    radiusY <= 0 ||
+    sampleCount <= 0 ||
+    orientationWeight < 0 ||
+    orientationExponent <= 0
+  ) {
+    return null;
+  }
+
+  const safeSampleCount = Math.max(180, Math.floor(sampleCount));
+  const safeSeatCount = Math.floor(totalSeats);
+  const sampledPoints = buildSampledEllipsePoints({
+    radiusX,
+    radiusY,
+    sampleCount: safeSampleCount,
+    startAngle,
+  });
+  const cumulativeLengths = buildCumulativeLengths(
+    sampledPoints,
+    ({ dx, length }) => {
+      const horizontalness = length > 0 ? Math.abs(dx) / length : 0;
+      return (
+        1 +
+        orientationWeight *
+          (1 - Math.pow(horizontalness, orientationExponent))
+      );
+    },
+  );
+
+  return buildPointsFromCumulativeLengths({
+    totalSeats: safeSeatCount,
+    sampledPoints,
+    cumulativeLengths,
+  });
+};
+
+export const buildEqualPerimeterRoundedRailPoints = ({
+  totalSeats,
+  halfWidth,
+  halfHeight,
+  cornerRadiusX = halfWidth * DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_X_RATIO,
+  cornerRadiusY = halfHeight * DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_Y_RATIO,
+  sampleCount = DEFAULT_SAMPLE_COUNT,
+}: {
+  totalSeats: number;
+  halfWidth: number;
+  halfHeight: number;
+  cornerRadiusX?: number;
+  cornerRadiusY?: number;
+  sampleCount?: number;
+}): OrbitPoint[] | null => {
+  if (
+    totalSeats <= 0 ||
+    halfWidth <= 0 ||
+    halfHeight <= 0 ||
+    sampleCount <= 0 ||
+    cornerRadiusX < 0 ||
+    cornerRadiusY < 0
+  ) {
+    return null;
+  }
+
+  const safeSeatCount = Math.floor(totalSeats);
+  const safeSampleCount = Math.max(180, Math.floor(sampleCount));
+  const straightSampleCount = Math.max(32, Math.floor(safeSampleCount / 8));
+  const arcSampleCount = Math.max(24, Math.floor(safeSampleCount / 10));
+  const safeCornerRadiusX = Math.min(halfWidth, cornerRadiusX);
+  const safeCornerRadiusY = Math.min(halfHeight, cornerRadiusY);
+  const sampledPoints = buildSampledRoundedRailPoints({
+    halfWidth,
+    halfHeight,
+    cornerRadiusX: safeCornerRadiusX,
+    cornerRadiusY: safeCornerRadiusY,
+    straightSampleCount,
+    arcSampleCount,
+  });
+  const cumulativeLengths = buildCumulativeLengths(sampledPoints);
+
+  return buildPointsFromCumulativeLengths({
+    totalSeats: safeSeatCount,
+    sampledPoints,
+    cumulativeLengths,
+  });
 };
 
 export const buildEqualArcEllipsePercentAnchors = ({
@@ -114,5 +376,127 @@ export const buildEqualArcEllipsePercentAnchors = ({
   return points.map((point) => ({
     left: `${(centerXPercent + point.x).toFixed(2)}%`,
     top: `${(centerYPercent + point.y).toFixed(2)}%`,
+  }));
+};
+
+export const buildVisualBalancedEllipsePercentAnchors = ({
+  totalSeats,
+  radiusXPercent,
+  radiusYPercent,
+  centerXPercent = 50,
+  centerYPercent = 50,
+  sampleCount = DEFAULT_SAMPLE_COUNT,
+  startAngle = DEFAULT_START_ANGLE,
+  orientationWeight = DEFAULT_VISUAL_BALANCE_ORIENTATION_WEIGHT,
+  orientationExponent = DEFAULT_VISUAL_BALANCE_ORIENTATION_EXPONENT,
+}: {
+  totalSeats: number;
+  radiusXPercent: number;
+  radiusYPercent: number;
+  centerXPercent?: number;
+  centerYPercent?: number;
+  sampleCount?: number;
+  startAngle?: number;
+  orientationWeight?: number;
+  orientationExponent?: number;
+}) => {
+  const points = buildVisualBalancedEllipsePoints({
+    totalSeats,
+    radiusX: radiusXPercent,
+    radiusY: radiusYPercent,
+    sampleCount,
+    startAngle,
+    orientationWeight,
+    orientationExponent,
+  });
+  if (!points) {
+    return null;
+  }
+
+  return points.map((point) => ({
+    left: `${(centerXPercent + point.x).toFixed(2)}%`,
+    top: `${(centerYPercent + point.y).toFixed(2)}%`,
+  }));
+};
+
+export const buildEqualPerimeterRoundedRailPercentAnchors = ({
+  totalSeats,
+  halfWidthPercent,
+  halfHeightPercent,
+  centerXPercent = 50,
+  centerYPercent = 50,
+  cornerRadiusXPercent = halfWidthPercent * DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_X_RATIO,
+  cornerRadiusYPercent = halfHeightPercent * DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_Y_RATIO,
+  sampleCount = DEFAULT_SAMPLE_COUNT,
+}: {
+  totalSeats: number;
+  halfWidthPercent: number;
+  halfHeightPercent: number;
+  centerXPercent?: number;
+  centerYPercent?: number;
+  cornerRadiusXPercent?: number;
+  cornerRadiusYPercent?: number;
+  sampleCount?: number;
+}) => {
+  const points = buildEqualPerimeterRoundedRailPoints({
+    totalSeats,
+    halfWidth: halfWidthPercent,
+    halfHeight: halfHeightPercent,
+    cornerRadiusX: cornerRadiusXPercent,
+    cornerRadiusY: cornerRadiusYPercent,
+    sampleCount,
+  });
+  if (!points) {
+    return null;
+  }
+
+  return points.map((point) => ({
+    left: `${(centerXPercent + point.x).toFixed(2)}%`,
+    top: `${(centerYPercent + point.y).toFixed(2)}%`,
+  }));
+};
+
+export const buildEqualPerimeterRoundedRailPercentAnchorsForFrame = ({
+  totalSeats,
+  feltWidthPx,
+  feltHeightPx,
+  halfWidthPercent,
+  halfHeightPercent,
+  centerXPercent = 50,
+  centerYPercent = 50,
+  cornerRadiusXPercent = halfWidthPercent * DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_X_RATIO,
+  cornerRadiusYPercent = halfHeightPercent * DEFAULT_ROUNDED_RAIL_CORNER_RADIUS_Y_RATIO,
+  sampleCount = DEFAULT_SAMPLE_COUNT,
+}: {
+  totalSeats: number;
+  feltWidthPx: number;
+  feltHeightPx: number;
+  halfWidthPercent: number;
+  halfHeightPercent: number;
+  centerXPercent?: number;
+  centerYPercent?: number;
+  cornerRadiusXPercent?: number;
+  cornerRadiusYPercent?: number;
+  sampleCount?: number;
+}) => {
+  if (feltWidthPx <= 0 || feltHeightPx <= 0) {
+    return null;
+  }
+
+  const points = buildEqualPerimeterRoundedRailPoints({
+    totalSeats,
+    halfWidth: feltWidthPx * (halfWidthPercent / 100),
+    halfHeight: feltHeightPx * (halfHeightPercent / 100),
+    cornerRadiusX: feltWidthPx * (cornerRadiusXPercent / 100),
+    cornerRadiusY: feltHeightPx * (cornerRadiusYPercent / 100),
+    sampleCount,
+  });
+  if (!points) {
+    return null;
+  }
+
+  return points.map((point) => ({
+    left: `${(centerXPercent + (point.x / feltWidthPx) * 100).toFixed(2)}%`,
+    top: `${(centerYPercent + (point.y / feltHeightPx) * 100).toFixed(2)}%`,
   }));
 };

--- a/poker-client/src/components/poker/table-board-center-spacing.spec.ts
+++ b/poker-client/src/components/poker/table-board-center-spacing.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import postcss, { type AtRule, type Container, type Declaration, type Rule } from "postcss";
+import { describe, expect, it } from "vitest";
+
+const indexCss = readFileSync(new URL("../../index.css", import.meta.url), "utf8");
+const indexCssRoot = postcss.parse(indexCss);
+
+function getContainerQuery(container: Container, query: string): AtRule {
+  const matchingQuery = container.nodes?.find(
+    (node): node is AtRule =>
+      node.type === "atrule" &&
+      node.name === "container" &&
+      node.params === query,
+  );
+
+  if (!matchingQuery) {
+    throw new Error(`Missing container query: ${query}`);
+  }
+
+  return matchingQuery;
+}
+
+function getRule(container: Container, selector: string): Rule {
+  const matchingRule = container.nodes?.find(
+    (node): node is Rule => node.type === "rule" && node.selector === selector,
+  );
+
+  if (!matchingRule) {
+    throw new Error(`Missing CSS block for selector: ${selector}`);
+  }
+
+  return matchingRule;
+}
+
+function getDeclarationValue(rule: Rule, propertyName: string): string | undefined {
+  return rule.nodes?.find(
+    (node): node is Declaration => node.type === "decl" && node.prop === propertyName,
+  )?.value;
+}
+
+describe("table board center stack spacing", () => {
+  it("keeps a little more community-to-pot spacing on mobile portrait breakpoints", () => {
+    const mobileContainerQuery = getContainerQuery(
+      indexCssRoot,
+      "tablefelt (max-width: 560px)",
+    );
+    const compactMobileContainerQuery = getContainerQuery(
+      indexCssRoot,
+      "tablefelt (max-width: 430px)",
+    );
+    const mobileBoardCenterRule = getRule(mobileContainerQuery, ".board-center-stack");
+    const compactMobileBoardCenterRule = getRule(
+      compactMobileContainerQuery,
+      ".board-center-stack",
+    );
+
+    expect(getDeclarationValue(mobileBoardCenterRule, "gap")).toBe("0.98rem");
+    expect(getDeclarationValue(compactMobileBoardCenterRule, "gap")).toBe("0.88rem");
+  });
+});

--- a/poker-client/src/components/poker/table-board-layout.spec.ts
+++ b/poker-client/src/components/poker/table-board-layout.spec.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEqualArcEllipsePoints,
+  buildEqualPerimeterRoundedRailPoints,
+} from "@/components/poker/seat-orbit-layout";
+import { buildDenseMobileSeatBorderLayout } from "@/components/poker/table-board-layout";
+
+const SYNTHETIC_FELT_WIDTH_PX = 355.56;
+const SYNTHETIC_FELT_HEIGHT_PX = 496;
+const SYNTHETIC_FELT_BORDER_RADIUS_X_RATIO = 0.42;
+const SYNTHETIC_FELT_BORDER_RADIUS_Y_RATIO = 0.26;
+const CORNER_INSET_TEST_HORIZONTAL_GAP_PX = 1;
+const CORNER_INSET_TEST_VERTICAL_GAP_PX = 1;
+
+const buildSyntheticDenseMobileSeats = ({
+  count,
+  width,
+}: {
+  count: number;
+  width: number;
+}) => {
+  const height = Number((width / 1.26).toFixed(2));
+  const points = buildEqualArcEllipsePoints({
+    totalSeats: count,
+    radiusX: SYNTHETIC_FELT_WIDTH_PX / 2 - width / 2 - 4,
+    radiusY: SYNTHETIC_FELT_HEIGHT_PX / 2 - height / 2 - 4,
+  });
+
+  if (!points) {
+    throw new Error(`Unable to build synthetic orbit points for ${count} seats`);
+  }
+
+  return points.map((point) => ({
+    x: SYNTHETIC_FELT_WIDTH_PX / 2 + point.x,
+    y: SYNTHETIC_FELT_HEIGHT_PX / 2 + point.y,
+    width,
+    height,
+  }));
+};
+
+const buildSyntheticRoundedRailDenseMobileSeats = ({
+  count,
+  width,
+  halfWidthPercent,
+  halfHeightPercent,
+}: {
+  count: number;
+  width: number;
+  halfWidthPercent: number;
+  halfHeightPercent: number;
+}) => {
+  const height = Number((width / 1.26).toFixed(2));
+  const points = buildEqualPerimeterRoundedRailPoints({
+    totalSeats: count,
+    halfWidth: SYNTHETIC_FELT_WIDTH_PX * (halfWidthPercent / 100),
+    halfHeight: SYNTHETIC_FELT_HEIGHT_PX * (halfHeightPercent / 100),
+  });
+
+  if (!points) {
+    throw new Error(`Unable to build rounded-rail points for ${count} seats`);
+  }
+
+  return points.map((point) => ({
+    x: SYNTHETIC_FELT_WIDTH_PX / 2 + point.x,
+    y: SYNTHETIC_FELT_HEIGHT_PX / 2 + point.y,
+    width,
+    height,
+  }));
+};
+
+const isPointInsideSyntheticRoundedRect = ({
+  x,
+  y,
+  horizontalGapPx,
+  verticalGapPx,
+}: {
+  x: number;
+  y: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+}) => {
+  const left = horizontalGapPx;
+  const right = SYNTHETIC_FELT_WIDTH_PX - horizontalGapPx;
+  const top = verticalGapPx;
+  const bottom = SYNTHETIC_FELT_HEIGHT_PX - verticalGapPx;
+  const radiusX = Math.max(
+    0,
+    Math.min((right - left) / 2, SYNTHETIC_FELT_WIDTH_PX * SYNTHETIC_FELT_BORDER_RADIUS_X_RATIO - left),
+  );
+  const radiusY = Math.max(
+    0,
+    Math.min((bottom - top) / 2, SYNTHETIC_FELT_HEIGHT_PX * SYNTHETIC_FELT_BORDER_RADIUS_Y_RATIO - top),
+  );
+  const innerTop = top + radiusY;
+  const innerBottom = bottom - radiusY;
+
+  if (x < left - 0.01 || x > right + 0.01 || y < top - 0.01 || y > bottom + 0.01) {
+    return false;
+  }
+
+  if (x >= left + radiusX && x <= right - radiusX) {
+    return true;
+  }
+
+  if (y >= innerTop && y <= innerBottom) {
+    return true;
+  }
+
+  if (radiusX <= 0.01 || radiusY <= 0.01) {
+    return false;
+  }
+
+  const cornerCenterX = x < left + radiusX ? left + radiusX : right - radiusX;
+  const cornerCenterY = y < innerTop ? innerTop : innerBottom;
+  const normalizedX = (x - cornerCenterX) / radiusX;
+  const normalizedY = (y - cornerCenterY) / radiusY;
+
+  return normalizedX ** 2 + normalizedY ** 2 <= 1.02;
+};
+
+describe("buildDenseMobileSeatBorderLayout", () => {
+  it("pulls eight-handed diagonal seats toward the visible side rail", () => {
+    const layout = buildDenseMobileSeatBorderLayout({
+      feltWidth: 355.56,
+      feltHeight: 496,
+      seats: [
+        { x: 177.78, y: 425.11, width: 73.25, height: 58.13 },
+        { x: 71.2, y: 377.34, width: 73.25, height: 58.13 },
+        { x: 40.63, y: 248.01, width: 73.25, height: 58.13 },
+        { x: 71.2, y: 118.65, width: 73.25, height: 58.13 },
+        { x: 177.78, y: 70.88, width: 73.25, height: 58.13 },
+        { x: 284.36, y: 118.65, width: 73.25, height: 58.13 },
+        { x: 314.93, y: 248.01, width: 73.25, height: 58.13 },
+        { x: 284.36, y: 377.34, width: 73.25, height: 58.13 },
+      ],
+      horizontalGapPx: 9,
+      verticalGapPx: 8,
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout?.safe).toBe(true);
+    expect(layout?.points[0]?.y).toBeCloseTo(458.93, 2);
+    expect(layout?.points[4]?.y).toBeGreaterThan(37);
+    expect(layout?.points[4]?.y).toBeLessThan(37.1);
+    expect(layout?.points[1]?.y).toBeCloseTo(377.34, 2);
+    expect(layout?.points[3]?.y).toBeCloseTo(118.65, 2);
+    expect(layout?.points[1]?.x).toBeCloseTo(layout?.points[3]?.x ?? 0, 2);
+    expect((layout?.points[1]?.x ?? 0) - 73.25 / 2).toBeGreaterThanOrEqual(8);
+    expect((layout?.points[1]?.x ?? 0) - 73.25 / 2).toBeLessThanOrEqual(10);
+    expect(355.56 - ((layout?.points[6]?.x ?? 0) + 73.25 / 2)).toBeGreaterThanOrEqual(8);
+    expect(355.56 - ((layout?.points[6]?.x ?? 0) + 73.25 / 2)).toBeLessThanOrEqual(10);
+    expect((layout?.points[4]?.y ?? 0) - 58.13 / 2).toBeGreaterThan(7.95);
+    expect(496 - ((layout?.points[0]?.y ?? 0) + 58.13 / 2)).toBeGreaterThan(7.95);
+  });
+
+  it("keeps ten-handed dense mobile seats safe while tightening the top and bottom gaps", () => {
+    const layout = buildDenseMobileSeatBorderLayout({
+      feltWidth: 355.56,
+      feltHeight: 496,
+      seats: [
+        { x: 177.78, y: 407.99, width: 66.45, height: 52.74 },
+        { x: 84.37, y: 376.69, width: 66.45, height: 52.74 },
+        { x: 42.17, y: 287.24, width: 66.45, height: 52.74 },
+        { x: 42.17, y: 169.57, width: 66.45, height: 52.74 },
+        { x: 84.37, y: 80.12, width: 66.45, height: 52.74 },
+        { x: 177.78, y: 42.44, width: 66.45, height: 52.74 },
+        { x: 271.19, y: 80.12, width: 66.45, height: 52.74 },
+        { x: 313.39, y: 169.57, width: 66.45, height: 52.74 },
+        { x: 313.39, y: 287.24, width: 66.45, height: 52.74 },
+        { x: 271.19, y: 376.69, width: 66.45, height: 52.74 },
+      ],
+      horizontalGapPx: 8,
+      verticalGapPx: 8,
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout?.safe).toBe(true);
+    expect((layout?.points[5]?.y ?? 0) - 52.74 / 2).toBeGreaterThanOrEqual(7.95);
+    expect(496 - ((layout?.points[0]?.y ?? 0) + 52.74 / 2)).toBeGreaterThanOrEqual(7.95);
+    expect((layout?.points[2]?.x ?? 0) - 66.45 / 2).toBeGreaterThanOrEqual(7.95);
+    expect((layout?.points[2]?.x ?? 0) - 66.45 / 2).toBeLessThanOrEqual(8.05);
+    expect(355.56 - ((layout?.points[7]?.x ?? 0) + 66.45 / 2)).toBeGreaterThanOrEqual(7.95);
+    expect(355.56 - ((layout?.points[7]?.x ?? 0) + 66.45 / 2)).toBeLessThanOrEqual(8.05);
+  });
+
+  it("supports denser 10-15 handed mobile layouts with border spacing on both axes", () => {
+    const scenarios = [
+      { count: 10, width: 66.45, horizontalGapPx: 8, verticalGapPx: 8, minSideGapPx: 8, minVerticalGapPx: 8 },
+      { count: 12, width: 60.04, horizontalGapPx: 7, verticalGapPx: 8, minSideGapPx: 7, minVerticalGapPx: 8 },
+      { count: 13, width: 54, horizontalGapPx: 6, verticalGapPx: 7, minSideGapPx: 6, minVerticalGapPx: 7 },
+      { count: 14, width: 54, horizontalGapPx: 6, verticalGapPx: 7, minSideGapPx: 6, minVerticalGapPx: 7 },
+      { count: 15, width: 54, horizontalGapPx: 6, verticalGapPx: 7, minSideGapPx: 6, minVerticalGapPx: 7 },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const layout = buildDenseMobileSeatBorderLayout({
+        feltWidth: SYNTHETIC_FELT_WIDTH_PX,
+        feltHeight: SYNTHETIC_FELT_HEIGHT_PX,
+        seats: buildSyntheticDenseMobileSeats({
+          count: scenario.count,
+          width: scenario.width,
+        }),
+        horizontalGapPx: scenario.horizontalGapPx,
+        verticalGapPx: scenario.verticalGapPx,
+      });
+
+      expect(layout, `${scenario.count}-handed layout should exist`).not.toBeNull();
+      expect(layout?.safe, `${scenario.count}-handed layout should be safe`).toBe(true);
+
+      const seatHeight = Number((scenario.width / 1.26).toFixed(2));
+      const leftmostGap = Math.min(
+        ...(layout?.points.map((point) => point.x - scenario.width / 2) ?? []),
+      );
+      const topGap = Math.min(
+        ...(layout?.points.map((point) => point.y - seatHeight / 2) ?? []),
+      );
+
+      expect(leftmostGap, `${scenario.count}-handed left gap`).toBeGreaterThanOrEqual(
+        scenario.minSideGapPx - 0.05,
+      );
+      expect(topGap, `${scenario.count}-handed top gap`).toBeGreaterThanOrEqual(
+        scenario.minVerticalGapPx - 0.05,
+      );
+    }
+  });
+
+  it("keeps 13-handed corner-adjacent seat corners inside a slightly inset rounded rail", () => {
+    const seatWidth = 54;
+    const seatHeight = Number((seatWidth / 1.26).toFixed(2));
+    const layout = buildDenseMobileSeatBorderLayout({
+      feltWidth: SYNTHETIC_FELT_WIDTH_PX,
+      feltHeight: SYNTHETIC_FELT_HEIGHT_PX,
+      seats: buildSyntheticRoundedRailDenseMobileSeats({
+        count: 13,
+        width: seatWidth,
+        halfWidthPercent: 41,
+        halfHeightPercent: 36.9,
+      }),
+      horizontalGapPx: 6,
+      verticalGapPx: 7,
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout?.safe).toBe(true);
+
+    const cornerSeatCornerViolations = (layout?.points ?? [])
+      .map((point) => ({
+        corners: [
+          { x: point.x - seatWidth / 2, y: point.y - seatHeight / 2 },
+          { x: point.x + seatWidth / 2, y: point.y - seatHeight / 2 },
+          { x: point.x - seatWidth / 2, y: point.y + seatHeight / 2 },
+          { x: point.x + seatWidth / 2, y: point.y + seatHeight / 2 },
+        ],
+        offsetX: Math.abs(point.x - SYNTHETIC_FELT_WIDTH_PX / 2),
+        offsetY: Math.abs(point.y - SYNTHETIC_FELT_HEIGHT_PX / 2),
+      }))
+      .filter(
+        (point) =>
+          point.offsetX > SYNTHETIC_FELT_WIDTH_PX * 0.22 &&
+          point.offsetY > SYNTHETIC_FELT_HEIGHT_PX * 0.24,
+      )
+      .map((point) =>
+        point.corners.filter(
+          (corner) =>
+            !isPointInsideSyntheticRoundedRect({
+              x: corner.x,
+              y: corner.y,
+              horizontalGapPx: CORNER_INSET_TEST_HORIZONTAL_GAP_PX,
+              verticalGapPx: CORNER_INSET_TEST_VERTICAL_GAP_PX,
+            }),
+        ).length,
+      );
+
+    expect(cornerSeatCornerViolations.length).toBeGreaterThanOrEqual(4);
+    expect(Math.max(...cornerSeatCornerViolations)).toBe(0);
+  });
+
+  it("keeps 13-handed rounded-rail corner seats visually closer to their neighbors", () => {
+    const seatWidth = 54;
+    const layout = buildDenseMobileSeatBorderLayout({
+      feltWidth: SYNTHETIC_FELT_WIDTH_PX,
+      feltHeight: SYNTHETIC_FELT_HEIGHT_PX,
+      seats: buildSyntheticRoundedRailDenseMobileSeats({
+        count: 13,
+        width: seatWidth,
+        halfWidthPercent: 41,
+        halfHeightPercent: 36.9,
+      }),
+      horizontalGapPx: 6,
+      verticalGapPx: 7,
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout?.safe).toBe(true);
+
+    const seatGaps = (layout?.points ?? []).map((point, index, points) => {
+      const nextPoint = points[(index + 1) % points.length] ?? point;
+      return Math.hypot(nextPoint.x - point.x, nextPoint.y - point.y);
+    });
+    const gapSpread = Math.max(...seatGaps) - Math.min(...seatGaps);
+
+    expect(gapSpread).toBeLessThan(16);
+    expect(seatGaps[0]).toBeLessThan(102);
+    expect(seatGaps[12]).toBeLessThan(102);
+    expect(seatGaps[1]).toBeGreaterThan(84);
+    expect(seatGaps[11]).toBeGreaterThan(84);
+  });
+});

--- a/poker-client/src/components/poker/table-board-layout.spec.ts
+++ b/poker-client/src/components/poker/table-board-layout.spec.ts
@@ -305,4 +305,68 @@ describe("buildDenseMobileSeatBorderLayout", () => {
     expect(seatGaps[1]).toBeGreaterThan(84);
     expect(seatGaps[11]).toBeGreaterThan(84);
   });
+
+  it("reserves extra top-right border space for corner role badges on mobile seats", () => {
+    const seatWidth = 66.45;
+    const seatHeight = 52.74;
+    const layout = buildDenseMobileSeatBorderLayout({
+      feltWidth: SYNTHETIC_FELT_WIDTH_PX,
+      feltHeight: SYNTHETIC_FELT_HEIGHT_PX,
+      seats: [
+        { x: 177.78, y: 407.99, width: seatWidth, height: seatHeight },
+        { x: 84.37, y: 376.69, width: seatWidth, height: seatHeight },
+        { x: 42.17, y: 287.24, width: seatWidth, height: seatHeight },
+        { x: 42.17, y: 169.57, width: seatWidth, height: seatHeight },
+        { x: 84.37, y: 80.12, width: seatWidth, height: seatHeight },
+        { x: 177.78, y: 42.44, width: seatWidth, height: seatHeight },
+        {
+          x: 271.19,
+          y: 80.12,
+          width: seatWidth,
+          height: seatHeight,
+          rightOverflowPx: 3,
+          topOverflowPx: 4,
+        } as any,
+        { x: 313.39, y: 169.57, width: seatWidth, height: seatHeight },
+        { x: 313.39, y: 287.24, width: seatWidth, height: seatHeight },
+        { x: 271.19, y: 376.69, width: seatWidth, height: seatHeight },
+      ],
+      horizontalGapPx: 8,
+      verticalGapPx: 8,
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout?.safe).toBe(true);
+
+    const cornerSeat = layout?.points[6];
+    const expandedCorners = [
+      {
+        x: (cornerSeat?.x ?? 0) - seatWidth / 2,
+        y: (cornerSeat?.y ?? 0) - seatHeight / 2 - 4,
+      },
+      {
+        x: (cornerSeat?.x ?? 0) + seatWidth / 2 + 3,
+        y: (cornerSeat?.y ?? 0) - seatHeight / 2 - 4,
+      },
+      {
+        x: (cornerSeat?.x ?? 0) - seatWidth / 2,
+        y: (cornerSeat?.y ?? 0) + seatHeight / 2,
+      },
+      {
+        x: (cornerSeat?.x ?? 0) + seatWidth / 2 + 3,
+        y: (cornerSeat?.y ?? 0) + seatHeight / 2,
+      },
+    ];
+
+    expect(
+      expandedCorners.every((corner) =>
+        isPointInsideSyntheticRoundedRect({
+          x: corner.x,
+          y: corner.y,
+          horizontalGapPx: CORNER_INSET_TEST_HORIZONTAL_GAP_PX,
+          verticalGapPx: CORNER_INSET_TEST_VERTICAL_GAP_PX,
+        }),
+      ),
+    ).toBe(true);
+  });
 });

--- a/poker-client/src/components/poker/table-board-layout.ts
+++ b/poker-client/src/components/poker/table-board-layout.ts
@@ -1,0 +1,711 @@
+type SeatLayoutInput = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type LayoutPoint = {
+  x: number;
+  y: number;
+};
+
+type DenseMobileSeatBorderLayout = {
+  points: LayoutPoint[];
+  safe: boolean;
+};
+
+const BORDER_TOLERANCE_PX = 0.01;
+const FELT_BORDER_RADIUS_X_RATIO = 0.42;
+const FELT_BORDER_RADIUS_Y_RATIO = 0.26;
+const SIDE_BIAS_THRESHOLD = 0.45;
+const VERTICAL_BIAS_THRESHOLD = 1.4;
+const CORNER_PROJECTION_SIDE_BIAS_THRESHOLD = 0.35;
+const CORNER_PROJECTION_VERTICAL_BIAS_THRESHOLD = 0.55;
+const VERTICALLY_BALANCED_DENSE_MOBILE_SEAT_COUNTS = new Set([8, 10, 12, 13, 14, 15]);
+const CORNER_PROJECTED_DENSE_MOBILE_SEAT_COUNT_THRESHOLD = 12;
+const CORNER_CLEARANCE_DENSE_MOBILE_SEAT_COUNT_THRESHOLD = 12;
+const CORNER_CLEARANCE_TARGET_INSET_PX = 1;
+const CORNER_CLEARANCE_GAP_BOOST_COMBINATIONS = [
+  { horizontalGapBoostPx: 1.5, verticalGapBoostPx: 1.5 },
+  { horizontalGapBoostPx: 1.5, verticalGapBoostPx: 3 },
+  { horizontalGapBoostPx: 3, verticalGapBoostPx: 1.5 },
+  { horizontalGapBoostPx: 3, verticalGapBoostPx: 3 },
+];
+const CORNER_CLEARANCE_FINAL_NUDGE_PX = 1;
+const CORNER_CLEARANCE_FINAL_NUDGE_STEPS = 3;
+
+const rectanglesOverlap = (
+  first: { left: number; right: number; top: number; bottom: number },
+  second: { left: number; right: number; top: number; bottom: number },
+) =>
+  Math.min(first.right, second.right) - Math.max(first.left, second.left) > BORDER_TOLERANCE_PX &&
+  Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top) > BORDER_TOLERANCE_PX;
+
+const getRoundedRectInsetMetrics = ({
+  feltWidth,
+  feltHeight,
+  seatWidth,
+  seatHeight,
+  horizontalGapPx,
+  verticalGapPx,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  seatWidth: number;
+  seatHeight: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+}) => {
+  const left = horizontalGapPx + seatWidth / 2;
+  const right = feltWidth - horizontalGapPx - seatWidth / 2;
+  const top = verticalGapPx + seatHeight / 2;
+  const bottom = feltHeight - verticalGapPx - seatHeight / 2;
+  const radiusX = Math.max(
+    0,
+    Math.min((right - left) / 2, feltWidth * FELT_BORDER_RADIUS_X_RATIO - left),
+  );
+  const radiusY = Math.max(
+    0,
+    Math.min((bottom - top) / 2, feltHeight * FELT_BORDER_RADIUS_Y_RATIO - top),
+  );
+
+  return {
+    left,
+    right,
+    top,
+    bottom,
+    radiusX,
+    radiusY,
+    innerTop: top + radiusY,
+    innerBottom: bottom - radiusY,
+  };
+};
+
+const resolveRoundedRectBoundaryX = ({
+  feltWidth,
+  feltHeight,
+  seatWidth,
+  seatHeight,
+  horizontalGapPx,
+  verticalGapPx,
+  y,
+  side,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  seatWidth: number;
+  seatHeight: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+  y: number;
+  side: "left" | "right";
+}) => {
+  const metrics = getRoundedRectInsetMetrics({
+    feltWidth,
+    feltHeight,
+    seatWidth,
+    seatHeight,
+    horizontalGapPx,
+    verticalGapPx,
+  });
+
+  if (
+    metrics.radiusX <= BORDER_TOLERANCE_PX ||
+    metrics.radiusY <= BORDER_TOLERANCE_PX
+  ) {
+    return side === "left" ? metrics.left : metrics.right;
+  }
+
+  if (y >= metrics.innerTop && y <= metrics.innerBottom) {
+    return side === "left" ? metrics.left : metrics.right;
+  }
+
+  const cornerCenterY = y < metrics.innerTop ? metrics.innerTop : metrics.innerBottom;
+  const cornerCenterX =
+    side === "left" ? metrics.left + metrics.radiusX : metrics.right - metrics.radiusX;
+  const normalizedY = (y - cornerCenterY) / metrics.radiusY;
+  const normalizedX = metrics.radiusX * Math.sqrt(Math.max(0, 1 - normalizedY ** 2));
+
+  return side === "left"
+    ? cornerCenterX - normalizedX
+    : cornerCenterX + normalizedX;
+};
+
+const resolveRoundedRectBoundaryY = ({
+  feltWidth,
+  feltHeight,
+  seatWidth,
+  seatHeight,
+  horizontalGapPx,
+  verticalGapPx,
+  x,
+  side,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  seatWidth: number;
+  seatHeight: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+  x: number;
+  side: "top" | "bottom";
+}) => {
+  const metrics = getRoundedRectInsetMetrics({
+    feltWidth,
+    feltHeight,
+    seatWidth,
+    seatHeight,
+    horizontalGapPx,
+    verticalGapPx,
+  });
+
+  if (
+    metrics.radiusX <= BORDER_TOLERANCE_PX ||
+    metrics.radiusY <= BORDER_TOLERANCE_PX
+  ) {
+    return side === "top" ? metrics.top : metrics.bottom;
+  }
+
+  const innerLeft = metrics.left + metrics.radiusX;
+  const innerRight = metrics.right - metrics.radiusX;
+  if (x >= innerLeft && x <= innerRight) {
+    return side === "top" ? metrics.top : metrics.bottom;
+  }
+
+  const cornerCenterX = x < innerLeft ? innerLeft : innerRight;
+  const cornerCenterY =
+    side === "top" ? metrics.top + metrics.radiusY : metrics.bottom - metrics.radiusY;
+  const normalizedX = (x - cornerCenterX) / metrics.radiusX;
+  const normalizedY = metrics.radiusY * Math.sqrt(Math.max(0, 1 - normalizedX ** 2));
+
+  return side === "top"
+    ? cornerCenterY - normalizedY
+    : cornerCenterY + normalizedY;
+};
+
+const resolveRoundedRectBoundaryPointOnRay = ({
+  feltWidth,
+  feltHeight,
+  seatWidth,
+  seatHeight,
+  horizontalGapPx,
+  verticalGapPx,
+  fromX,
+  fromY,
+  towardX,
+  towardY,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  seatWidth: number;
+  seatHeight: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+  fromX: number;
+  fromY: number;
+  towardX: number;
+  towardY: number;
+}) => {
+  const deltaX = towardX - fromX;
+  const deltaY = towardY - fromY;
+
+  if (
+    Math.abs(deltaX) <= BORDER_TOLERANCE_PX &&
+    Math.abs(deltaY) <= BORDER_TOLERANCE_PX
+  ) {
+    return { x: towardX, y: towardY };
+  }
+
+  const isScaleInside = (scale: number) =>
+    isSeatCenterInsideRoundedRect({
+      feltWidth,
+      feltHeight,
+      x: fromX + deltaX * scale,
+      y: fromY + deltaY * scale,
+      seatWidth,
+      seatHeight,
+      horizontalGapPx,
+      verticalGapPx,
+    });
+
+  let lowScale = 0;
+  let highScale = 1;
+  while (highScale < 4 && isScaleInside(highScale)) {
+    lowScale = highScale;
+    highScale *= 1.35;
+  }
+
+  if (isScaleInside(highScale)) {
+    return {
+      x: fromX + deltaX * highScale,
+      y: fromY + deltaY * highScale,
+    };
+  }
+
+  for (let step = 0; step < 20; step += 1) {
+    const midScale = (lowScale + highScale) / 2;
+    if (isScaleInside(midScale)) {
+      lowScale = midScale;
+    } else {
+      highScale = midScale;
+    }
+  }
+
+  return {
+    x: fromX + deltaX * lowScale,
+    y: fromY + deltaY * lowScale,
+  };
+};
+
+const isSeatCenterInsideRoundedRect = ({
+  feltWidth,
+  feltHeight,
+  x,
+  y,
+  seatWidth,
+  seatHeight,
+  horizontalGapPx,
+  verticalGapPx,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  x: number;
+  y: number;
+  seatWidth: number;
+  seatHeight: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+}) => {
+  const metrics = getRoundedRectInsetMetrics({
+    feltWidth,
+    feltHeight,
+    seatWidth,
+    seatHeight,
+    horizontalGapPx,
+    verticalGapPx,
+  });
+
+  if (
+    x < metrics.left - BORDER_TOLERANCE_PX ||
+    x > metrics.right + BORDER_TOLERANCE_PX ||
+    y < metrics.top - BORDER_TOLERANCE_PX ||
+    y > metrics.bottom + BORDER_TOLERANCE_PX
+  ) {
+    return false;
+  }
+
+  if (x >= metrics.left + metrics.radiusX && x <= metrics.right - metrics.radiusX) {
+    return true;
+  }
+
+  if (y >= metrics.innerTop && y <= metrics.innerBottom) {
+    return true;
+  }
+
+  if (
+    metrics.radiusX <= BORDER_TOLERANCE_PX ||
+    metrics.radiusY <= BORDER_TOLERANCE_PX
+  ) {
+    return false;
+  }
+
+  const cornerCenterX =
+    x < metrics.left + metrics.radiusX
+      ? metrics.left + metrics.radiusX
+      : metrics.right - metrics.radiusX;
+  const cornerCenterY =
+    y < metrics.innerTop ? metrics.innerTop : metrics.innerBottom;
+  const normalizedX = (x - cornerCenterX) / metrics.radiusX;
+  const normalizedY = (y - cornerCenterY) / metrics.radiusY;
+  return normalizedX ** 2 + normalizedY ** 2 <= 1 + 0.02;
+};
+
+const isPointInsideRoundedRect = ({
+  feltWidth,
+  feltHeight,
+  x,
+  y,
+  horizontalGapPx,
+  verticalGapPx,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  x: number;
+  y: number;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+}) => {
+  const metrics = getRoundedRectInsetMetrics({
+    feltWidth,
+    feltHeight,
+    seatWidth: 0,
+    seatHeight: 0,
+    horizontalGapPx,
+    verticalGapPx,
+  });
+
+  if (
+    x < metrics.left - BORDER_TOLERANCE_PX ||
+    x > metrics.right + BORDER_TOLERANCE_PX ||
+    y < metrics.top - BORDER_TOLERANCE_PX ||
+    y > metrics.bottom + BORDER_TOLERANCE_PX
+  ) {
+    return false;
+  }
+
+  if (x >= metrics.left + metrics.radiusX && x <= metrics.right - metrics.radiusX) {
+    return true;
+  }
+
+  if (y >= metrics.innerTop && y <= metrics.innerBottom) {
+    return true;
+  }
+
+  if (
+    metrics.radiusX <= BORDER_TOLERANCE_PX ||
+    metrics.radiusY <= BORDER_TOLERANCE_PX
+  ) {
+    return false;
+  }
+
+  const cornerCenterX =
+    x < metrics.left + metrics.radiusX
+      ? metrics.left + metrics.radiusX
+      : metrics.right - metrics.radiusX;
+  const cornerCenterY =
+    y < metrics.innerTop ? metrics.innerTop : metrics.innerBottom;
+  const normalizedX = (x - cornerCenterX) / metrics.radiusX;
+  const normalizedY = (y - cornerCenterY) / metrics.radiusY;
+  return normalizedX ** 2 + normalizedY ** 2 <= 1 + 0.02;
+};
+
+const getSeatCornersOutsideRoundedRect = ({
+  feltWidth,
+  feltHeight,
+  seat,
+  point,
+  horizontalGapPx,
+  verticalGapPx,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  seat: SeatLayoutInput;
+  point: LayoutPoint;
+  horizontalGapPx: number;
+  verticalGapPx: number;
+}) =>
+  [
+    { x: point.x - seat.width / 2, y: point.y - seat.height / 2 },
+    { x: point.x + seat.width / 2, y: point.y - seat.height / 2 },
+    { x: point.x - seat.width / 2, y: point.y + seat.height / 2 },
+    { x: point.x + seat.width / 2, y: point.y + seat.height / 2 },
+  ].filter(
+    (corner) =>
+      !isPointInsideRoundedRect({
+        feltWidth,
+        feltHeight,
+        x: corner.x,
+        y: corner.y,
+        horizontalGapPx,
+        verticalGapPx,
+      }),
+  );
+
+export const buildDenseMobileSeatBorderLayout = ({
+  feltWidth,
+  feltHeight,
+  seats,
+  horizontalGapPx,
+  verticalGapPx,
+}: {
+  feltWidth: number;
+  feltHeight: number;
+  seats: SeatLayoutInput[];
+  horizontalGapPx: number;
+  verticalGapPx: number;
+}): DenseMobileSeatBorderLayout | null => {
+  if (
+    feltWidth <= 0 ||
+    feltHeight <= 0 ||
+    seats.length === 0 ||
+    horizontalGapPx < 0 ||
+    verticalGapPx < 0
+  ) {
+    return null;
+  }
+
+  const centerX = feltWidth / 2;
+  const centerY = feltHeight / 2;
+  const useDenseMobileVerticalBalancing =
+    VERTICALLY_BALANCED_DENSE_MOBILE_SEAT_COUNTS.has(seats.length);
+  const resolveSeatTargetPoint = ({
+    seat,
+    resolvedHorizontalGapPx,
+    resolvedVerticalGapPx,
+  }: {
+    seat: SeatLayoutInput;
+    resolvedHorizontalGapPx: number;
+    resolvedVerticalGapPx: number;
+  }) => {
+    const offsetX = seat.x - centerX;
+    const offsetY = seat.y - centerY;
+    const isSideBiased = Math.abs(offsetX) >= Math.abs(offsetY) * SIDE_BIAS_THRESHOLD;
+    const isVerticalBiased =
+      useDenseMobileVerticalBalancing &&
+      Math.abs(offsetY) > Math.abs(offsetX) * VERTICAL_BIAS_THRESHOLD;
+    const isCornerProjectionCandidate =
+      seats.length >= CORNER_PROJECTED_DENSE_MOBILE_SEAT_COUNT_THRESHOLD &&
+      useDenseMobileVerticalBalancing &&
+      Math.abs(offsetX) >= Math.abs(offsetY) * CORNER_PROJECTION_SIDE_BIAS_THRESHOLD &&
+      Math.abs(offsetY) >= Math.abs(offsetX) * CORNER_PROJECTION_VERTICAL_BIAS_THRESHOLD;
+    let targetX = seat.x;
+    let targetY = seat.y;
+
+    if (isCornerProjectionCandidate) {
+      return resolveRoundedRectBoundaryPointOnRay({
+        feltWidth,
+        feltHeight,
+        seatWidth: seat.width,
+        seatHeight: seat.height,
+        horizontalGapPx: resolvedHorizontalGapPx,
+        verticalGapPx: resolvedVerticalGapPx,
+        fromX: centerX,
+        fromY: centerY,
+        towardX: seat.x,
+        towardY: seat.y,
+      });
+    }
+
+    if (isSideBiased) {
+      targetX = resolveRoundedRectBoundaryX({
+        feltWidth,
+        feltHeight,
+        seatWidth: seat.width,
+        seatHeight: seat.height,
+        horizontalGapPx: resolvedHorizontalGapPx,
+        verticalGapPx: resolvedVerticalGapPx,
+        y: seat.y,
+        side: offsetX < 0 ? "left" : "right",
+      });
+    }
+
+    if (isVerticalBiased) {
+      targetY = resolveRoundedRectBoundaryY({
+        feltWidth,
+        feltHeight,
+        seatWidth: seat.width,
+        seatHeight: seat.height,
+        horizontalGapPx: resolvedHorizontalGapPx,
+        verticalGapPx: resolvedVerticalGapPx,
+        x: targetX,
+        side: offsetY < 0 ? "top" : "bottom",
+      });
+    }
+
+    return {
+      x: targetX,
+      y: targetY,
+    };
+  };
+
+  const points = seats.map((seat) => {
+    const basePoint = resolveSeatTargetPoint({
+      seat,
+      resolvedHorizontalGapPx: horizontalGapPx,
+      resolvedVerticalGapPx: verticalGapPx,
+    });
+
+    if (seats.length < CORNER_CLEARANCE_DENSE_MOBILE_SEAT_COUNT_THRESHOLD) {
+      return basePoint;
+    }
+
+    if (
+      getSeatCornersOutsideRoundedRect({
+        feltWidth,
+        feltHeight,
+        seat,
+        point: basePoint,
+        horizontalGapPx: horizontalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+        verticalGapPx: verticalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+      }).length === 0
+    ) {
+      return basePoint;
+    }
+
+    let clearancePoint = basePoint;
+    for (const gapBoost of CORNER_CLEARANCE_GAP_BOOST_COMBINATIONS) {
+      clearancePoint = resolveSeatTargetPoint({
+        seat,
+        resolvedHorizontalGapPx: horizontalGapPx + gapBoost.horizontalGapBoostPx,
+        resolvedVerticalGapPx: verticalGapPx + gapBoost.verticalGapBoostPx,
+      });
+
+      if (
+        getSeatCornersOutsideRoundedRect({
+          feltWidth,
+          feltHeight,
+          seat,
+          point: clearancePoint,
+          horizontalGapPx: horizontalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+          verticalGapPx: verticalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+        }).length === 0
+      ) {
+        return clearancePoint;
+      }
+    }
+
+    let nudgedPoint = clearancePoint;
+    for (let step = 0; step < CORNER_CLEARANCE_FINAL_NUDGE_STEPS; step += 1) {
+      const badCorners = getSeatCornersOutsideRoundedRect({
+        feltWidth,
+        feltHeight,
+        seat,
+        point: nudgedPoint,
+        horizontalGapPx: horizontalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+        verticalGapPx: verticalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+      });
+      if (badCorners.length === 0) {
+        return nudgedPoint;
+      }
+
+      const nextPoint = {
+        x:
+          nudgedPoint.x +
+          (badCorners.some((corner) => corner.x < centerX)
+            ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+            : 0) -
+          (badCorners.some((corner) => corner.x > centerX)
+            ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+            : 0),
+        y:
+          nudgedPoint.y +
+          (badCorners.some((corner) => corner.y < centerY)
+            ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+            : 0) -
+          (badCorners.some((corner) => corner.y > centerY)
+            ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+            : 0),
+      };
+
+      if (
+        !isSeatCenterInsideRoundedRect({
+          feltWidth,
+          feltHeight,
+          x: nextPoint.x,
+          y: nextPoint.y,
+          seatWidth: seat.width,
+          seatHeight: seat.height,
+          horizontalGapPx,
+          verticalGapPx,
+        })
+      ) {
+        break;
+      }
+
+      nudgedPoint = nextPoint;
+    }
+
+    if (
+      getSeatCornersOutsideRoundedRect({
+        feltWidth,
+        feltHeight,
+        seat,
+        point: nudgedPoint,
+        horizontalGapPx: horizontalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+        verticalGapPx: verticalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+      }).length === 0
+    ) {
+      return nudgedPoint;
+    }
+
+    return clearancePoint;
+  });
+
+  const resolvedPoints =
+    seats.length < CORNER_CLEARANCE_DENSE_MOBILE_SEAT_COUNT_THRESHOLD
+      ? points
+      : points.map((point, index) => {
+          let nudgedPoint = point;
+
+          for (let step = 0; step < CORNER_CLEARANCE_FINAL_NUDGE_STEPS; step += 1) {
+            const badCorners = getSeatCornersOutsideRoundedRect({
+              feltWidth,
+              feltHeight,
+              seat: seats[index],
+              point: nudgedPoint,
+              horizontalGapPx: horizontalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+              verticalGapPx: verticalGapPx + CORNER_CLEARANCE_TARGET_INSET_PX,
+            });
+            if (badCorners.length === 0) {
+              return nudgedPoint;
+            }
+
+            const nextPoint = {
+              x:
+                nudgedPoint.x +
+                (badCorners.some((corner) => corner.x < centerX)
+                  ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+                  : 0) -
+                (badCorners.some((corner) => corner.x > centerX)
+                  ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+                  : 0),
+              y:
+                nudgedPoint.y +
+                (badCorners.some((corner) => corner.y < centerY)
+                  ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+                  : 0) -
+                (badCorners.some((corner) => corner.y > centerY)
+                  ? CORNER_CLEARANCE_FINAL_NUDGE_PX
+                  : 0),
+            };
+
+            if (
+              !isSeatCenterInsideRoundedRect({
+                feltWidth,
+                feltHeight,
+                x: nextPoint.x,
+                y: nextPoint.y,
+                seatWidth: seats[index].width,
+                seatHeight: seats[index].height,
+                horizontalGapPx,
+                verticalGapPx,
+              })
+            ) {
+              break;
+            }
+
+            nudgedPoint = nextPoint;
+          }
+
+          return nudgedPoint;
+        });
+
+  const safe = resolvedPoints.every((point, index) =>
+    isSeatCenterInsideRoundedRect({
+      feltWidth,
+      feltHeight,
+      x: point.x,
+      y: point.y,
+      seatWidth: seats[index].width,
+      seatHeight: seats[index].height,
+      horizontalGapPx,
+      verticalGapPx,
+    }),
+  ) &&
+    resolvedPoints
+      .map((point, index) => ({
+        left: point.x - seats[index].width / 2,
+        right: point.x + seats[index].width / 2,
+        top: point.y - seats[index].height / 2,
+        bottom: point.y + seats[index].height / 2,
+      }))
+      .every((rect, index, rects) =>
+        rects.slice(index + 1).every((otherRect) => !rectanglesOverlap(rect, otherRect)),
+      );
+
+  return {
+    points: resolvedPoints,
+    safe,
+  };
+};

--- a/poker-client/src/components/poker/table-board-layout.ts
+++ b/poker-client/src/components/poker/table-board-layout.ts
@@ -3,6 +3,10 @@ type SeatLayoutInput = {
   y: number;
   width: number;
   height: number;
+  leftOverflowPx?: number;
+  rightOverflowPx?: number;
+  topOverflowPx?: number;
+  bottomOverflowPx?: number;
 };
 
 type LayoutPoint = {
@@ -26,6 +30,8 @@ const VERTICALLY_BALANCED_DENSE_MOBILE_SEAT_COUNTS = new Set([8, 10, 12, 13, 14,
 const CORNER_PROJECTED_DENSE_MOBILE_SEAT_COUNT_THRESHOLD = 12;
 const CORNER_CLEARANCE_DENSE_MOBILE_SEAT_COUNT_THRESHOLD = 12;
 const CORNER_CLEARANCE_TARGET_INSET_PX = 1;
+const DECORATIVE_OVERFLOW_BUFFER_RIGHT_PX = 2;
+const DECORATIVE_OVERFLOW_BUFFER_TOP_PX = 2;
 const CORNER_CLEARANCE_GAP_BOOST_COMBINATIONS = [
   { horizontalGapBoostPx: 1.5, verticalGapBoostPx: 1.5 },
   { horizontalGapBoostPx: 1.5, verticalGapBoostPx: 3 },
@@ -34,6 +40,19 @@ const CORNER_CLEARANCE_GAP_BOOST_COMBINATIONS = [
 ];
 const CORNER_CLEARANCE_FINAL_NUDGE_PX = 1;
 const CORNER_CLEARANCE_FINAL_NUDGE_STEPS = 3;
+
+const getSeatExtents = (seat: SeatLayoutInput) => ({
+  left: seat.width / 2 + (seat.leftOverflowPx ?? 0),
+  right:
+    seat.width / 2 +
+    (seat.rightOverflowPx ?? 0) +
+    ((seat.rightOverflowPx ?? 0) > 0 ? DECORATIVE_OVERFLOW_BUFFER_RIGHT_PX : 0),
+  top:
+    seat.height / 2 +
+    (seat.topOverflowPx ?? 0) +
+    ((seat.topOverflowPx ?? 0) > 0 ? DECORATIVE_OVERFLOW_BUFFER_TOP_PX : 0),
+  bottom: seat.height / 2 + (seat.bottomOverflowPx ?? 0),
+});
 
 const rectanglesOverlap = (
   first: { left: number; right: number; top: number; bottom: number },
@@ -45,22 +64,26 @@ const rectanglesOverlap = (
 const getRoundedRectInsetMetrics = ({
   feltWidth,
   feltHeight,
-  seatWidth,
-  seatHeight,
+  leftExtent,
+  rightExtent,
+  topExtent,
+  bottomExtent,
   horizontalGapPx,
   verticalGapPx,
 }: {
   feltWidth: number;
   feltHeight: number;
-  seatWidth: number;
-  seatHeight: number;
+  leftExtent: number;
+  rightExtent: number;
+  topExtent: number;
+  bottomExtent: number;
   horizontalGapPx: number;
   verticalGapPx: number;
 }) => {
-  const left = horizontalGapPx + seatWidth / 2;
-  const right = feltWidth - horizontalGapPx - seatWidth / 2;
-  const top = verticalGapPx + seatHeight / 2;
-  const bottom = feltHeight - verticalGapPx - seatHeight / 2;
+  const left = horizontalGapPx + leftExtent;
+  const right = feltWidth - horizontalGapPx - rightExtent;
+  const top = verticalGapPx + topExtent;
+  const bottom = feltHeight - verticalGapPx - bottomExtent;
   const radiusX = Math.max(
     0,
     Math.min((right - left) / 2, feltWidth * FELT_BORDER_RADIUS_X_RATIO - left),
@@ -85,8 +108,10 @@ const getRoundedRectInsetMetrics = ({
 const resolveRoundedRectBoundaryX = ({
   feltWidth,
   feltHeight,
-  seatWidth,
-  seatHeight,
+  leftExtent,
+  rightExtent,
+  topExtent,
+  bottomExtent,
   horizontalGapPx,
   verticalGapPx,
   y,
@@ -94,8 +119,10 @@ const resolveRoundedRectBoundaryX = ({
 }: {
   feltWidth: number;
   feltHeight: number;
-  seatWidth: number;
-  seatHeight: number;
+  leftExtent: number;
+  rightExtent: number;
+  topExtent: number;
+  bottomExtent: number;
   horizontalGapPx: number;
   verticalGapPx: number;
   y: number;
@@ -104,8 +131,10 @@ const resolveRoundedRectBoundaryX = ({
   const metrics = getRoundedRectInsetMetrics({
     feltWidth,
     feltHeight,
-    seatWidth,
-    seatHeight,
+    leftExtent,
+    rightExtent,
+    topExtent,
+    bottomExtent,
     horizontalGapPx,
     verticalGapPx,
   });
@@ -135,8 +164,10 @@ const resolveRoundedRectBoundaryX = ({
 const resolveRoundedRectBoundaryY = ({
   feltWidth,
   feltHeight,
-  seatWidth,
-  seatHeight,
+  leftExtent,
+  rightExtent,
+  topExtent,
+  bottomExtent,
   horizontalGapPx,
   verticalGapPx,
   x,
@@ -144,8 +175,10 @@ const resolveRoundedRectBoundaryY = ({
 }: {
   feltWidth: number;
   feltHeight: number;
-  seatWidth: number;
-  seatHeight: number;
+  leftExtent: number;
+  rightExtent: number;
+  topExtent: number;
+  bottomExtent: number;
   horizontalGapPx: number;
   verticalGapPx: number;
   x: number;
@@ -154,8 +187,10 @@ const resolveRoundedRectBoundaryY = ({
   const metrics = getRoundedRectInsetMetrics({
     feltWidth,
     feltHeight,
-    seatWidth,
-    seatHeight,
+    leftExtent,
+    rightExtent,
+    topExtent,
+    bottomExtent,
     horizontalGapPx,
     verticalGapPx,
   });
@@ -187,8 +222,10 @@ const resolveRoundedRectBoundaryY = ({
 const resolveRoundedRectBoundaryPointOnRay = ({
   feltWidth,
   feltHeight,
-  seatWidth,
-  seatHeight,
+  leftExtent,
+  rightExtent,
+  topExtent,
+  bottomExtent,
   horizontalGapPx,
   verticalGapPx,
   fromX,
@@ -198,8 +235,10 @@ const resolveRoundedRectBoundaryPointOnRay = ({
 }: {
   feltWidth: number;
   feltHeight: number;
-  seatWidth: number;
-  seatHeight: number;
+  leftExtent: number;
+  rightExtent: number;
+  topExtent: number;
+  bottomExtent: number;
   horizontalGapPx: number;
   verticalGapPx: number;
   fromX: number;
@@ -223,8 +262,10 @@ const resolveRoundedRectBoundaryPointOnRay = ({
       feltHeight,
       x: fromX + deltaX * scale,
       y: fromY + deltaY * scale,
-      seatWidth,
-      seatHeight,
+      leftExtent,
+      rightExtent,
+      topExtent,
+      bottomExtent,
       horizontalGapPx,
       verticalGapPx,
     });
@@ -263,8 +304,10 @@ const isSeatCenterInsideRoundedRect = ({
   feltHeight,
   x,
   y,
-  seatWidth,
-  seatHeight,
+  leftExtent,
+  rightExtent,
+  topExtent,
+  bottomExtent,
   horizontalGapPx,
   verticalGapPx,
 }: {
@@ -272,16 +315,20 @@ const isSeatCenterInsideRoundedRect = ({
   feltHeight: number;
   x: number;
   y: number;
-  seatWidth: number;
-  seatHeight: number;
+  leftExtent: number;
+  rightExtent: number;
+  topExtent: number;
+  bottomExtent: number;
   horizontalGapPx: number;
   verticalGapPx: number;
 }) => {
   const metrics = getRoundedRectInsetMetrics({
     feltWidth,
     feltHeight,
-    seatWidth,
-    seatHeight,
+    leftExtent,
+    rightExtent,
+    topExtent,
+    bottomExtent,
     horizontalGapPx,
     verticalGapPx,
   });
@@ -339,8 +386,10 @@ const isPointInsideRoundedRect = ({
   const metrics = getRoundedRectInsetMetrics({
     feltWidth,
     feltHeight,
-    seatWidth: 0,
-    seatHeight: 0,
+    leftExtent: 0,
+    rightExtent: 0,
+    topExtent: 0,
+    bottomExtent: 0,
     horizontalGapPx,
     verticalGapPx,
   });
@@ -395,12 +444,15 @@ const getSeatCornersOutsideRoundedRect = ({
   horizontalGapPx: number;
   verticalGapPx: number;
 }) =>
-  [
-    { x: point.x - seat.width / 2, y: point.y - seat.height / 2 },
-    { x: point.x + seat.width / 2, y: point.y - seat.height / 2 },
-    { x: point.x - seat.width / 2, y: point.y + seat.height / 2 },
-    { x: point.x + seat.width / 2, y: point.y + seat.height / 2 },
-  ].filter(
+  (() => {
+    const extents = getSeatExtents(seat);
+    return [
+      { x: point.x - extents.left, y: point.y - extents.top },
+      { x: point.x + extents.right, y: point.y - extents.top },
+      { x: point.x - extents.left, y: point.y + extents.bottom },
+      { x: point.x + extents.right, y: point.y + extents.bottom },
+    ];
+  })().filter(
     (corner) =>
       !isPointInsideRoundedRect({
         feltWidth,
@@ -450,6 +502,7 @@ export const buildDenseMobileSeatBorderLayout = ({
   }) => {
     const offsetX = seat.x - centerX;
     const offsetY = seat.y - centerY;
+    const extents = getSeatExtents(seat);
     const isSideBiased = Math.abs(offsetX) >= Math.abs(offsetY) * SIDE_BIAS_THRESHOLD;
     const isVerticalBiased =
       useDenseMobileVerticalBalancing &&
@@ -466,8 +519,10 @@ export const buildDenseMobileSeatBorderLayout = ({
       return resolveRoundedRectBoundaryPointOnRay({
         feltWidth,
         feltHeight,
-        seatWidth: seat.width,
-        seatHeight: seat.height,
+        leftExtent: extents.left,
+        rightExtent: extents.right,
+        topExtent: extents.top,
+        bottomExtent: extents.bottom,
         horizontalGapPx: resolvedHorizontalGapPx,
         verticalGapPx: resolvedVerticalGapPx,
         fromX: centerX,
@@ -481,8 +536,10 @@ export const buildDenseMobileSeatBorderLayout = ({
       targetX = resolveRoundedRectBoundaryX({
         feltWidth,
         feltHeight,
-        seatWidth: seat.width,
-        seatHeight: seat.height,
+        leftExtent: extents.left,
+        rightExtent: extents.right,
+        topExtent: extents.top,
+        bottomExtent: extents.bottom,
         horizontalGapPx: resolvedHorizontalGapPx,
         verticalGapPx: resolvedVerticalGapPx,
         y: seat.y,
@@ -494,8 +551,10 @@ export const buildDenseMobileSeatBorderLayout = ({
       targetY = resolveRoundedRectBoundaryY({
         feltWidth,
         feltHeight,
-        seatWidth: seat.width,
-        seatHeight: seat.height,
+        leftExtent: extents.left,
+        rightExtent: extents.right,
+        topExtent: extents.top,
+        bottomExtent: extents.bottom,
         horizontalGapPx: resolvedHorizontalGapPx,
         verticalGapPx: resolvedVerticalGapPx,
         x: targetX,
@@ -515,8 +574,16 @@ export const buildDenseMobileSeatBorderLayout = ({
       resolvedHorizontalGapPx: horizontalGapPx,
       resolvedVerticalGapPx: verticalGapPx,
     });
+    const hasDecorativeOverflow =
+      (seat.leftOverflowPx ?? 0) > 0 ||
+      (seat.rightOverflowPx ?? 0) > 0 ||
+      (seat.topOverflowPx ?? 0) > 0 ||
+      (seat.bottomOverflowPx ?? 0) > 0;
 
-    if (seats.length < CORNER_CLEARANCE_DENSE_MOBILE_SEAT_COUNT_THRESHOLD) {
+    if (
+      seats.length < CORNER_CLEARANCE_DENSE_MOBILE_SEAT_COUNT_THRESHOLD &&
+      !hasDecorativeOverflow
+    ) {
       return basePoint;
     }
 
@@ -594,8 +661,10 @@ export const buildDenseMobileSeatBorderLayout = ({
           feltHeight,
           x: nextPoint.x,
           y: nextPoint.y,
-          seatWidth: seat.width,
-          seatHeight: seat.height,
+          leftExtent: getSeatExtents(seat).left,
+          rightExtent: getSeatExtents(seat).right,
+          topExtent: getSeatExtents(seat).top,
+          bottomExtent: getSeatExtents(seat).bottom,
           horizontalGapPx,
           verticalGapPx,
         })
@@ -666,8 +735,10 @@ export const buildDenseMobileSeatBorderLayout = ({
                 feltHeight,
                 x: nextPoint.x,
                 y: nextPoint.y,
-                seatWidth: seats[index].width,
-                seatHeight: seats[index].height,
+                leftExtent: getSeatExtents(seats[index]).left,
+                rightExtent: getSeatExtents(seats[index]).right,
+                topExtent: getSeatExtents(seats[index]).top,
+                bottomExtent: getSeatExtents(seats[index]).bottom,
                 horizontalGapPx,
                 verticalGapPx,
               })
@@ -687,19 +758,24 @@ export const buildDenseMobileSeatBorderLayout = ({
       feltHeight,
       x: point.x,
       y: point.y,
-      seatWidth: seats[index].width,
-      seatHeight: seats[index].height,
+      leftExtent: getSeatExtents(seats[index]).left,
+      rightExtent: getSeatExtents(seats[index]).right,
+      topExtent: getSeatExtents(seats[index]).top,
+      bottomExtent: getSeatExtents(seats[index]).bottom,
       horizontalGapPx,
       verticalGapPx,
     }),
   ) &&
     resolvedPoints
-      .map((point, index) => ({
-        left: point.x - seats[index].width / 2,
-        right: point.x + seats[index].width / 2,
-        top: point.y - seats[index].height / 2,
-        bottom: point.y + seats[index].height / 2,
-      }))
+      .map((point, index) => {
+        const extents = getSeatExtents(seats[index]);
+        return {
+          left: point.x - extents.left,
+          right: point.x + extents.right,
+          top: point.y - extents.top,
+          bottom: point.y + extents.bottom,
+        };
+      })
       .every((rect, index, rects) =>
         rects.slice(index + 1).every((otherRect) => !rectanglesOverlap(rect, otherRect)),
       );

--- a/poker-client/src/components/poker/table-board.stories.tsx
+++ b/poker-client/src/components/poker/table-board.stories.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { Card as PokerCard } from "poker-types";
 import { TableBoard } from "@/components/poker/table-board";
-import { buildEqualArcEllipsePercentAnchors } from "@/components/poker/seat-orbit-layout";
+import {
+  buildEqualArcEllipsePercentAnchors,
+  buildEqualPerimeterRoundedRailPercentAnchorsForFrame,
+} from "@/components/poker/seat-orbit-layout";
 
 const boardCards: Array<PokerCard | null> = [
   { rank: "A", suit: "spades" },
@@ -135,6 +138,8 @@ const seatOrbitItems: SeatOrbitItems = [
 ];
 
 const MOBILE_SEAT_SIDE_MARGIN_PERCENT = 12;
+const MOBILE_PORTRAIT_PREVIEW_FELT_WIDTH_PX = 355.56;
+const MOBILE_PORTRAIT_PREVIEW_FELT_HEIGHT_PX = 496;
 
 const clampSeatLeftPercent = (left: string): string => {
   const trimmedLeft = left.trim();
@@ -598,6 +603,119 @@ const tenHandedStatusSeatOrbitItems: SeatOrbitItems = [
   },
 ];
 
+const denseStatusSeatOrbitTemplates: SeatOrbitItems = [
+  ...tenHandedStatusSeatOrbitItems,
+  {
+    slotIndex: 10,
+    top: "50%",
+    left: "50%",
+    width: "4.15rem",
+    playerId: "t11",
+    playerEmoji: "🦋",
+    playerName: "Nia",
+    isYou: false,
+    badge: { tone: "position", text: "LJ" },
+    externalStatusLabel: "已准备",
+    externalStatusToneClass: "seat-pod__status-badge--waiting",
+    internalStatusLabel: null,
+    internalStatusToneClass: "",
+    actionLabel: null,
+    remainingLabel: "$1,460",
+    seatState: "default" as const,
+    densityClass: "seat-pod--dense",
+  },
+  {
+    slotIndex: 11,
+    top: "50%",
+    left: "50%",
+    width: "4.15rem",
+    playerId: "t12",
+    playerEmoji: "🦊",
+    playerName: "Omar",
+    isYou: false,
+    badge: { tone: "position", text: "UTG" },
+    externalStatusLabel: null,
+    externalStatusToneClass: "",
+    internalStatusLabel: null,
+    internalStatusToneClass: "",
+    actionLabel: { text: "加注到 $120", tone: "aggressive" as const },
+    remainingLabel: "$1,180",
+    seatState: "default" as const,
+    densityClass: "seat-pod--dense",
+  },
+  {
+    slotIndex: 12,
+    top: "50%",
+    left: "50%",
+    width: "4.15rem",
+    playerId: "t13",
+    playerEmoji: "🐨",
+    playerName: "Tess",
+    isYou: false,
+    badge: { tone: "position", text: "UTG+1" },
+    externalStatusLabel: null,
+    externalStatusToneClass: "",
+    internalStatusLabel: "弃牌",
+    internalStatusToneClass: "seat-pod__status-badge--folded",
+    actionLabel: { text: "Fold", tone: "pending" as const },
+    remainingLabel: "$840",
+    seatState: "folded" as const,
+    densityClass: "seat-pod--dense",
+  },
+  {
+    slotIndex: 13,
+    top: "50%",
+    left: "50%",
+    width: "4.15rem",
+    playerId: "t14",
+    playerEmoji: "🐻",
+    playerName: "Milo",
+    isYou: false,
+    badge: { tone: "position", text: "UTG+2" },
+    externalStatusLabel: "等待中",
+    externalStatusToneClass: "seat-pod__status-badge--waiting",
+    internalStatusLabel: null,
+    internalStatusToneClass: "",
+    actionLabel: { text: "下手入局", tone: "pending" as const },
+    remainingLabel: "$930",
+    seatState: "waiting" as const,
+    densityClass: "seat-pod--dense",
+  },
+  {
+    slotIndex: 14,
+    top: "50%",
+    left: "50%",
+    width: "4.15rem",
+    playerId: "t15",
+    playerEmoji: "🦅",
+    playerName: "Sora",
+    isYou: false,
+    badge: { tone: "position", text: "UTG+3" },
+    externalStatusLabel: null,
+    externalStatusToneClass: "",
+    internalStatusLabel: "ALL-IN",
+    internalStatusToneClass: "seat-pod__status-badge--allin",
+    actionLabel: { text: "All-in $960", tone: "allin" as const },
+    remainingLabel: "$0",
+    seatState: "all-in" as const,
+    densityClass: "seat-pod--dense",
+  },
+];
+
+const buildDenseStatusSeatOrbitItems = ({
+  count,
+  width,
+}: {
+  count: number;
+  width: string;
+}) =>
+  denseStatusSeatOrbitTemplates.slice(0, count).map((seat, index) => ({
+    ...seat,
+    slotIndex: index,
+    width,
+    densityClass: "seat-pod--dense" as const,
+  }));
+
 const applyPreciseEllipseSeatLayout = (
   seats: SeatOrbitItems,
   {
@@ -617,6 +735,48 @@ const applyPreciseEllipseSeatLayout = (
     radiusXPercent,
     radiusYPercent,
     centerYPercent,
+  });
+
+  return seats.map((seat, index) => ({
+    ...seat,
+    left: anchors?.[index]?.left ?? seat.left,
+    top: anchors?.[index]?.top ?? seat.top,
+    width,
+    densityClass: "seat-pod--dense",
+  }));
+};
+
+const applyPreviewRoundedRailSeatLayout = (
+  seats: SeatOrbitItems,
+  {
+    feltWidthPx,
+    feltHeightPx,
+    halfWidthPercent,
+    halfHeightPercent,
+    centerYPercent,
+    width,
+    cornerRadiusXPercent,
+    cornerRadiusYPercent,
+  }: {
+    feltWidthPx: number;
+    feltHeightPx: number;
+    halfWidthPercent: number;
+    halfHeightPercent: number;
+    centerYPercent: number;
+    width: string;
+    cornerRadiusXPercent?: number;
+    cornerRadiusYPercent?: number;
+  },
+) => {
+  const anchors = buildEqualPerimeterRoundedRailPercentAnchorsForFrame({
+    totalSeats: seats.length,
+    feltWidthPx,
+    feltHeightPx,
+    halfWidthPercent,
+    halfHeightPercent,
+    centerYPercent,
+    cornerRadiusXPercent,
+    cornerRadiusYPercent,
   });
 
   return seats.map((seat, index) => ({
@@ -685,6 +845,66 @@ const tenHandedMobileLandscapeSeatOrbitItems = applyPreciseEllipseSeatLayout(
     radiusYPercent: 35.8,
     centerYPercent: 49.5,
     width: "3.28rem",
+  },
+);
+
+const twelveHandedMobilePortraitSeatOrbitItems = applyPreviewRoundedRailSeatLayout(
+  buildDenseStatusSeatOrbitItems({
+    count: 12,
+    width: "3.18rem",
+  }),
+  {
+    feltWidthPx: MOBILE_PORTRAIT_PREVIEW_FELT_WIDTH_PX,
+    feltHeightPx: MOBILE_PORTRAIT_PREVIEW_FELT_HEIGHT_PX,
+    halfWidthPercent: 41.2,
+    halfHeightPercent: 36.7,
+    centerYPercent: 50,
+    width: "3.18rem",
+  },
+);
+
+const thirteenHandedMobilePortraitSeatOrbitItems = applyPreviewRoundedRailSeatLayout(
+  buildDenseStatusSeatOrbitItems({
+    count: 13,
+    width: "3rem",
+  }),
+  {
+    feltWidthPx: MOBILE_PORTRAIT_PREVIEW_FELT_WIDTH_PX,
+    feltHeightPx: MOBILE_PORTRAIT_PREVIEW_FELT_HEIGHT_PX,
+    halfWidthPercent: 41,
+    halfHeightPercent: 36.9,
+    centerYPercent: 50,
+    width: "3rem",
+  },
+);
+
+const fourteenHandedMobilePortraitSeatOrbitItems = applyPreviewRoundedRailSeatLayout(
+  buildDenseStatusSeatOrbitItems({
+    count: 14,
+    width: "2.9rem",
+  }),
+  {
+    feltWidthPx: MOBILE_PORTRAIT_PREVIEW_FELT_WIDTH_PX,
+    feltHeightPx: MOBILE_PORTRAIT_PREVIEW_FELT_HEIGHT_PX,
+    halfWidthPercent: 40.9,
+    halfHeightPercent: 37,
+    centerYPercent: 50,
+    width: "2.9rem",
+  },
+);
+
+const fifteenHandedMobilePortraitSeatOrbitItems = applyPreviewRoundedRailSeatLayout(
+  buildDenseStatusSeatOrbitItems({
+    count: 15,
+    width: "2.82rem",
+  }),
+  {
+    feltWidthPx: MOBILE_PORTRAIT_PREVIEW_FELT_WIDTH_PX,
+    feltHeightPx: MOBILE_PORTRAIT_PREVIEW_FELT_HEIGHT_PX,
+    halfWidthPercent: 40.8,
+    halfHeightPercent: 37.1,
+    centerYPercent: 50,
+    width: "2.82rem",
   },
 );
 
@@ -844,6 +1064,30 @@ const tenHandedMobileLandscapeArgs: TableBoardStoryArgs = {
   seatOrbitItems: tenHandedMobileLandscapeSeatOrbitItems,
 };
 
+const twelveHandedMobilePortraitArgs: TableBoardStoryArgs = {
+  ...tenHandedShowcaseArgs,
+  potValue: "$1,640",
+  seatOrbitItems: twelveHandedMobilePortraitSeatOrbitItems,
+};
+
+const thirteenHandedMobilePortraitArgs: TableBoardStoryArgs = {
+  ...tenHandedShowcaseArgs,
+  potValue: "$1,860",
+  seatOrbitItems: thirteenHandedMobilePortraitSeatOrbitItems,
+};
+
+const fourteenHandedMobilePortraitArgs: TableBoardStoryArgs = {
+  ...tenHandedShowcaseArgs,
+  potValue: "$2,040",
+  seatOrbitItems: fourteenHandedMobilePortraitSeatOrbitItems,
+};
+
+const fifteenHandedMobilePortraitArgs: TableBoardStoryArgs = {
+  ...tenHandedShowcaseArgs,
+  potValue: "$2,280",
+  seatOrbitItems: fifteenHandedMobilePortraitSeatOrbitItems,
+};
+
 const meta = {
   title: "Poker/TableBoard",
   component: TableBoard as unknown as React.ComponentType<TableBoardMetaArgs>,
@@ -927,5 +1171,41 @@ export const TenHandedStatusMobileLandscape844x390: Story = {
       width: 844,
       height: 390,
       args: tenHandedMobileLandscapeArgs,
+    }),
+};
+
+export const TwelveHandedStatusMobilePortrait393x852: Story = {
+  render: () =>
+    renderBoardFrame({
+      width: 393,
+      height: 852,
+      args: twelveHandedMobilePortraitArgs,
+    }),
+};
+
+export const ThirteenHandedStatusMobilePortrait393x852: Story = {
+  render: () =>
+    renderBoardFrame({
+      width: 393,
+      height: 852,
+      args: thirteenHandedMobilePortraitArgs,
+    }),
+};
+
+export const FourteenHandedStatusMobilePortrait393x852: Story = {
+  render: () =>
+    renderBoardFrame({
+      width: 393,
+      height: 852,
+      args: fourteenHandedMobilePortraitArgs,
+    }),
+};
+
+export const FifteenHandedStatusMobilePortrait393x852: Story = {
+  render: () =>
+    renderBoardFrame({
+      width: 393,
+      height: 852,
+      args: fifteenHandedMobilePortraitArgs,
     }),
 };

--- a/poker-client/src/components/poker/table-board.tsx
+++ b/poker-client/src/components/poker/table-board.tsx
@@ -59,6 +59,12 @@ const BOARD_COLLISION_SELECTORS = [
   '[data-testid^="community-card-"]',
   '[data-testid^="board-back-"]',
 ];
+const SEAT_DECORATION_OVERFLOW_SELECTORS = [
+  ".seat-pod__role-icon",
+  ".seat-pod__status-badge--external",
+  ".seat-pod__live-audio-badge",
+  ".seat-pod__ready-overlay",
+];
 const SEAT_OVERFLOW_TOLERANCE_PX = 0.5;
 const SEAT_LAYOUT_MARGIN_PX = 2;
 const SEAT_LAYOUT_COLLISION_TOLERANCE_PX = 0.5;
@@ -69,6 +75,8 @@ const SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 14;
 const SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 9;
 const DENSE_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 4;
 const DENSE_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 4;
+const DENSE_MOBILE_POTENTIAL_ROLE_BADGE_RIGHT_OVERFLOW_PX = 3;
+const DENSE_MOBILE_POTENTIAL_ROLE_BADGE_TOP_OVERFLOW_PX = 4;
 const EIGHT_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 9;
 const EIGHT_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 8;
 const TEN_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 8;
@@ -203,13 +211,47 @@ const hasNonNameTextOverflow = (seatOrbitNode: HTMLElement) =>
     }),
   );
 
-const overlapExceedsTolerance = (a: DOMRect, b: DOMRect) => {
+const overlapExceedsTolerance = (
+  a: { left: number; right: number; top: number; bottom: number },
+  b: { left: number; right: number; top: number; bottom: number },
+) => {
   const overlapWidth = Math.min(a.right, b.right) - Math.max(a.left, b.left);
   const overlapHeight = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
   return (
     overlapWidth > SEAT_LAYOUT_COLLISION_TOLERANCE_PX &&
     overlapHeight > SEAT_LAYOUT_COLLISION_TOLERANCE_PX
   );
+};
+
+const getSeatDecoratedBounds = (seatNode: HTMLElement) => {
+  const seatRect = seatNode.getBoundingClientRect();
+  let left = seatRect.left;
+  let right = seatRect.right;
+  let top = seatRect.top;
+  let bottom = seatRect.bottom;
+
+  SEAT_DECORATION_OVERFLOW_SELECTORS.forEach((selector) => {
+    seatNode.querySelectorAll<HTMLElement>(selector).forEach((node) => {
+      const rect = node.getBoundingClientRect();
+      left = Math.min(left, rect.left);
+      right = Math.max(right, rect.right);
+      top = Math.min(top, rect.top);
+      bottom = Math.max(bottom, rect.bottom);
+    });
+  });
+
+  return {
+    left,
+    right,
+    top,
+    bottom,
+    width: seatRect.width,
+    height: seatRect.height,
+    leftOverflowPx: Math.max(0, seatRect.left - left),
+    rightOverflowPx: Math.max(0, right - seatRect.right),
+    topOverflowPx: Math.max(0, seatRect.top - top),
+    bottomOverflowPx: Math.max(0, bottom - seatRect.bottom),
+  };
 };
 
 const isSeatLayoutSafe = ({
@@ -222,7 +264,7 @@ const isSeatLayoutSafe = ({
   const feltRect = feltNode.getBoundingClientRect();
   const seatRects = Array.from(
     seatOrbitNode.querySelectorAll<HTMLElement>('.seat-pod[data-testid^="player-seat-"]'),
-  ).map((node) => node.getBoundingClientRect());
+  ).map((node) => getSeatDecoratedBounds(node));
 
   if (seatRects.some((seatRect) => {
     return (
@@ -348,12 +390,23 @@ const resolveDenseMobileSeatBorderOffsets = ({
       }
 
       const seatRect = seatNode.getBoundingClientRect();
+      const decoratedBounds = getSeatDecoratedBounds(seatNode);
       return {
         slotNode,
         seatCenterX: seatRect.left - feltRect.left + seatRect.width / 2,
         seatCenterY: seatRect.top - feltRect.top + seatRect.height / 2,
         width: seatRect.width,
         height: seatRect.height,
+        leftOverflowPx: decoratedBounds.leftOverflowPx,
+        rightOverflowPx: Math.max(
+          decoratedBounds.rightOverflowPx,
+          DENSE_MOBILE_POTENTIAL_ROLE_BADGE_RIGHT_OVERFLOW_PX,
+        ),
+        topOverflowPx: Math.max(
+          decoratedBounds.topOverflowPx,
+          DENSE_MOBILE_POTENTIAL_ROLE_BADGE_TOP_OVERFLOW_PX,
+        ),
+        bottomOverflowPx: decoratedBounds.bottomOverflowPx,
       };
     })
     .filter((slot): slot is {
@@ -362,6 +415,10 @@ const resolveDenseMobileSeatBorderOffsets = ({
       seatCenterY: number;
       width: number;
       height: number;
+      leftOverflowPx: number;
+      rightOverflowPx: number;
+      topOverflowPx: number;
+      bottomOverflowPx: number;
     } => Boolean(slot));
 
   const targetGaps = getDenseMobileSeatBorderTargetGaps(seatCount);
@@ -373,6 +430,10 @@ const resolveDenseMobileSeatBorderOffsets = ({
       y: slotNode.seatCenterY,
       width: slotNode.width,
       height: slotNode.height,
+      leftOverflowPx: slotNode.leftOverflowPx,
+      rightOverflowPx: slotNode.rightOverflowPx,
+      topOverflowPx: slotNode.topOverflowPx,
+      bottomOverflowPx: slotNode.bottomOverflowPx,
     })),
     horizontalGapPx: targetGaps.horizontalGapPx,
     verticalGapPx: targetGaps.verticalGapPx,

--- a/poker-client/src/components/poker/table-board.tsx
+++ b/poker-client/src/components/poker/table-board.tsx
@@ -4,6 +4,7 @@ import { Card } from "@/components/Card";
 import { CommunityCardsLane } from "@/components/poker/community-cards-lane";
 import { PotDropZone } from "@/components/poker/pot-drop-zone";
 import { SeatPod, type SeatBadge, type SeatLiveAudioBadge } from "@/components/poker/seat-pod";
+import { buildDenseMobileSeatBorderLayout } from "@/components/poker/table-board-layout";
 
 type SeatMainState = "turn" | "disconnected" | "all-in" | "folded" | "waiting" | "default";
 
@@ -61,7 +62,25 @@ const BOARD_COLLISION_SELECTORS = [
 const SEAT_OVERFLOW_TOLERANCE_PX = 0.5;
 const SEAT_LAYOUT_MARGIN_PX = 2;
 const SEAT_LAYOUT_COLLISION_TOLERANCE_PX = 0.5;
+const MOBILE_SEAT_BORDER_OFFSET_MAX_WIDTH_PX = 430;
 const SEAT_WIDTH_SOLVER_STEPS = 12;
+const SEAT_BORDER_OFFSET_SOLVER_STEPS = 14;
+const SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 14;
+const SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 9;
+const DENSE_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 4;
+const DENSE_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 4;
+const EIGHT_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 9;
+const EIGHT_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 8;
+const TEN_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 8;
+const TEN_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 8;
+const TWELVE_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 7;
+const TWELVE_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 8;
+const THIRTEEN_PLUS_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX = 6;
+const THIRTEEN_PLUS_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX = 7;
+const DENSE_MOBILE_SEAT_WIDTH_TARGET_EXPANSION_RATIO = 1.18;
+const DENSE_MOBILE_SEAT_WIDTH_MAX_FELT_RATIO = 0.235;
+const ULTRA_DENSE_MOBILE_SEAT_WIDTH_TARGET_EXPANSION_RATIO = 1.26;
+const ULTRA_DENSE_MOBILE_SEAT_WIDTH_MAX_FELT_RATIO = 0.25;
 const SEAT_WIDTH_MAX_EXPANSION_RATIO = 1.4;
 const SEAT_WIDTH_EXPANSION_MULTIPLIER = 1.22;
 const SEAT_WIDTH_EXPANSION_PROBE_STEPS = 10;
@@ -249,6 +268,290 @@ const setUniformSeatWidth = (seatOrbitNode: HTMLElement, widthPx: number | null)
   seatOrbitNode.style.setProperty("--seat-slot-width-uniform", `${widthPx}px`);
 };
 
+const getSeatSlotNodes = (seatOrbitNode: HTMLElement) =>
+  Array.from(seatOrbitNode.querySelectorAll<HTMLElement>(".seat-orbit__slot"));
+
+const clearSeatSlotOffsets = (seatOrbitNode: HTMLElement) => {
+  getSeatSlotNodes(seatOrbitNode).forEach((slotNode) => {
+    slotNode.style.removeProperty("--seat-slot-offset-x");
+    slotNode.style.removeProperty("--seat-slot-offset-y");
+  });
+};
+
+const setSeatSlotOffset = ({
+  slotNode,
+  offsetX,
+  offsetY,
+}: {
+  slotNode: HTMLElement;
+  offsetX: number;
+  offsetY: number;
+}) => {
+  slotNode.style.setProperty("--seat-slot-offset-x", `${offsetX}px`);
+  slotNode.style.setProperty("--seat-slot-offset-y", `${offsetY}px`);
+};
+
+const getDenseMobileSeatBorderTargetGaps = (seatCount: number) =>
+  seatCount === 8
+    ? {
+        horizontalGapPx: EIGHT_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX,
+        verticalGapPx: EIGHT_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX,
+      }
+    : seatCount === 10
+      ? {
+          horizontalGapPx: TEN_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX,
+          verticalGapPx: TEN_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX,
+        }
+      : seatCount === 12
+        ? {
+            horizontalGapPx: TWELVE_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX,
+            verticalGapPx: TWELVE_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX,
+          }
+        : seatCount >= 13
+          ? {
+              horizontalGapPx: THIRTEEN_PLUS_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX,
+              verticalGapPx: THIRTEEN_PLUS_HANDED_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX,
+            }
+    : {
+        horizontalGapPx: DENSE_MOBILE_SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX,
+        verticalGapPx: DENSE_MOBILE_SEAT_BORDER_TARGET_GAP_VERTICAL_PX,
+      };
+
+const getDenseMobileSeatWidthTargets = (seatCount: number) =>
+  seatCount >= 12
+    ? {
+        targetExpansionRatio: ULTRA_DENSE_MOBILE_SEAT_WIDTH_TARGET_EXPANSION_RATIO,
+        maxFeltRatio: ULTRA_DENSE_MOBILE_SEAT_WIDTH_MAX_FELT_RATIO,
+      }
+    : {
+        targetExpansionRatio: DENSE_MOBILE_SEAT_WIDTH_TARGET_EXPANSION_RATIO,
+        maxFeltRatio: DENSE_MOBILE_SEAT_WIDTH_MAX_FELT_RATIO,
+      };
+
+const resolveDenseMobileSeatBorderOffsets = ({
+  feltNode,
+  seatOrbitNode,
+  seatCount,
+}: {
+  feltNode: HTMLElement;
+  seatOrbitNode: HTMLElement;
+  seatCount: number;
+}) => {
+  clearSeatSlotOffsets(seatOrbitNode);
+
+  const feltRect = feltNode.getBoundingClientRect();
+  const slotNodes = getSeatSlotNodes(seatOrbitNode)
+    .map((slotNode) => {
+      const seatNode = slotNode.querySelector<HTMLElement>('.seat-pod[data-testid^="player-seat-"]');
+      if (!seatNode) {
+        return null;
+      }
+
+      const seatRect = seatNode.getBoundingClientRect();
+      return {
+        slotNode,
+        seatCenterX: seatRect.left - feltRect.left + seatRect.width / 2,
+        seatCenterY: seatRect.top - feltRect.top + seatRect.height / 2,
+        width: seatRect.width,
+        height: seatRect.height,
+      };
+    })
+    .filter((slot): slot is {
+      slotNode: HTMLElement;
+      seatCenterX: number;
+      seatCenterY: number;
+      width: number;
+      height: number;
+    } => Boolean(slot));
+
+  const targetGaps = getDenseMobileSeatBorderTargetGaps(seatCount);
+  const layout = buildDenseMobileSeatBorderLayout({
+    feltWidth: feltRect.width,
+    feltHeight: feltRect.height,
+    seats: slotNodes.map((slotNode) => ({
+      x: slotNode.seatCenterX,
+      y: slotNode.seatCenterY,
+      width: slotNode.width,
+      height: slotNode.height,
+    })),
+    horizontalGapPx: targetGaps.horizontalGapPx,
+    verticalGapPx: targetGaps.verticalGapPx,
+  });
+
+  if (!layout || !layout.safe || layout.points.length !== slotNodes.length) {
+    clearSeatSlotOffsets(seatOrbitNode);
+    return false;
+  }
+
+  slotNodes.forEach((slotNode, index) => {
+    const targetPoint = layout.points[index];
+    setSeatSlotOffset({
+      slotNode: slotNode.slotNode,
+      offsetX: targetPoint.x - slotNode.seatCenterX,
+      offsetY: targetPoint.y - slotNode.seatCenterY,
+    });
+  });
+
+  if (!isSeatLayoutSafe({ feltNode, seatOrbitNode })) {
+    clearSeatSlotOffsets(seatOrbitNode);
+    return false;
+  }
+
+  return true;
+};
+
+const resolveSeatSlotBorderOffsets = ({
+  feltNode,
+  seatOrbitNode,
+  seatCount,
+}: {
+  feltNode: HTMLElement;
+  seatOrbitNode: HTMLElement;
+  seatCount: number;
+}) => {
+  clearSeatSlotOffsets(seatOrbitNode);
+
+  const feltRect = feltNode.getBoundingClientRect();
+  const centerX = feltRect.left + feltRect.width / 2;
+  const centerY = feltRect.top + feltRect.height / 2;
+  const maxProbeDistance = Math.max(feltRect.width, feltRect.height);
+  const slotNodes = getSeatSlotNodes(seatOrbitNode)
+    .map((slotNode) => {
+      const seatNode = slotNode.querySelector<HTMLElement>('.seat-pod[data-testid^="player-seat-"]');
+      if (!seatNode) {
+        return null;
+      }
+
+      const seatRect = seatNode.getBoundingClientRect();
+      const seatCenterX = seatRect.left + seatRect.width / 2;
+      const seatCenterY = seatRect.top + seatRect.height / 2;
+      const vectorX = seatCenterX - centerX;
+      const vectorY = seatCenterY - centerY;
+      const vectorLength = Math.hypot(vectorX, vectorY);
+
+      if (vectorLength <= SEAT_LAYOUT_COLLISION_TOLERANCE_PX) {
+        return null;
+      }
+
+      return {
+        slotNode,
+        unitX: vectorX / vectorLength,
+        unitY: vectorY / vectorLength,
+        priority: Math.abs(vectorY) - Math.abs(vectorX),
+      };
+    })
+    .filter((slot): slot is {
+      slotNode: HTMLElement;
+      unitX: number;
+      unitY: number;
+      priority: number;
+    } => Boolean(slot))
+    .sort((a, b) => b.priority - a.priority);
+
+  slotNodes.forEach(({ slotNode, unitX, unitY }) => {
+    let low = 0;
+    let high = maxProbeDistance;
+
+    for (let step = 0; step < SEAT_BORDER_OFFSET_SOLVER_STEPS; step += 1) {
+      const mid = (low + high) / 2;
+      setSeatSlotOffset({
+        slotNode,
+        offsetX: unitX * mid,
+        offsetY: unitY * mid,
+      });
+
+      if (isSeatLayoutSafe({ feltNode, seatOrbitNode })) {
+        low = mid;
+        continue;
+      }
+
+      high = mid;
+    }
+
+    const axisBlend = Math.min(1, Math.abs(unitY));
+    const denseTargetGaps = getDenseMobileSeatBorderTargetGaps(seatCount);
+    const horizontalGapPx =
+      seatCount > 6
+        ? denseTargetGaps.horizontalGapPx
+        : SEAT_BORDER_TARGET_GAP_HORIZONTAL_PX;
+    const verticalGapPx =
+      seatCount > 6
+        ? denseTargetGaps.verticalGapPx
+        : SEAT_BORDER_TARGET_GAP_VERTICAL_PX;
+    const targetGapPx = horizontalGapPx * (1 - axisBlend) + verticalGapPx * axisBlend;
+    const settledDistance = Math.max(0, low - targetGapPx);
+    setSeatSlotOffset({
+      slotNode,
+      offsetX: unitX * settledDistance,
+      offsetY: unitY * settledDistance,
+    });
+  });
+};
+
+const resolveDenseMobileSeatWidth = ({
+  feltNode,
+  seatOrbitNode,
+  seatWidthToken,
+  seatCount,
+}: {
+  feltNode: HTMLElement;
+  seatOrbitNode: HTMLElement;
+  seatWidthToken: string;
+  seatCount: number;
+}) => {
+  const baseWidthPx = resolveSeatBaseWidthPx(seatWidthToken);
+  if (!Number.isFinite(baseWidthPx) || baseWidthPx <= 0) {
+    return null;
+  }
+
+  const feltWidthPx = feltNode.getBoundingClientRect().width;
+  const widthTargets = getDenseMobileSeatWidthTargets(seatCount);
+  const maxWidthPx = Math.max(
+    baseWidthPx + SEAT_OVERFLOW_TOLERANCE_PX,
+    Math.min(
+      baseWidthPx * widthTargets.targetExpansionRatio,
+      feltWidthPx * widthTargets.maxFeltRatio,
+    ),
+  );
+
+  if (maxWidthPx <= baseWidthPx + SEAT_OVERFLOW_TOLERANCE_PX) {
+    setUniformSeatWidth(seatOrbitNode, null);
+    clearSeatSlotOffsets(seatOrbitNode);
+    return null;
+  }
+
+  let bestWidthPx = baseWidthPx;
+  let low = baseWidthPx;
+  let high = maxWidthPx;
+
+  for (let step = 0; step < SEAT_WIDTH_SOLVER_STEPS; step += 1) {
+    const candidateWidthPx = (low + high) / 2;
+    setUniformSeatWidth(seatOrbitNode, candidateWidthPx);
+    resetInlineSeatFontSizes(seatOrbitNode);
+
+    const resolvedLayout = resolveDenseMobileSeatBorderOffsets({
+      feltNode,
+      seatOrbitNode,
+      seatCount: seatOrbitNode.querySelectorAll('.seat-pod[data-testid^="player-seat-"]').length,
+    });
+    if (resolvedLayout && isSeatLayoutSafe({ feltNode, seatOrbitNode })) {
+      bestWidthPx = candidateWidthPx;
+      low = candidateWidthPx;
+      continue;
+    }
+
+    high = candidateWidthPx;
+  }
+
+  if (bestWidthPx <= baseWidthPx + SEAT_OVERFLOW_TOLERANCE_PX) {
+    setUniformSeatWidth(seatOrbitNode, null);
+    clearSeatSlotOffsets(seatOrbitNode);
+    return null;
+  }
+
+  return bestWidthPx;
+};
+
 const resolveUniformSeatWidth = ({
   feltNode,
   seatOrbitNode,
@@ -387,12 +690,44 @@ export const TableBoard: React.FC<TableBoardProps> = ({
 
       rafId = window.requestAnimationFrame(() => {
         rafId = 0;
-        const uniformSeatWidth = resolveUniformSeatWidth({
-          feltNode,
-          seatOrbitNode,
-          seatWidthToken: baseSeatWidthToken,
-        });
+        clearSeatSlotOffsets(seatOrbitNode);
+        const isDenseMobileSeatOrbit =
+          seatOrbitItemCount > 6 &&
+          feltNode.getBoundingClientRect().width <= MOBILE_SEAT_BORDER_OFFSET_MAX_WIDTH_PX;
+        const uniformSeatWidth = isDenseMobileSeatOrbit
+          ? resolveDenseMobileSeatWidth({
+              feltNode,
+              seatOrbitNode,
+              seatWidthToken: baseSeatWidthToken,
+              seatCount: seatOrbitItemCount,
+            }) ??
+            resolveUniformSeatWidth({
+              feltNode,
+              seatOrbitNode,
+              seatWidthToken: baseSeatWidthToken,
+            })
+          : resolveUniformSeatWidth({
+              feltNode,
+              seatOrbitNode,
+              seatWidthToken: baseSeatWidthToken,
+            });
         setUniformSeatWidth(seatOrbitNode, uniformSeatWidth);
+        if (feltNode.getBoundingClientRect().width <= MOBILE_SEAT_BORDER_OFFSET_MAX_WIDTH_PX) {
+          const resolvedDenseMobileLayout =
+            seatOrbitItemCount > 6 &&
+            resolveDenseMobileSeatBorderOffsets({
+              feltNode,
+              seatOrbitNode,
+              seatCount: seatOrbitItemCount,
+            });
+          if (!resolvedDenseMobileLayout) {
+            resolveSeatSlotBorderOffsets({
+              feltNode,
+              seatOrbitNode,
+              seatCount: seatOrbitItemCount,
+            });
+          }
+        }
       });
     };
 
@@ -436,6 +771,7 @@ export const TableBoard: React.FC<TableBoardProps> = ({
       mutationObserver.disconnect();
       window.removeEventListener("resize", scheduleSolve);
       seatOrbitNode.style.removeProperty("--seat-slot-width-uniform");
+      clearSeatSlotOffsets(seatOrbitNode);
     };
   }, [
     boardCenterStackRef,
@@ -494,7 +830,8 @@ export const TableBoard: React.FC<TableBoardProps> = ({
                 top: item.top,
                 left: item.left,
                 width: `var(--seat-slot-width-uniform, ${item.width})`,
-                transform: "translate(-50%, -50%)",
+                transform:
+                  "translate(calc(-50% + var(--seat-slot-offset-x, 0px)), calc(-50% + var(--seat-slot-offset-y, 0px)))",
               }}
             >
               <div ref={(node) => setSeatNodeRef(item.playerId, node)}>

--- a/poker-client/src/index.css
+++ b/poker-client/src/index.css
@@ -530,20 +530,29 @@ body {
 }
 
 @container tablefelt (max-width: 560px) {
+  .felt-oval {
+    min-height: clamp(33rem, 82svh, 39rem);
+  }
+
+  .felt-oval::before {
+    content: none;
+  }
+
   .board-center-stack {
-    gap: 0.1rem;
+    gap: 0.98rem;
+    width: min(100%, 18rem);
   }
 
   .community-lane {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    --community-card-width: clamp(1.95rem, 10.8cqw, 2.5rem);
-    --community-card-height: clamp(2.9rem, 16.2cqw, 3.8rem);
-    --community-card-radius: clamp(0.25rem, 2.5cqw, 0.52rem);
-    --community-card-inner-pad: clamp(0.03rem, 0.3cqw, 0.09rem);
+    --community-card-width: clamp(2.34rem, 11.2cqw, 2.9rem);
+    --community-card-height: clamp(3.42rem, 16.4cqw, 4.2rem);
+    --community-card-radius: clamp(0.28rem, 2.3cqw, 0.58rem);
+    --community-card-inner-pad: clamp(0.03rem, 0.28cqw, 0.09rem);
     --community-card-border-width: 1px;
-    column-gap: clamp(0.12rem, 0.9cqw, 0.24rem);
-    row-gap: clamp(0.1rem, 0.7cqw, 0.2rem);
+    column-gap: clamp(0.14rem, 0.82cqw, 0.3rem);
+    row-gap: clamp(0.16rem, 0.86cqw, 0.28rem);
     width: max-content;
     margin-inline: auto;
     justify-items: center;
@@ -562,60 +571,73 @@ body {
   }
 
   .community-lane [data-testid^="community-card-"] {
-    --community-rank-size: clamp(0.6rem, 31cqi, 1rem);
-    --community-suit-size: clamp(0.72rem, 49cqi, 1.2rem);
+    --community-rank-size: clamp(0.66rem, 31cqi, 1.04rem);
+    --community-suit-size: clamp(0.84rem, 54cqi, 1.34rem);
     --community-rank-inset: clamp(0.04rem, 5cqi, 0.14rem);
   }
 
   .pot-drop-zone {
-    width: 6.18rem;
-    min-height: 6.18rem;
+    width: 5.65rem;
+    min-height: 5.65rem;
     padding: 0.42rem;
   }
 
   .pot-drop-zone__value {
-    font-size: 0.94rem;
+    font-size: 0.9rem;
   }
 
   .pot-drop-zone__hint {
-    margin-top: 0.14rem;
-    font-size: 0.54rem;
+    margin-top: 0.12rem;
+    font-size: 0.5rem;
   }
 }
 
 @container tablefelt (max-width: 430px) {
+  .felt-oval {
+    min-height: clamp(34rem, 84svh, 40rem);
+  }
+
   .board-center-stack {
-    gap: 2.16rem;
+    gap: 0.88rem;
+    width: min(100%, 16rem);
+  }
+
+  .community-lane {
+    --community-card-width: clamp(2.2rem, 11.2cqw, 2.56rem);
+    --community-card-height: clamp(3.18rem, 16.2cqw, 3.72rem);
+    --community-card-radius: clamp(0.24rem, 2.2cqw, 0.46rem);
+    --community-card-inner-pad: clamp(0.02rem, 0.24cqw, 0.07rem);
+    column-gap: clamp(0.1rem, 0.68cqw, 0.22rem);
+    row-gap: clamp(0.14rem, 0.8cqw, 0.24rem);
   }
 
   .community-lane [data-testid^="community-card-"],
   .community-lane [data-testid^="board-back-"] {
-    width: clamp(1.75rem, 9.6cqw, 2.15rem) !important;
-    height: clamp(2.62rem, 14.2cqw, 3.25rem) !important;
-    --community-card-radius: clamp(0.2rem, 2.3cqw, 0.42rem);
-    --community-card-inner-pad: clamp(0.02rem, 0.26cqw, 0.07rem);
+    width: var(--community-card-width) !important;
+    height: var(--community-card-height) !important;
+    border-radius: var(--community-card-radius) !important;
     --community-card-border-width: 1px;
   }
 
   .community-lane [data-testid^="community-card-"] {
-    --community-rank-size: clamp(0.56rem, 29cqi, 0.92rem);
-    --community-suit-size: clamp(0.66rem, 46cqi, 1.06rem);
+    --community-rank-size: clamp(0.6rem, 31cqi, 0.98rem);
+    --community-suit-size: clamp(0.76rem, 50cqi, 1.18rem);
     --community-rank-inset: clamp(0.04rem, 4.5cqi, 0.12rem);
   }
 
   .pot-drop-zone {
-    width: 7.7rem;
-    min-height: 7.7rem;
-    padding: 0.6rem;
+    width: 5.2rem;
+    min-height: 5.2rem;
+    padding: 0.36rem;
   }
 
   .pot-drop-zone__value {
-    font-size: 1.14rem;
+    font-size: 0.84rem;
   }
 
   .pot-drop-zone__hint {
-    margin-top: 0.2rem;
-    font-size: 0.6rem;
+    margin-top: 0.1rem;
+    font-size: 0.46rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- improve mobile seat placement and width handling so dense tables sit closer to the felt border without clipping
- add frame-aware Storybook coverage plus verification helpers for 12 to 15 handed mobile layouts
- tune the mobile center stack so community cards and the pot have more breathing room

## Testing
- pnpm --dir poker-client test --run src/components/poker/table-board-center-spacing.spec.ts src/components/poker/seat-orbit-layout.spec.ts src/components/poker/table-board-layout.spec.ts
- pnpm --dir poker-client build

Closes #175