### PR TITLE
fix: clear previous-street seat action labels when a new betting round starts

### DIFF
--- a/poker-client/src/contexts/GameContext.tsx
+++ b/poker-client/src/contexts/GameContext.tsx
@@ -1245,6 +1245,7 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
       socket.on("BETTING_ROUND_COMPLETE", (data) => {
         console.log("Betting round complete, next round:", data.nextRound);
 
+        setLastPlayerActionEvent(null);
         if (data.awaitingPlayerStreetReveal) {
           setNextStreetRevealState({
             nextRound: data.nextRound,
@@ -1279,9 +1280,22 @@ const useGameProviderElement = ({ children }: GameProviderProps) => {
                   runCountDecision: null,
                 }
               : prev.currentHand,
-            players: prev.players.map((p) => ({ ...p, currentBet: 0 })),
+            players: prev.players.map((p) => ({
+              ...p,
+              currentBet: 0,
+              lastAction: null,
+            })),
           };
         });
+        setPlayer((prev) =>
+          prev
+            ? {
+                ...prev,
+                currentBet: 0,
+                lastAction: null,
+              }
+            : prev,
+        );
       });
 
       socket.on("CHAT_HISTORY_SYNC", (data: ChatHistorySyncData) => {

--- a/poker-server/test/e2e/comprehensive-poker.spec.ts
+++ b/poker-server/test/e2e/comprehensive-poker.spec.ts
@@ -9239,6 +9239,73 @@ test.describe('Poker E2E - Test Suite 8: UI/UX Validation', () => {
     }
   });
 
+  test('8.13b3: Seat action labels clear when a new betting street starts', async ({
+    browser,
+  }) => {
+    const session = await setupTwoPlayerSession(browser, {
+      viewport: { width: 430, height: 932 },
+    });
+
+    try {
+      const { alicePage, bobPage } = session;
+
+      await startGameFromLobby(alicePage, bobPage);
+
+      const seatIds = await alicePage.evaluate(() => {
+        const room = (window as any).pokerDebug?.getRoom?.();
+        const alice = room?.players?.find((entry: any) => entry.name === 'Alice');
+        const bob = room?.players?.find((entry: any) => entry.name === 'Bob');
+        return {
+          aliceId: alice?.id ? String(alice.id) : null,
+          bobId: bob?.id ? String(bob.id) : null,
+        };
+      });
+      if (!seatIds.aliceId || !seatIds.bobId) {
+        throw new Error('Missing Alice/Bob seat ids for cross-street action assertion');
+      }
+
+      await waitForPlayerTurn(alicePage, 'Bob');
+      await bobPage.click('[data-testid="action-call"]');
+
+      await waitForPlayerTurn(alicePage, 'Alice');
+      await alicePage.click('[data-testid="action-check"]');
+
+      await waitForRound(alicePage, 'FLOP', 3);
+
+      const flopSnapshot = await getRoomSnapshot(alicePage);
+      const firstFlopPlayerName = flopSnapshot.currentPlayerName;
+      if (firstFlopPlayerName !== 'Alice' && firstFlopPlayerName !== 'Bob') {
+        throw new Error(`Unexpected flop acting player: ${firstFlopPlayerName}`);
+      }
+      const secondFlopPlayerName =
+        firstFlopPlayerName === 'Alice' ? 'Bob' : 'Alice';
+      const firstFlopPage =
+        firstFlopPlayerName === 'Alice' ? alicePage : bobPage;
+      const secondFlopPage =
+        secondFlopPlayerName === 'Alice' ? alicePage : bobPage;
+
+      await waitForPlayerTurn(alicePage, firstFlopPlayerName);
+      await firstFlopPage.click('[data-testid="action-check"]');
+
+      await waitForPlayerTurn(alicePage, secondFlopPlayerName);
+      await secondFlopPage.click('[data-testid="action-check"]');
+
+      await waitForRound(alicePage, 'TURN', 4);
+
+      const aliceSeatAction = alicePage.locator(
+        `[data-testid="player-seat-${seatIds.aliceId}-action"]`,
+      );
+      const bobSeatAction = alicePage.locator(
+        `[data-testid="player-seat-${seatIds.bobId}-action"]`,
+      );
+
+      await expect(aliceSeatAction).not.toContainText(/Check|过牌/);
+      await expect(bobSeatAction).not.toContainText(/Check|过牌/);
+    } finally {
+      await teardownTwoPlayerSession(session);
+    }
+  });
+
   test('8.13c: Mobile Reveal Uses Operation Bar And Keeps Cards Above Actions', async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary

- Clear stale seat action state when BETTING_ROUND_COMPLETE advances the street
- Add focused Playwright coverage for previous-street Check labels leaking into the next street

## Linked Issue

Closes #200

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/Poker/issues/200#issuecomment-4287813806

## Validation

- PW_FRONTEND_PORT=5188 PW_BACKEND_PORT=3015 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --grep "8.13b3: Seat action labels clear when a new betting street starts" --reporter=line
- PW_FRONTEND_PORT=5190 PW_BACKEND_PORT=3017 pnpm --dir poker-server exec playwright test --project comprehensive-e2e --grep "8.13b2: Earlier checked seat keeps the Check label after a later seat also checks" --reporter=line
- pnpm --dir poker-client build
