### PR TITLE
fix: collapse unrevealed hands in the result modal

### DIFF
--- a/poker-client/src/components/poker/hand-results-content.spec.ts
+++ b/poker-client/src/components/poker/hand-results-content.spec.ts
@@ -1,0 +1,108 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { Card as PokerCard, HandEvaluation } from "poker-types";
+import { HandResultsContent } from "./hand-results-content";
+import { storyTranslate } from "./storybook-fixtures";
+
+const communityCards: Array<PokerCard | null> = [
+  { rank: "A", suit: "spades" },
+  { rank: "Q", suit: "spades" },
+  { rank: "J", suit: "spades" },
+  { rank: "10", suit: "spades" },
+  { rank: "2", suit: "hearts" },
+];
+
+const shownHand: HandEvaluation = {
+  rank: "STRAIGHT_FLUSH",
+  value: 10,
+  cards: [
+    { rank: "A", suit: "spades" },
+    { rank: "K", suit: "spades" },
+    { rank: "Q", suit: "spades" },
+    { rank: "J", suit: "spades" },
+    { rank: "10", suit: "spades" },
+  ],
+  description: "Straight Flush, A high",
+};
+
+const renderHandResultsContent = () =>
+  renderToStaticMarkup(
+    React.createElement(HandResultsContent, {
+      currentHandNumber: 22,
+      totalPot: 480,
+      winnerCount: 1,
+      myNetChange: 240,
+      showNetChange: true,
+      currentPlayerId: "p1",
+      communityCards,
+      payoutBreakdownRows: [],
+      handResultRows: [
+        {
+          playerId: "p1",
+          playerName: "Kai",
+          rankOrder: 1,
+          isWinner: true,
+          amountWon: 360,
+          netChange: 240,
+          cards: [
+            { rank: "K", suit: "spades" },
+            { rank: "9", suit: "spades" },
+          ],
+          hand: shownHand,
+          resultStatus: "shown",
+          cardsVisibility: "shown",
+          seatPosition: 0,
+        },
+        {
+          playerId: "p2",
+          playerName: "Maya",
+          rankOrder: 2,
+          isWinner: false,
+          amountWon: 0,
+          netChange: -120,
+          cards: [],
+          hand: null,
+          resultStatus: "hidden_contender",
+          cardsVisibility: "hidden",
+          seatPosition: 1,
+        },
+        {
+          playerId: "p3",
+          playerName: "Noah",
+          rankOrder: 3,
+          isWinner: false,
+          amountWon: 0,
+          netChange: -120,
+          cards: [],
+          hand: null,
+          resultStatus: "folded_at_showdown",
+          cardsVisibility: "hidden",
+          seatPosition: 2,
+        },
+      ],
+      revealedHandPlayerIdSet: new Set(["p1"]),
+      onSaveResultScreenshot: () => {},
+      onExportHandHistory: () => {},
+      isExportingHandHistory: false,
+      onOpenHandReview: () => {},
+      isOpeningHandReview: false,
+      handReviewUnavailableSummary: null,
+      describeEvaluatedHand: (hand: HandEvaluation) => hand.description,
+      t: storyTranslate,
+    }),
+  );
+
+describe("HandResultsContent", () => {
+  it("omits hidden card placeholders and redundant hidden-hand copy for unrevealed rows", () => {
+    const html = renderHandResultsContent();
+
+    expect(html).toContain('data-testid="hand-result-card-p1-0"');
+    expect(html).toContain("Straight Flush, A high");
+    expect(html).not.toContain("hand-result-hidden-card-p2-0");
+    expect(html).not.toContain("hand-result-hidden-card-p3-0");
+    expect(html).not.toContain('data-testid="hand-result-rank-p2"');
+    expect(html).not.toContain('data-testid="hand-result-rank-p3"');
+    expect(html).not.toContain("game.handHidden");
+  });
+});

--- a/poker-client/src/components/poker/hand-results-content.tsx
+++ b/poker-client/src/components/poker/hand-results-content.tsx
@@ -95,11 +95,6 @@ const HAND_RESULT_COMMUNITY_SLOT_META = [
     hiddenTestId: "hand-results-community-back-4",
   },
 ] as const;
-const HIDDEN_HOLE_CARD_META = [
-  { id: "left", testIndex: 0 },
-  { id: "right", testIndex: 1 },
-] as const;
-
 export const HandResultsContent: React.FC<HandResultsContentProps> = ({
   currentHandNumber,
   totalPot,
@@ -342,9 +337,6 @@ export const HandResultsContent: React.FC<HandResultsContentProps> = ({
             const resultStatusLabel = showCards
               ? t("game.resultStatus.shown")
               : getResultStatusLabel(entry.resultStatus);
-            const isFoldedResultStatus =
-              entry.resultStatus === "folded_pre_showdown" ||
-              entry.resultStatus === "folded_at_showdown";
 
             return (
               <article
@@ -380,39 +372,29 @@ export const HandResultsContent: React.FC<HandResultsContentProps> = ({
                   )}
                 </div>
 
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {showCards
-                    ? entry.cards.map((card, idx) => (
+                {showCards && (
+                  <>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {entry.cards.map((card, idx) => (
                         <Card
                           key={`${entry.playerId}-shown-${card.suit}-${card.rank}`}
                           card={card}
                           size="small"
                           dataTestId={`hand-result-card-${entry.playerId}-${idx}`}
                         />
-                      ))
-                    : HIDDEN_HOLE_CARD_META.map((slotMeta) => (
-                        <Card
-                          key={`${entry.playerId}-hidden-${slotMeta.id}`}
-                          card={null}
-                          size="small"
-                          faceDown
-                          dataTestId={`hand-result-hidden-card-${entry.playerId}-${slotMeta.testIndex}`}
-                        />
                       ))}
-                </div>
+                    </div>
 
-                <p
-                  className="mt-2 text-xs text-emerald-100/75"
-                  data-testid={`hand-result-rank-${entry.playerId}`}
-                >
-                  {showCards
-                    ? entry.hand
-                      ? describeEvaluatedHand(entry.hand)
-                      : t("game.cardsShownNoEvaluated")
-                    : isFoldedResultStatus
-                      ? `${t("game.resultStatus.folded")} · ${t("game.handHidden")}`
-                      : t("game.handHidden")}
-                </p>
+                    <p
+                      className="mt-2 text-xs text-emerald-100/75"
+                      data-testid={`hand-result-rank-${entry.playerId}`}
+                    >
+                      {entry.hand
+                        ? describeEvaluatedHand(entry.hand)
+                        : t("game.cardsShownNoEvaluated")}
+                    </p>
+                  </>
+                )}
                 {showCards && entry.runHands && entry.runHands.length > 1 && (
                   <div
                     className="mt-2 flex flex-wrap gap-2 text-[11px] text-emerald-100/75"

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -3579,19 +3579,19 @@ test.describe('Poker E2E - Test Suite 3: All-In Scenarios', () => {
       ).toHaveCount(4);
       await expect(
         alicePage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(2);
+      ).toHaveCount(0);
       await expect(
         bobPage.locator('[data-testid^="hand-result-card-"]'),
       ).toHaveCount(4);
       await expect(
         bobPage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(2);
+      ).toHaveCount(0);
       await expect(
         charliePage.locator('[data-testid^="hand-result-card-"]'),
       ).toHaveCount(4);
       await expect(
         charliePage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(2);
+      ).toHaveCount(0);
 
       await verifyChipConservation(alicePage, 5000);
     } finally {
@@ -9891,7 +9891,7 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       ).toContainText(`Your hand: -$${expectedWinnerNet}`);
       await expect(
         alicePage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(4);
+      ).toHaveCount(0);
       await expect(
         alicePage.locator('[data-testid^="hand-result-card-"]'),
       ).toHaveCount(0);
@@ -9900,7 +9900,7 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
       ).toHaveCount(0);
       await expect(
         bobPage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(4);
+      ).toHaveCount(0);
       await expect(
         bobPage.locator('[data-testid^="hand-result-card-"]'),
       ).toHaveCount(0);
@@ -10377,19 +10377,19 @@ test.describe('Poker E2E - Test Suite 9: Three-Player Coverage', () => {
       ).toHaveCount(4);
       await expect(
         alicePage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(2);
+      ).toHaveCount(0);
       await expect(
         bobPage.locator('[data-testid^="hand-result-card-"]'),
       ).toHaveCount(4);
       await expect(
         bobPage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(2);
+      ).toHaveCount(0);
       await expect(
         charliePage.locator('[data-testid^="hand-result-card-"]'),
       ).toHaveCount(4);
       await expect(
         charliePage.locator('[data-testid^="hand-result-hidden-card-"]'),
-      ).toHaveCount(2);
+      ).toHaveCount(0);
 
     } finally {
       await teardownThreePlayerSession(session);


### PR DESCRIPTION
## Summary

- stop rendering face-down placeholder cards for hidden rows in the hand results modal
- remove the redundant hidden-hand rank/copy block so unrevealed rows keep only their status and payout summary
- add focused client coverage plus reconcile existing comprehensive Playwright expectations with the collapsed hidden-row presentation

## Linked Issue

Closes #196

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/196#issuecomment-4282415208

## Validation

- `pnpm --dir poker-client exec vitest run src/components/poker/hand-results-content.spec.ts`
- `pnpm --dir poker-client build`
- `PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 TEST_MODE=true pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep '8\.16: Non-Showdown Result Keeps Hole Cards Hidden' --reporter=line`
- `PW_FRONTEND_PORT=5190 PW_BACKEND_PORT=3017 TEST_MODE=true pnpm --dir poker-server exec playwright test --project comprehensive-e2e --workers=1 --grep '9\.4: Folded Player Is Excluded And Only Required Showdown Hands Are Visible' --reporter=line`
